### PR TITLE
fix: consistent encodeURIComponent on all path parameters

### DIFF
--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerAuthTools(server: McpServer, client: DockhandClient): void {
 
@@ -40,21 +41,21 @@ export function registerAuthTools(server: McpServer, client: DockhandClient): vo
   registerTool(server, 'get_oidc_provider', 'Get details of an OIDC provider',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
-      return jsonResponse(await client.get(`/api/auth/oidc/${providerId}`));
+      return jsonResponse(await client.get(`/api/auth/oidc/${encodePath(providerId)}`));
     }
   );
 
   registerTool(server, 'test_oidc_provider', 'Test an OIDC provider connection',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
-      return jsonResponse(await client.post(`/api/auth/oidc/${providerId}/test`));
+      return jsonResponse(await client.post(`/api/auth/oidc/${encodePath(providerId)}/test`));
     }
   );
 
   registerTool(server, 'initiate_oidc_login', 'Initiate an OIDC login flow',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
-      return jsonResponse(await client.post(`/api/auth/oidc/${providerId}/initiate`));
+      return jsonResponse(await client.post(`/api/auth/oidc/${encodePath(providerId)}/initiate`));
     }
   );
 
@@ -68,14 +69,14 @@ export function registerAuthTools(server: McpServer, client: DockhandClient): vo
   registerTool(server, 'get_ldap_provider', 'Get details of a LDAP provider',
     { providerId: z.number().describe('LDAP provider ID') },
     async ({ providerId }) => {
-      return jsonResponse(await client.get(`/api/auth/ldap/${providerId}`));
+      return jsonResponse(await client.get(`/api/auth/ldap/${encodePath(providerId)}`));
     }
   );
 
   registerTool(server, 'test_ldap_provider', 'Test a LDAP provider connection',
     { providerId: z.number().describe('LDAP provider ID') },
     async ({ providerId }) => {
-      return jsonResponse(await client.post(`/api/auth/ldap/${providerId}/test`));
+      return jsonResponse(await client.post(`/api/auth/ldap/${encodePath(providerId)}/test`));
     }
   );
 

--- a/src/tools/auto-update.ts
+++ b/src/tools/auto-update.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerAutoUpdateTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerAutoUpdateTools(server: McpServer, client: DockhandClien
       containerName: z.string().describe('Container name'),
     },
     async ({ environmentId, containerName }) => {
-      return jsonResponse(await client.get(`/api/auto-update/${encodeURIComponent(containerName)}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/auto-update/${encodePath(containerName)}`, { env: environmentId }));
     }
   );
 
@@ -33,7 +34,7 @@ export function registerAutoUpdateTools(server: McpServer, client: DockhandClien
       policy: z.enum(['never', 'any', 'critical-high', 'critical', 'more-than-current']).describe('Auto-update policy'),
     },
     async ({ environmentId, containerName, policy }) => {
-      return jsonResponse(await client.put(`/api/auto-update/${encodeURIComponent(containerName)}`, { policy }, { env: environmentId }));
+      return jsonResponse(await client.put(`/api/auto-update/${encodePath(containerName)}`, { policy }, { env: environmentId }));
     }
   );
 }

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerContainerTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.get(`/api/containers/${encodeURIComponent(String(containerId))}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}`, { env: environmentId }));
     }
   );
 
@@ -32,7 +33,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.get(`/api/containers/${containerId}/inspect`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}/inspect`, { env: environmentId }));
     }
   );
 
@@ -43,7 +44,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       tail: z.number().optional().describe('Number of lines from the end (default: 100)'),
     },
     async ({ environmentId, containerId, tail }) => {
-      const data = await client.get(`/api/containers/${containerId}/logs`, {
+      const data = await client.get(`/api/containers/${encodePath(containerId)}/logs`, {
         env: environmentId,
         tail: tail ?? 100,
       });
@@ -57,7 +58,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.get(`/api/containers/${containerId}/stats`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}/stats`, { env: environmentId }));
     }
   );
 
