### PR TITLE
fix: typed parameters for environments and git tools

### DIFF
--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -101,15 +101,27 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       host: z.string().optional().describe('Docker host IP or hostname (for hawser-standard mode)'),
       port: z.number().optional().describe('Docker host port (for hawser-standard mode)'),
       url: z.string().optional().describe('Docker host URL (legacy, will be parsed into host/port)'),
-      settings: z.record(z.unknown()).optional().describe('Additional settings to update'),
+      icon: z.string().optional().describe('Icon name for the environment'),
+      labels: z.array(z.string()).optional().describe('Labels assigned to the environment'),
+      collectActivity: z.boolean().optional().describe('Collect container activity logs'),
+      collectMetrics: z.boolean().optional().describe('Collect host metrics (CPU, memory, etc.)'),
+      highlightChanges: z.boolean().optional().describe('Highlight recent container changes'),
+      socketPath: z.string().optional().describe('Custom Docker socket path (e.g. /var/run/docker.sock)'),
+      additionalSettings: z.record(z.unknown()).optional().describe('Additional settings not covered by explicit parameters'),
     },
-    async ({ environmentId, name, host, port, url, settings }) => {
+    async ({ environmentId, name, host, port, url, icon, labels, collectActivity, collectMetrics, highlightChanges, socketPath, additionalSettings }) => {
       const env = await client.get(`/api/environments/${encodePath(environmentId)}`) as Record<string, unknown>;
       const connectionType = (env.connectionType as string) ?? '';
       const body: Record<string, unknown> = {};
       if (name) body.name = name;
-      // Merge settings first so explicit host/port can override them
-      if (settings) Object.assign(body, settings);
+      // Merge additional settings first so explicit fields can override them
+      if (additionalSettings) Object.assign(body, additionalSettings);
+      if (icon !== undefined) body.icon = icon;
+      if (labels !== undefined) body.labels = labels;
+      if (collectActivity !== undefined) body.collectActivity = collectActivity;
+      if (collectMetrics !== undefined) body.collectMetrics = collectMetrics;
+      if (highlightChanges !== undefined) body.highlightChanges = highlightChanges;
+      if (socketPath !== undefined) body.socketPath = socketPath;
       resolveHostPort(body, { host, port, url }, connectionType, false);
       return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}`, body));
     }

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -82,10 +82,20 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     {
       name: z.string().describe('Credential name'),
       type: z.string().describe('Credential type (e.g. ssh, token, password)'),
-      config: z.record(z.unknown()).describe('Credential configuration'),
+      username: z.string().optional().describe('Username for password-based authentication'),
+      password: z.string().optional().describe('Password for password-based authentication'),
+      sshKey: z.string().optional().describe('Private SSH key content for SSH authentication'),
+      token: z.string().optional().describe('Personal access token for token-based authentication'),
+      additionalConfig: z.record(z.unknown()).optional().describe('Additional configuration not covered by explicit parameters'),
     },
-    async ({ name, type, config }) => {
-      return jsonResponse(await client.post('/api/git/credentials', { name, type, ...config }));
+    async ({ name, type, username, password, sshKey, token, additionalConfig }) => {
+      const body: Record<string, unknown> = { name, type };
+      if (username !== undefined) body.username = username;
+      if (password !== undefined) body.password = password;
+      if (sshKey !== undefined) body.sshKey = sshKey;
+      if (token !== undefined) body.token = token;
+      if (additionalConfig) Object.assign(body, additionalConfig);
+      return jsonResponse(await client.post('/api/git/credentials', body));
     }
   );
 
@@ -99,10 +109,24 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'update_git_credential', 'Update a Git credential',
     {
       credentialId: z.number().describe('Credential ID'),
-      config: z.record(z.unknown()).describe('Updated credential configuration'),
+      name: z.string().optional().describe('Updated credential name'),
+      type: z.string().optional().describe('Updated credential type (e.g. ssh, token, password)'),
+      username: z.string().optional().describe('Username for password-based authentication'),
+      password: z.string().optional().describe('Password for password-based authentication'),
+      sshKey: z.string().optional().describe('Private SSH key content for SSH authentication'),
+      token: z.string().optional().describe('Personal access token for token-based authentication'),
+      additionalConfig: z.record(z.unknown()).optional().describe('Additional configuration not covered by explicit parameters'),
     },
-    async ({ credentialId, config }) => {
-      return jsonResponse(await client.put(`/api/git/credentials/${encodePath(credentialId)}`, config));
+    async ({ credentialId, name, type, username, password, sshKey, token, additionalConfig }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body.name = name;
+      if (type !== undefined) body.type = type;
+      if (username !== undefined) body.username = username;
+      if (password !== undefined) body.password = password;
+      if (sshKey !== undefined) body.sshKey = sshKey;
+      if (token !== undefined) body.token = token;
+      if (additionalConfig) Object.assign(body, additionalConfig);
+      return jsonResponse(await client.put(`/api/git/credentials/${encodePath(credentialId)}`, body));
     }
   );
 
@@ -124,10 +148,23 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
 
   registerTool(server, 'create_git_repository', 'Create a new Git repository configuration',
     {
-      config: z.record(z.unknown()).describe('Repository configuration (url, branch, credentialId, etc.)'),
+      url: z.string().describe('Git repository URL (HTTPS or SSH)'),
+      branch: z.string().optional().describe('Branch to track (default: main or master)'),
+      credentialId: z.number().optional().describe('ID of the Git credential to use for authentication'),
+      composePath: z.string().optional().describe('Path to docker-compose file within the repository'),
+      envFilePath: z.string().optional().describe('Path to .env file within the repository'),
+      stackName: z.string().optional().describe('Name for the stack created from this repository'),
+      additionalConfig: z.record(z.unknown()).optional().describe('Additional configuration not covered by explicit parameters'),
     },
-    async ({ config }) => {
-      return jsonResponse(await client.post('/api/git/repositories', config));
+    async ({ url, branch, credentialId, composePath, envFilePath, stackName, additionalConfig }) => {
+      const body: Record<string, unknown> = { url };
+      if (branch !== undefined) body.branch = branch;
+      if (credentialId !== undefined) body.credentialId = credentialId;
+      if (composePath !== undefined) body.composePath = composePath;
+      if (envFilePath !== undefined) body.envFilePath = envFilePath;
+      if (stackName !== undefined) body.stackName = stackName;
+      if (additionalConfig) Object.assign(body, additionalConfig);
+      return jsonResponse(await client.post('/api/git/repositories', body));
     }
   );
 


### PR DESCRIPTION
## Summary

- **`update_environment`**: Ersetzt `settings: Record<string, unknown>` durch explizite Parameter: `icon`, `labels`, `collectActivity`, `collectMetrics`, `highlightChanges`, `socketPath`
- **`create_git_credential`** und **`update_git_credential`**: Ersetzt `config: Record<string, unknown>` durch `username`, `password`, `sshKey`, `token`
- **`create_git_repository`**: Ersetzt `config: Record<string, unknown>` durch `url`, `branch`, `credentialId`, `composePath`, `envFilePath`, `stackName`
- Alle Tools behalten einen optionalen `additionalConfig`/`additionalSettings`-Fallback für seltene oder zukünftige Felder

## Motivation

LLMs bekommen bei `Record<string, unknown>` keine Hinweise, welche Felder erwartet werden. Durch explizit typisierte Parameter mit `.describe()` können MCP-Clients die richtigen Felder vorschlagen.

## Test plan

- [x] `npm run typecheck` — keine Fehler
- [x] `npm test` — alle 178 Tests bestanden
- [ ] Manueller Test: `update_environment` mit einzelnen Feldern aufrufen
- [ ] Manueller Test: `create_git_credential` mit verschiedenen Typen (ssh, token, password)
- [ ] Manueller Test: `create_git_repository` mit url + branch + credentialId

Closes #17