### PR TITLE
fix: Test-Praezision fuer Tool-Registration und Environment-Scope verbessern

### DIFF
--- a/tests/environment-scope.test.ts
+++ b/tests/environment-scope.test.ts
@@ -42,11 +42,21 @@ describe('Environment scope consistency', () => {
 
         if (handlerMatch) {
           const handlerBody = handlerMatch[1]!;
+          // Verify environmentId is actually used in the handler body,
+          // not just destructured. Check for specific usage patterns:
           const passesEnv =
-            handlerBody.includes('env: environmentId') ||
-            handlerBody.includes('env: environmentId,') ||
-            // Some tools pass it as a query param directly
-            handlerBody.includes('environmentId');
+            // Passed as env parameter: { env: environmentId }
+            /env:\s*environmentId/.test(handlerBody) ||
+            // Passed as named property: { environmentId: environmentId } or shorthand { environmentId }
+            /\benvironmentId\b/.test(handlerBody) && (
+              // Used in template literal: `.../${encodePath(environmentId)}`
+              /encodePath\(environmentId\)/.test(handlerBody) ||
+              /\$\{environmentId\}/.test(handlerBody) ||
+              // Used in object literal (shorthand or explicit)
+              /\{\s*[^}]*\benvironmentId\b[^}]*\}/.test(handlerBody) ||
+              // Used as query/body parameter
+              /params.*environmentId|body.*environmentId/.test(handlerBody)
+            );
 
           expect(
             passesEnv,

--- a/tests/tool-registration.test.ts
+++ b/tests/tool-registration.test.ts
@@ -35,12 +35,22 @@ describe('Tool registration completeness', () => {
 
     it(`${file}: should have its register function called in registerAllTools()`, () => {
       // Convention: each module exports register<Category>Tools
-      // Check that at least one function from this module is called
-      const registerFnRegex = new RegExp(`register\\w+Tools\\(server, client\\)`);
+      // Derive the expected function name from the import path in index.ts
+      const importRegex = new RegExp(
+        `import\\s*\\{\\s*(register\\w+Tools)\\s*\\}\\s*from\\s*['\\./"]*${moduleName}\\.js['"]`
+      );
+      const importMatch = indexContent.match(importRegex);
+      expect(
+        importMatch,
+        `No import found for module ${moduleName} in tools/index.ts`
+      ).not.toBeNull();
+
+      const registerFnName = importMatch![1]!;
+      const callRegex = new RegExp(`${registerFnName}\\(server, client\\)`);
       expect(
         indexContent,
-        `No register function call found for ${file} in tools/index.ts`
-      ).toMatch(registerFnRegex);
+        `Function ${registerFnName} not called for ${file} in tools/index.ts`
+      ).toMatch(callRegex);
     });
   }
 


### PR DESCRIPTION
## Summary

- **Tool-Registration-Test** prueft jetzt modulspezifisch: Der erwartete Funktionsname wird aus dem tatsaechlichen Import in `index.ts` abgeleitet, statt beliebige `register*Tools`-Aufrufe zu matchen
- **Environment-Scope-Test** nutzt gezielte Regex-Patterns statt `string.includes()`, um zu verifizieren dass `environmentId` tatsaechlich an die API weitergegeben wird (erkennt `encodePath(environmentId)`, Template-Literals, Objekt-Shorthand-Properties)

## Test plan

- [x] Alle 178 Tests bestehen (`npm test`)
- [x] Tool-Registration-Test schlaegt fehl wenn ein Modul nicht korrekt importiert/registriert ist
- [x] Environment-Scope-Test erkennt alle Varianten der environmentId-Weitergabe

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)