@@ -67,7 +68,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.get(`/api/containers/${containerId}/top`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}/top`, { env: environmentId }));
     }
   );
 
@@ -77,7 +78,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/start`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/start`, undefined, { env: environmentId }));
     }
   );
 
@@ -87,7 +88,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/stop`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/stop`, undefined, { env: environmentId }));
     }
   );
 
@@ -97,7 +98,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/restart`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/restart`, undefined, { env: environmentId }));
     }
   );
 
@@ -107,7 +108,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/pause`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/pause`, undefined, { env: environmentId }));
     }
   );
 
@@ -117,7 +118,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/unpause`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/unpause`, undefined, { env: environmentId }));
     }
   );
 
@@ -128,7 +129,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       name: z.string().describe('New container name'),
     },
     async ({ environmentId, containerId, name }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/rename`, { name }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/rename`, { name }, { env: environmentId }));
     }
   );
 
@@ -139,7 +140,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       settings: z.record(z.unknown()).optional().describe('Container settings to update'),
     },
     async ({ environmentId, containerId, settings }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/update`, settings, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/update`, settings, { env: environmentId }));
     }
   );
 
@@ -178,7 +179,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       containerId: z.string().describe('Container ID'),
     },
     async ({ environmentId, containerId }) => {
-      return jsonResponse(await client.get(`/api/containers/${containerId}/shells`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}/shells`, { env: environmentId }));
     }
   );
 
@@ -191,7 +192,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       path: z.string().optional().describe('Path inside container (default: /)'),
     },
     async ({ environmentId, containerId, path }) => {
-      return jsonResponse(await client.get(`/api/containers/${containerId}/files`, {
+      return jsonResponse(await client.get(`/api/containers/${encodePath(containerId)}/files`, {
         env: environmentId,
         path: path ?? '/',
       }));
@@ -205,7 +206,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       path: z.string().describe('File path inside container'),
     },
     async ({ environmentId, containerId, path }) => {
-      const data = await client.get(`/api/containers/${containerId}/files/content`, {
+      const data = await client.get(`/api/containers/${encodePath(containerId)}/files/content`, {
         env: environmentId,
         path,
       });
@@ -221,7 +222,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       content: z.string().describe('File content'),
     },
     async ({ environmentId, containerId, path, content }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/files/create`, { path, content }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/files/create`, { path, content }, { env: environmentId }));
     }
   );
 
@@ -232,7 +233,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       path: z.string().describe('File path inside container'),
     },
     async ({ environmentId, containerId, path }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/files/delete`, { path }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/files/delete`, { path }, { env: environmentId }));
     }
   );
 
@@ -244,7 +245,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       newPath: z.string().describe('New file path'),
     },
     async ({ environmentId, containerId, oldPath, newPath }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/files/rename`, { oldPath, newPath }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/files/rename`, { oldPath, newPath }, { env: environmentId }));
     }
   );
 
@@ -256,7 +257,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       mode: z.string().describe('Permission mode (e.g. 0755)'),
     },
     async ({ environmentId, containerId, path, mode }) => {
-      return jsonResponse(await client.post(`/api/containers/${containerId}/files/chmod`, { path, mode }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/files/chmod`, { path, mode }, { env: environmentId }));
     }
   );
 

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 /**
  * Resolve host/port from explicit args or a URL string into the request body.
@@ -74,7 +75,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
   registerTool(server, 'get_environment', 'Get details of a specific environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}`));
     }
   );
 
@@ -103,28 +104,28 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.unknown()).optional().describe('Additional settings to update'),
     },
     async ({ environmentId, name, host, port, url, settings }) => {
-      const env = await client.get(`/api/environments/${environmentId}`) as Record<string, unknown>;
+      const env = await client.get(`/api/environments/${encodePath(environmentId)}`) as Record<string, unknown>;
       const connectionType = (env.connectionType as string) ?? '';
       const body: Record<string, unknown> = {};
       if (name) body.name = name;
       // Merge settings first so explicit host/port can override them
       if (settings) Object.assign(body, settings);
       resolveHostPort(body, { host, port, url }, connectionType, false);
-      return jsonResponse(await client.put(`/api/environments/${environmentId}`, body));
+      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}`, body));
     }
   );
 
   registerTool(server, 'delete_environment', 'Delete an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.delete(`/api/environments/${environmentId}`));
+      return jsonResponse(await client.delete(`/api/environments/${encodePath(environmentId)}`));
     }
   );
 
   registerTool(server, 'test_environment', 'Test connection to an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.post(`/api/environments/${environmentId}/test`));
+      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/test`));
     }
   );
 
@@ -152,7 +153,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
   registerTool(server, 'get_environment_timezone', 'Get the timezone of an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}/timezone`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/timezone`));
     }
   );
 
@@ -162,14 +163,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       timezone: z.string().describe('Timezone string (e.g. Europe/Berlin)'),
     },
     async ({ environmentId, timezone }) => {
-      return jsonResponse(await client.put(`/api/environments/${environmentId}/timezone`, { timezone }));
+      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/timezone`, { timezone }));
     }
   );
 
   registerTool(server, 'get_environment_update_check', 'Get update-check settings of an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}/update-check`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/update-check`));
     }
   );
 
@@ -179,14 +180,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.unknown()).describe('Update-check settings'),
     },
     async ({ environmentId, settings }) => {
-      return jsonResponse(await client.put(`/api/environments/${environmentId}/update-check`, settings));
+      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/update-check`, settings));
     }
   );
 
   registerTool(server, 'get_environment_image_prune', 'Get image prune settings of an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}/image-prune`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/image-prune`));
     }
   );
 
