### PR TITLE
fix: address PR #15 review comments (resolveHostPort helper)

### DIFF
--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -7,6 +7,61 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
 
+/**
+ * Resolve host/port from explicit args or a URL string into the request body.
+ * Only applies to hawser-standard connections — other types ignore host/port.
+ *
+ * @param body        - The request body to mutate
+ * @param args        - User-supplied host, port, url
+ * @param connectionType - The connection type of the environment
+ * @param useDefaultPort - If true, default port 2376 when not explicitly set (create/test).
+ *                         If false, only set port when the caller provided one (update).
+ */
+function resolveHostPort(
+  body: Record<string, unknown>,
+  args: { host?: string; port?: number; url?: string },
+  connectionType: string,
+  useDefaultPort: boolean,
+): void {
+  if (connectionType !== 'hawser-standard') return;
+
+  if (args.host) {
+    body.host = args.host;
+    if (useDefaultPort) {
+      body.port = args.port ?? 2376;
+    } else if (args.port !== undefined) {
+      body.port = args.port;
+    }
+    return;
+  }
+
+  if (args.url) {
+    try {
+      const parsed = new URL(args.url);
+      body.host = parsed.hostname;
+      if (parsed.port) {
+        body.port = parseInt(parsed.port, 10);
+      } else if (useDefaultPort) {
+        body.port = 2376;
+      }
+    } catch {
+      try {
+        const parsed = new URL(`tcp://${args.url}`);
+        body.host = parsed.hostname;
+        if (parsed.port) {
+          body.port = parseInt(parsed.port, 10);
+        } else if (useDefaultPort) {
+          body.port = 2376;
+        }
+      } catch {
+        throw new Error(
+          'Invalid Docker host URL for hawser-standard. Provide host:port or tcp://host:port.',
+        );
+      }
+    }
+  }
+}
+
 export function registerEnvironmentTools(server: McpServer, client: DockhandClient): void {
 
   registerTool(server, 'list_environments', 'List all Dockhand environments (Docker hosts)',
@@ -33,19 +88,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     },
     async ({ name, connectionType, host, port, url }) => {
       const body: Record<string, unknown> = { name, connectionType };
-      if (host) {
-        body.host = host;
-        body.port = port ?? 2376;
-      } else if (url) {
-        try {
-          const parsed = new URL(url);
-          body.host = parsed.hostname;
-          body.port = parsed.port ? parseInt(parsed.port, 10) : 2376;
-        } catch {
-          // If URL parsing fails, pass url as-is for backward compatibility
-          body.url = url;
-        }
-      }
+      resolveHostPort(body, { host, port, url }, connectionType, true);
       return jsonResponse(await client.post('/api/environments', body));
     }
   );
@@ -60,21 +103,13 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.unknown()).optional().describe('Additional settings to update'),
     },
     async ({ environmentId, name, host, port, url, settings }) => {
+      const env = await client.get(`/api/environments/${environmentId}`) as Record<string, unknown>;
+      const connectionType = (env.connectionType as string) ?? '';
       const body: Record<string, unknown> = {};
       if (name) body.name = name;
-      if (host) {
-        body.host = host;
-        if (port !== undefined) body.port = port;
-      } else if (url) {
-        try {
-          const parsed = new URL(url);
-          body.host = parsed.hostname;
-          body.port = parsed.port ? parseInt(parsed.port, 10) : 2376;
-        } catch {
-          body.url = url;
-        }
-      }
+      // Merge settings first so explicit host/port can override them
       if (settings) Object.assign(body, settings);
+      resolveHostPort(body, { host, port, url }, connectionType, false);
       return jsonResponse(await client.put(`/api/environments/${environmentId}`, body));
     }
   );
@@ -102,18 +137,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     },
     async ({ connectionType, host, port, url }) => {
       const body: Record<string, unknown> = { connectionType };
-      if (host) {
-        body.host = host;
-        body.port = port ?? 2376;
-      } else if (url) {
-        try {
-          const parsed = new URL(url);
-          body.host = parsed.hostname;
-          body.port = parsed.port ? parseInt(parsed.port, 10) : 2376;
-        } catch {
-          body.url = url;
-        }
-      }
+      resolveHostPort(body, { host, port, url }, connectionType, true);
       return jsonResponse(await client.post('/api/environments/test', body));
     }
   );


### PR DESCRIPTION
## Summary

Adressiert alle Review-Findings aus Issue #20 (Gemini + Copilot Code Review von PR #15):

- **Helper-Funktion extrahiert**: `resolveHostPort()` ersetzt die 3x duplizierte host/port/url-Logik in `create_environment`, `update_environment` und `test_environment_connection`
- **connectionType-Gate**: host/port werden nur bei `hawser-standard` verarbeitet — andere Typen (z.B. `hawser-edge`) ignorieren diese Felder
- **Port-Default korrigiert**: Default-Port 2376 nur bei `create` und `test`, nicht bei `update` (um versehentliches Überschreiben zu vermeiden)
- **settings-Merge-Reihenfolge**: In `update_environment` werden `settings` zuerst gemergt, danach host/port — so können explizite Werte settings überschreiben
- **Fail-fast bei ungültiger URL**: Statt stillem Fallback wird bei ungültiger URL für hawser-standard ein klarer Fehler geworfen
- **tcp:// Format**: URLs wie `tcp://host:port` werden korrekt geparst

Closes #20

## Test plan

- [ ] `npm run typecheck` besteht (verifiziert im PR)
- [ ] `create_environment` mit hawser-standard setzt Default-Port 2376
- [ ] `create_environment` mit hawser-edge ignoriert host/port
- [ ] `update_environment` setzt Port nur wenn explizit angegeben
- [ ] `update_environment` settings werden vor host/port gemergt
- [ ] `test_environment_connection` mit URL im Format `tcp://host:port`
- [ ] Ungültige URL wirft klaren Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)