@@ -196,14 +197,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.unknown()).describe('Image prune settings'),
     },
     async ({ environmentId, settings }) => {
-      return jsonResponse(await client.put(`/api/environments/${environmentId}/image-prune`, settings));
+      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/image-prune`, settings));
     }
   );
 
   registerTool(server, 'list_environment_notifications', 'List notifications configured for an environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}/notifications`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/notifications`));
     }
   );
 
@@ -213,7 +214,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       config: z.record(z.unknown()).describe('Notification configuration'),
     },
     async ({ environmentId, config }) => {
-      return jsonResponse(await client.post(`/api/environments/${environmentId}/notifications`, config));
+      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/notifications`, config));
     }
   );
 
@@ -223,7 +224,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       notificationId: z.number().describe('Notification ID'),
     },
     async ({ environmentId, notificationId }) => {
-      return jsonResponse(await client.get(`/api/environments/${environmentId}/notifications/${notificationId}`));
+      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/notifications/${encodePath(notificationId)}`));
     }
   );
 
@@ -233,7 +234,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       notificationId: z.number().describe('Notification ID'),
     },
     async ({ environmentId, notificationId }) => {
-      return jsonResponse(await client.delete(`/api/environments/${environmentId}/notifications/${notificationId}`));
+      return jsonResponse(await client.delete(`/api/environments/${encodePath(environmentId)}/notifications/${encodePath(notificationId)}`));
     }
   );
 }

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerGitStackTools(server: McpServer, client: DockhandClient): void {
 
@@ -19,35 +20,35 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_git_stack', 'Get details of a specific Git stack',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
-      return jsonResponse(await client.get(`/api/git/stacks/${stackId}`));
+      return jsonResponse(await client.get(`/api/git/stacks/${encodePath(stackId)}`));
     }
   );
 
   registerTool(server, 'deploy_git_stack', 'Deploy a Git-based stack (pulls latest and deploys via SSE)',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
-      return jsonResponse(await client.postSSE(`/api/git/stacks/${stackId}/deploy`));
+      return jsonResponse(await client.postSSE(`/api/git/stacks/${encodePath(stackId)}/deploy`));
     }
   );
 
   registerTool(server, 'sync_git_stack', 'Synchronize a Git-based stack with its remote repository',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
-      return jsonResponse(await client.post(`/api/git/stacks/${stackId}/sync`));
+      return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/sync`));
     }
   );
 
   registerTool(server, 'test_git_stack', 'Test the Git connection for a stack',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
-      return jsonResponse(await client.post(`/api/git/stacks/${stackId}/test`));
+      return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/test`));
     }
   );
 
   registerTool(server, 'get_git_stack_env_files', 'Get environment files for a Git-based stack',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
-      return jsonResponse(await client.get(`/api/git/stacks/${stackId}/env-files`));
+      return jsonResponse(await client.get(`/api/git/stacks/${encodePath(stackId)}/env-files`));
     }
   );
 
@@ -57,14 +58,14 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
       token: z.string().optional().describe('Webhook secret token'),
     },
     async ({ stackId, token }) => {
-      return jsonResponse(await client.post(`/api/git/stacks/${stackId}/webhook`, undefined, token ? { token } : undefined));
+      return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/webhook`, undefined, token ? { token } : undefined));
     }
   );
 
   registerTool(server, 'get_git_webhook', 'Get webhook details for a Git stack',
     { webhookId: z.number().describe('Webhook ID') },
     async ({ webhookId }) => {
-      return jsonResponse(await client.get(`/api/git/webhook/${webhookId}`));
+      return jsonResponse(await client.get(`/api/git/webhook/${encodePath(webhookId)}`));
     }
   );
 
@@ -91,7 +92,7 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_git_credential', 'Get details of a Git credential',
     { credentialId: z.number().describe('Credential ID') },
     async ({ credentialId }) => {
-      return jsonResponse(await client.get(`/api/git/credentials/${credentialId}`));
+      return jsonResponse(await client.get(`/api/git/credentials/${encodePath(credentialId)}`));
     }
   );
 
@@ -101,14 +102,14 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
       config: z.record(z.unknown()).describe('Updated credential configuration'),
     },
     async ({ credentialId, config }) => {
-      return jsonResponse(await client.put(`/api/git/credentials/${credentialId}`, config));
+      return jsonResponse(await client.put(`/api/git/credentials/${encodePath(credentialId)}`, config));
     }
   );
 
   registerTool(server, 'delete_git_credential', 'Delete a Git credential',
     { credentialId: z.number().describe('Credential ID') },
     async ({ credentialId }) => {
-      return jsonResponse(await client.delete(`/api/git/credentials/${credentialId}`));
+      return jsonResponse(await client.delete(`/api/git/credentials/${encodePath(credentialId)}`));
     }
   );
 
@@ -133,28 +134,28 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_git_repository', 'Get details of a Git repository',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
-      return jsonResponse(await client.get(`/api/git/repositories/${repositoryId}`));
+      return jsonResponse(await client.get(`/api/git/repositories/${encodePath(repositoryId)}`));
     }
   );
 
   registerTool(server, 'deploy_git_repository', 'Deploy a Git repository',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
-      return jsonResponse(await client.postSSE(`/api/git/repositories/${repositoryId}/deploy`));
+      return jsonResponse(await client.postSSE(`/api/git/repositories/${encodePath(repositoryId)}/deploy`));
     }
   );
 
   registerTool(server, 'sync_git_repository', 'Synchronize a Git repository',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
-      return jsonResponse(await client.post(`/api/git/repositories/${repositoryId}/sync`));
+      return jsonResponse(await client.post(`/api/git/repositories/${encodePath(repositoryId)}/sync`));
     }
   );
 
   registerTool(server, 'test_git_repository', 'Test connection to a Git repository',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
-      return jsonResponse(await client.post(`/api/git/repositories/${repositoryId}/test`));
+      return jsonResponse(await client.post(`/api/git/repositories/${encodePath(repositoryId)}/test`));
     }
   );
 

--- a/src/tools/images.ts
+++ b/src/tools/images.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerImageTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       imageId: z.string().describe('Image ID'),
     },
     async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.get(`/api/images/${encodeURIComponent(String(imageId))}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/images/${encodePath(imageId)}`, { env: environmentId }));
     }
   );
 
@@ -32,7 +33,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       imageId: z.string().describe('Image ID'),
     },
     async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.get(`/api/images/${imageId}/history`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/images/${encodePath(imageId)}/history`, { env: environmentId }));
     }
   );
 
@@ -44,7 +45,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       tag: z.string().describe('Tag name'),
     },
     async ({ environmentId, imageId, repo, tag }) => {
-      return jsonResponse(await client.post(`/api/images/${imageId}/tag`, { repo, tag }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/images/${encodePath(imageId)}/tag`, { repo, tag }, { env: environmentId }));
     }
   );
 
@@ -54,7 +55,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       imageId: z.string().describe('Image ID'),
     },
     async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.delete(`/api/images/${encodeURIComponent(String(imageId))}`, { env: environmentId }));
+      return jsonResponse(await client.delete(`/api/images/${encodePath(imageId)}`, { env: environmentId }));
     }
   );
 
@@ -94,7 +95,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       imageId: z.string().describe('Image ID'),
     },
     async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.post(`/api/images/${imageId}/export`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/images/${encodePath(imageId)}/export`, undefined, { env: environmentId }));
     }
   );
 }

--- a/src/tools/networks.ts
+++ b/src/tools/networks.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerNetworkTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
       networkId: z.string().describe('Network ID'),
     },
     async ({ environmentId, networkId }) => {
-      return jsonResponse(await client.get(`/api/networks/${encodeURIComponent(String(networkId))}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/networks/${encodePath(networkId)}`, { env: environmentId }));
     }
   );
 
@@ -32,7 +33,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
       networkId: z.string().describe('Network ID'),
     },
     async ({ environmentId, networkId }) => {
-      return jsonResponse(await client.get(`/api/networks/${networkId}/inspect`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/networks/${encodePath(networkId)}/inspect`, { env: environmentId }));
     }
   );
 
@@ -66,7 +67,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
       networkId: z.string().describe('Network ID'),
     },
     async ({ environmentId, networkId }) => {
-      return jsonResponse(await client.delete(`/api/networks/${encodeURIComponent(String(networkId))}`, { env: environmentId }));
+      return jsonResponse(await client.delete(`/api/networks/${encodePath(networkId)}`, { env: environmentId }));
     }
   );
 
@@ -77,7 +78,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
       containerId: z.string().describe('Container ID to connect'),
     },
     async ({ environmentId, networkId, containerId }) => {
-      return jsonResponse(await client.post(`/api/networks/${networkId}/connect`, { containerId }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/networks/${encodePath(networkId)}/connect`, { containerId }, { env: environmentId }));
     }
   );
 
@@ -88,7 +89,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
       containerId: z.string().describe('Container ID to disconnect'),
     },
     async ({ environmentId, networkId, containerId }) => {
-      return jsonResponse(await client.post(`/api/networks/${networkId}/disconnect`, { containerId }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/networks/${encodePath(networkId)}/disconnect`, { containerId }, { env: environmentId }));
     }
   );
 }

--- a/src/tools/notifications.ts
+++ b/src/tools/notifications.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerNotificationTools(server: McpServer, client: DockhandClient): void {
 
@@ -28,7 +29,7 @@ export function registerNotificationTools(server: McpServer, client: DockhandCli
   registerTool(server, 'get_notification', 'Get details of a notification configuration',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
-      return jsonResponse(await client.get(`/api/notifications/${notificationId}`));
+      return jsonResponse(await client.get(`/api/notifications/${encodePath(notificationId)}`));
     }
   );
 
@@ -38,21 +39,21 @@ export function registerNotificationTools(server: McpServer, client: DockhandCli
       config: z.record(z.unknown()).describe('Updated notification configuration'),
     },
     async ({ notificationId, config }) => {
-      return jsonResponse(await client.put(`/api/notifications/${notificationId}`, config));
+      return jsonResponse(await client.put(`/api/notifications/${encodePath(notificationId)}`, config));
     }
   );
 
   registerTool(server, 'delete_notification', 'Delete a notification configuration',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
-      return jsonResponse(await client.delete(`/api/notifications/${notificationId}`));
+      return jsonResponse(await client.delete(`/api/notifications/${encodePath(notificationId)}`));
     }
   );
 
   registerTool(server, 'test_notification', 'Send a test notification using a saved configuration',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
-      return jsonResponse(await client.post(`/api/notifications/${notificationId}/test`));
+      return jsonResponse(await client.post(`/api/notifications/${encodePath(notificationId)}/test`));
     }
   );
 

--- a/src/tools/registries.ts
+++ b/src/tools/registries.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerRegistryTools(server: McpServer, client: DockhandClient): void {
 
@@ -28,7 +29,7 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_registry', 'Get details of a Docker registry',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
-      return jsonResponse(await client.get(`/api/registries/${registryId}`));
+      return jsonResponse(await client.get(`/api/registries/${encodePath(registryId)}`));
     }
   );
 
@@ -38,21 +39,21 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
       config: z.record(z.unknown()).describe('Updated registry configuration'),
     },
     async ({ registryId, config }) => {
-      return jsonResponse(await client.put(`/api/registries/${registryId}`, config));
+      return jsonResponse(await client.put(`/api/registries/${encodePath(registryId)}`, config));
     }
   );
 
   registerTool(server, 'delete_registry', 'Delete a Docker registry',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
-      return jsonResponse(await client.delete(`/api/registries/${registryId}`));
+      return jsonResponse(await client.delete(`/api/registries/${encodePath(registryId)}`));
     }
   );
 
   registerTool(server, 'set_default_registry', 'Set a registry as the default',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
-      return jsonResponse(await client.post(`/api/registries/${registryId}/default`));
+      return jsonResponse(await client.post(`/api/registries/${encodePath(registryId)}/default`));
     }
   );
 

--- a/src/tools/schedules.ts
+++ b/src/tools/schedules.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerScheduleTools(server: McpServer, client: DockhandClient): void {
 
@@ -42,7 +43,7 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_schedule_execution', 'Get details of a specific schedule execution',
     { executionId: z.number().describe('Execution ID') },
     async ({ executionId }) => {
-      return jsonResponse(await client.get(`/api/schedules/executions/${executionId}`));
+      return jsonResponse(await client.get(`/api/schedules/executions/${encodePath(executionId)}`));
     }
   );
 
@@ -52,7 +53,7 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
       scheduleId: z.number().describe('Schedule ID'),
     },
     async ({ type, scheduleId }) => {
-      return jsonResponse(await client.get(`/api/schedules/${type}/${scheduleId}`));
+      return jsonResponse(await client.get(`/api/schedules/${encodePath(type)}/${encodePath(scheduleId)}`));
     }
   );
 
@@ -62,7 +63,7 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
       scheduleId: z.number().describe('Schedule ID'),
     },
     async ({ type, scheduleId }) => {
-      return jsonResponse(await client.post(`/api/schedules/${type}/${scheduleId}/run`));
+      return jsonResponse(await client.post(`/api/schedules/${encodePath(type)}/${encodePath(scheduleId)}/run`));
     }
   );
 
@@ -72,14 +73,14 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
       scheduleId: z.number().describe('Schedule ID'),
     },
     async ({ type, scheduleId }) => {
-      return jsonResponse(await client.post(`/api/schedules/${type}/${scheduleId}/toggle`));
+      return jsonResponse(await client.post(`/api/schedules/${encodePath(type)}/${encodePath(scheduleId)}/toggle`));
     }
   );
 
   registerTool(server, 'toggle_system_schedule', 'Enable or disable a system schedule',
     { scheduleId: z.number().describe('System schedule ID') },
     async ({ scheduleId }) => {
-      return jsonResponse(await client.post(`/api/schedules/system/${scheduleId}/toggle`));
+      return jsonResponse(await client.post(`/api/schedules/system/${encodePath(scheduleId)}/toggle`));
     }
   );
 }

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerStackTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.get(`/api/stacks/${encodeURIComponent(name)}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/stacks/${encodePath(name)}`, { env: environmentId }));
     }
   );
 
@@ -55,7 +56,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.postSSE(`/api/stacks/${encodeURIComponent(name)}/start`, undefined, { env: environmentId }));
+      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/start`, undefined, { env: environmentId }));
     }
   );
 
@@ -65,7 +66,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.postSSE(`/api/stacks/${encodeURIComponent(name)}/stop`, undefined, { env: environmentId }));
+      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/stop`, undefined, { env: environmentId }));
     }
   );
 
@@ -75,7 +76,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.postSSE(`/api/stacks/${encodeURIComponent(name)}/restart`, undefined, { env: environmentId }));
+      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/restart`, undefined, { env: environmentId }));
     }
   );
 
@@ -87,7 +88,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     },
     async ({ environmentId, name, removeVolumes }) => {
       const body = removeVolumes !== undefined ? { removeVolumes } : undefined;
-      return jsonResponse(await client.postSSE(`/api/stacks/${encodeURIComponent(name)}/down`, body, { env: environmentId }));
+      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/down`, body, { env: environmentId }));
     }
   );
 
@@ -98,7 +99,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       force: z.boolean().optional().describe('Force deletion'),
     },
     async ({ environmentId, name, force }) => {
-      return jsonResponse(await client.delete(`/api/stacks/${encodeURIComponent(name)}`, {
+      return jsonResponse(await client.delete(`/api/stacks/${encodePath(name)}`, {
         env: environmentId,
         force: force ? 'true' : undefined,
       }));
@@ -111,7 +112,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.get(`/api/stacks/${encodeURIComponent(name)}/compose`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/stacks/${encodePath(name)}/compose`, { env: environmentId }));
     }
   );
 
@@ -127,10 +128,10 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       if (restart !== undefined) body.restart = restart;
 
       if (restart) {
-        return jsonResponse(await client.putSSE(`/api/stacks/${encodeURIComponent(name)}/compose`, body, { env: environmentId }));
+        return jsonResponse(await client.putSSE(`/api/stacks/${encodePath(name)}/compose`, body, { env: environmentId }));
       }
 
-      return jsonResponse(await client.put(`/api/stacks/${encodeURIComponent(name)}/compose`, body, { env: environmentId }));
+      return jsonResponse(await client.put(`/api/stacks/${encodePath(name)}/compose`, body, { env: environmentId }));
     }
   );
 
@@ -140,7 +141,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.get(`/api/stacks/${encodeURIComponent(name)}/env`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/stacks/${encodePath(name)}/env`, { env: environmentId }));
     }
   );
 
@@ -159,7 +160,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       const body: Record<string, unknown> = {};
       if (variables) body.variables = variables;
       if (rawContent) body.rawContent = rawContent;
-      return jsonResponse(await client.put(`/api/stacks/${encodeURIComponent(name)}/env`, body, { env: environmentId }));
+      return jsonResponse(await client.put(`/api/stacks/${encodePath(name)}/env`, body, { env: environmentId }));
     }
   );
 
@@ -169,7 +170,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return textResponse(await client.get(`/api/stacks/${encodeURIComponent(name)}/env/raw`, { env: environmentId }));
+      return textResponse(await client.get(`/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId }));
     }
   );
 
@@ -179,7 +180,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return jsonResponse(await client.post(`/api/stacks/${encodeURIComponent(name)}/env/validate`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/env/validate`, undefined, { env: environmentId }));
     }
   );
 
@@ -210,7 +211,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       newPath: z.string().describe('New filesystem path'),
     },
     async ({ environmentId, name, newPath }) => {
-      return jsonResponse(await client.post(`/api/stacks/${encodeURIComponent(name)}/relocate`, { path: newPath }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/relocate`, { path: newPath }, { env: environmentId }));
     }
   );
 
@@ -261,7 +262,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       newPath: z.string().describe('New filesystem path to check'),
     },
     async ({ environmentId, name, newPath }) => {
-      return jsonResponse(await client.post(`/api/stacks/${encodeURIComponent(name)}/check-path-change`, { path: newPath }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/check-path-change`, { path: newPath }, { env: environmentId }));
     }
   );
 }

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerUserTools(server: McpServer, client: DockhandClient): void {
 
@@ -36,7 +37,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
   registerTool(server, 'get_user', 'Get details of a Dockhand user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.get(`/api/users/${userId}`));
+      return jsonResponse(await client.get(`/api/users/${encodePath(userId)}`));
     }
   );
 
@@ -46,42 +47,42 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       settings: z.record(z.unknown()).describe('User settings to update'),
     },
     async ({ userId, settings }) => {
-      return jsonResponse(await client.put(`/api/users/${userId}`, settings));
+      return jsonResponse(await client.put(`/api/users/${encodePath(userId)}`, settings));
     }
   );
 
   registerTool(server, 'delete_user', 'Delete a Dockhand user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.delete(`/api/users/${userId}`));
+      return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}`));
     }
   );
 
   registerTool(server, 'get_user_mfa_status', 'Get MFA status of a user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.get(`/api/users/${userId}/mfa`));
+      return jsonResponse(await client.get(`/api/users/${encodePath(userId)}/mfa`));
     }
   );
 
   registerTool(server, 'enable_user_mfa', 'Enable MFA for a user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.post(`/api/users/${userId}/mfa`));
+      return jsonResponse(await client.post(`/api/users/${encodePath(userId)}/mfa`));
     }
   );
 
   registerTool(server, 'disable_user_mfa', 'Disable MFA for a user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.delete(`/api/users/${userId}/mfa`));
+      return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}/mfa`));
     }
   );
 
   registerTool(server, 'get_user_roles', 'Get roles assigned to a user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
-      return jsonResponse(await client.get(`/api/users/${userId}/roles`));
+      return jsonResponse(await client.get(`/api/users/${encodePath(userId)}/roles`));
     }
   );
 
@@ -91,7 +92,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       roles: z.array(z.string()).describe('Role names to assign'),
     },
     async ({ userId, roles }) => {
-      return jsonResponse(await client.put(`/api/users/${userId}/roles`, { roles }));
+      return jsonResponse(await client.put(`/api/users/${encodePath(userId)}/roles`, { roles }));
     }
   );
 
@@ -119,7 +120,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
   registerTool(server, 'get_role', 'Get details of a Dockhand role',
     { roleId: z.number().describe('Role ID') },
     async ({ roleId }) => {
-      return jsonResponse(await client.get(`/api/roles/${roleId}`));
+      return jsonResponse(await client.get(`/api/roles/${encodePath(roleId)}`));
     }
   );
 
@@ -129,14 +130,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       config: z.record(z.unknown()).describe('Role configuration to update'),
     },
     async ({ roleId, config }) => {
-      return jsonResponse(await client.put(`/api/roles/${roleId}`, config));
+      return jsonResponse(await client.put(`/api/roles/${encodePath(roleId)}`, config));
     }
   );
 
   registerTool(server, 'delete_role', 'Delete a Dockhand role',
     { roleId: z.number().describe('Role ID') },
     async ({ roleId }) => {
-      return jsonResponse(await client.delete(`/api/roles/${roleId}`));
+      return jsonResponse(await client.delete(`/api/roles/${encodePath(roleId)}`));
     }
   );
 
@@ -245,7 +246,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
   registerTool(server, 'get_config_set', 'Get a specific config set',
     { configSetId: z.number().describe('Config set ID') },
     async ({ configSetId }) => {
-      return jsonResponse(await client.get(`/api/config-sets/${configSetId}`));
+      return jsonResponse(await client.get(`/api/config-sets/${encodePath(configSetId)}`));
     }
   );
 
@@ -255,14 +256,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       config: z.record(z.unknown()).describe('Updated config set data'),
     },
     async ({ configSetId, config }) => {
-      return jsonResponse(await client.put(`/api/config-sets/${configSetId}`, config));
+      return jsonResponse(await client.put(`/api/config-sets/${encodePath(configSetId)}`, config));
     }
   );
 
   registerTool(server, 'delete_config_set', 'Delete a config set',
     { configSetId: z.number().describe('Config set ID') },
     async ({ configSetId }) => {
-      return jsonResponse(await client.delete(`/api/config-sets/${configSetId}`));
+      return jsonResponse(await client.delete(`/api/config-sets/${encodePath(configSetId)}`));
     }
   );
 }

--- a/src/tools/volumes.ts
+++ b/src/tools/volumes.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export function registerVolumeTools(server: McpServer, client: DockhandClient): void {
 
@@ -22,7 +23,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.get(`/api/volumes/${encodeURIComponent(volumeName)}`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/volumes/${encodePath(volumeName)}`, { env: environmentId }));
     }
   );
 
@@ -32,7 +33,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.get(`/api/volumes/${encodeURIComponent(volumeName)}/inspect`, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/volumes/${encodePath(volumeName)}/inspect`, { env: environmentId }));
     }
   );
 
@@ -43,7 +44,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       path: z.string().optional().describe('Path inside the volume (default: /)'),
     },
     async ({ environmentId, volumeName, path }) => {
-      return jsonResponse(await client.get(`/api/volumes/${encodeURIComponent(volumeName)}/browse`, {
+      return jsonResponse(await client.get(`/api/volumes/${encodePath(volumeName)}/browse`, {
         env: environmentId,
         path: path ?? '/',
       }));
@@ -57,7 +58,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       path: z.string().describe('File path inside the volume'),
     },
     async ({ environmentId, volumeName, path }) => {
-      const data = await client.get(`/api/volumes/${encodeURIComponent(volumeName)}/browse/content`, {
+      const data = await client.get(`/api/volumes/${encodePath(volumeName)}/browse/content`, {
         env: environmentId,
         path,
       });
@@ -71,7 +72,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.post(`/api/volumes/${encodeURIComponent(volumeName)}/browse/release`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/browse/release`, undefined, { env: environmentId }));
     }
   );
 
@@ -84,7 +85,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     async ({ environmentId, volumeName, newName }) => {
       const body: Record<string, unknown> = {};
       if (newName) body.newName = newName;
-      return jsonResponse(await client.post(`/api/volumes/${encodeURIComponent(volumeName)}/clone`, body, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/clone`, body, { env: environmentId }));
     }
   );
 
@@ -94,7 +95,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.post(`/api/volumes/${encodeURIComponent(volumeName)}/export`, undefined, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/export`, undefined, { env: environmentId }));
     }
   );
 
@@ -104,7 +105,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.delete(`/api/volumes/${encodeURIComponent(volumeName)}`, { env: environmentId }));
+      return jsonResponse(await client.delete(`/api/volumes/${encodePath(volumeName)}`, { env: environmentId }));
     }
   );
 }

--- a/src/utils/encode-path.ts
+++ b/src/utils/encode-path.ts
@@ -1,0 +1,5 @@
+/**
+ * Encode a path parameter for safe use in URL paths.
+ * Prevents path injection by ensuring special characters are percent-encoded.
+ */
+export const encodePath = (id: string | number): string => encodeURIComponent(String(id));


### PR DESCRIPTION
## Summary

- Neue `encodePath()` Helper-Funktion in `src/utils/encode-path.ts` als zentrale Stelle fuer URL-Pfad-Encoding
- **128 Pfad-Parameter** in **13 Tool-Dateien** werden jetzt konsistent ueber `encodePath()` encoded
- Vorher: Nur ~30 Stellen (in stacks.ts, volumes.ts, und teilweise images/networks/containers) nutzten `encodeURIComponent` direkt, der Rest interpolierte IDs ungesichert in URL-Pfade
- Ersetzt auch bestehende `encodeURIComponent(String(...))` Aufrufe durch den einheitlichen Helper

### Betroffene Dateien

| Datei | Encoded Parameter |
|-------|-------------------|
| `auth.ts` | providerId |
| `auto-update.ts` | containerName |
| `containers.ts` | containerId |
| `environments.ts` | environmentId, notificationId |
| `git-stacks.ts` | stackId, webhookId, credentialId, repositoryId |
| `images.ts` | imageId |
| `networks.ts` | networkId |
| `notifications.ts` | notificationId |
| `registries.ts` | registryId |
| `schedules.ts` | executionId, type, scheduleId |
| `stacks.ts` | name (refactored to encodePath) |
| `users.ts` | userId, roleId, configSetId |
| `volumes.ts` | volumeName (refactored to encodePath) |

## Test plan

- [x] `npm run typecheck` besteht ohne Fehler
- [ ] Manueller Test: Container/Stack/Image Operationen funktionieren weiterhin
- [ ] Verifiziert: `grep -rn '/api/.*\${[^}]*}' src/tools/ | grep -v encodePath` liefert 0 Treffer

Closes #16