### PR TITLE
fix: correct HTTP methods for 21 MCP tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.tgz
 coverage/
 .nyc_output/
+validation-report.md

--- a/src/tools/auto-update.ts
+++ b/src/tools/auto-update.ts
@@ -34,7 +34,7 @@ export function registerAutoUpdateTools(server: McpServer, client: DockhandClien
       policy: z.enum(['never', 'any', 'critical-high', 'critical', 'more-than-current']).describe('Auto-update policy'),
     },
     async ({ environmentId, containerName, policy }) => {
-      return jsonResponse(await client.put(`/api/auto-update/${encodePath(containerName)}`, { policy }, { env: environmentId }));
+      return jsonResponse(await client.post(`/api/auto-update/${encodePath(containerName)}`, { policy }, { env: environmentId }));
     }
   );
 }

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -233,7 +233,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
       path: z.string().describe('File path inside container'),
     },
     async ({ environmentId, containerId, path }) => {
-      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/files/delete`, { path }, { env: environmentId }));
+      return jsonResponse(await client.delete(`/api/containers/${encodePath(containerId)}/files/delete`, { env: environmentId, path }));
     }
   );
 

--- a/src/tools/dashboard.ts
+++ b/src/tools/dashboard.ts
@@ -26,7 +26,7 @@ export function registerDashboardTools(server: McpServer, client: DockhandClient
   registerTool(server, 'set_dashboard_preferences', 'Set dashboard display preferences',
     { preferences: z.record(z.unknown()).describe('Dashboard preferences') },
     async ({ preferences }) => {
-      return jsonResponse(await client.put('/api/dashboard/preferences', preferences));
+      return jsonResponse(await client.post('/api/dashboard/preferences', preferences));
     }
   );
 

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -163,7 +163,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       timezone: z.string().describe('Timezone string (e.g. Europe/Berlin)'),
     },
     async ({ environmentId, timezone }) => {
-      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/timezone`, { timezone }));
+      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/timezone`, { timezone }));
     }
   );
 
@@ -180,7 +180,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.unknown()).describe('Update-check settings'),
     },
     async ({ environmentId, settings }) => {
-      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/update-check`, settings));
+      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/update-check`, settings));
     }
   );
 

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -174,7 +174,7 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
   registerTool(server, 'get_git_preview_env', 'Get preview environment for Git deployments',
     {},
     async () => {
-      return jsonResponse(await client.get('/api/git/preview-env'));
+      return jsonResponse(await client.post('/api/git/preview-env'));
     }
   );
 }

--- a/src/tools/images.ts
+++ b/src/tools/images.ts
@@ -17,16 +17,6 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_image', 'Get details of a specific Docker image',
-    {
-      environmentId: z.number().describe('Environment ID'),
-      imageId: z.string().describe('Image ID'),
-    },
-    async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.get(`/api/images/${encodePath(imageId)}`, { env: environmentId }));
-    }
-  );
-
   registerTool(server, 'get_image_history', 'Get the layer history of a Docker image',
     {
       environmentId: z.number().describe('Environment ID'),
@@ -95,7 +85,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
       imageId: z.string().describe('Image ID'),
     },
     async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.post(`/api/images/${encodePath(imageId)}/export`, undefined, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/images/${encodePath(imageId)}/export`, { env: environmentId }));
     }
   );
 }

--- a/src/tools/registries.ts
+++ b/src/tools/registries.ts
@@ -78,16 +78,6 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_registry_image', 'Get image details from a registry',
-    {
-      image: z.string().describe('Image name'),
-      environmentId: z.number().optional().describe('Environment ID'),
-    },
-    async ({ image, environmentId }) => {
-      return jsonResponse(await client.get('/api/registry/image', { image, env: environmentId }));
-    }
-  );
-
   registerTool(server, 'get_registry_tags', 'Get available tags for an image in a registry',
     {
       image: z.string().describe('Image name'),

--- a/src/tools/schedules.ts
+++ b/src/tools/schedules.ts
@@ -47,16 +47,6 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_schedule', 'Get a specific schedule by type and ID',
-    {
-      type: z.string().describe('Schedule type'),
-      scheduleId: z.number().describe('Schedule ID'),
-    },
-    async ({ type, scheduleId }) => {
-      return jsonResponse(await client.get(`/api/schedules/${encodePath(type)}/${encodePath(scheduleId)}`));
-    }
-  );
-
   registerTool(server, 'run_schedule_now', 'Run a schedule immediately',
     {
       type: z.string().describe('Schedule type'),

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -17,16 +17,6 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack', 'Get details of a specific stack by name',
-    {
-      environmentId: z.number().describe('Environment ID'),
-      name: z.string().describe('Stack name'),
-    },
-    async ({ environmentId, name }) => {
-      return jsonResponse(await client.get(`/api/stacks/${encodePath(name)}`, { env: environmentId }));
-    }
-  );
-
   registerTool(server, 'create_stack', 'Create a new Docker Compose stack and optionally deploy it',
     {
       environmentId: z.number().describe('Environment ID'),

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -94,7 +94,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
       settings: z.record(z.unknown()).describe('Settings to update'),
     },
     async ({ settings }) => {
-      return jsonResponse(await client.put('/api/settings/general', settings));
+      return jsonResponse(await client.post('/api/settings/general', settings));
     }
   );
 
@@ -102,15 +102,6 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     {},
     async () => {
       return jsonResponse(await client.get('/api/settings/theme'));
-    }
-  );
-
-  registerTool(server, 'update_theme_settings', 'Update Dockhand theme settings',
-    {
-      settings: z.record(z.unknown()).describe('Theme settings to update'),
-    },
-    async ({ settings }) => {
-      return jsonResponse(await client.put('/api/settings/theme', settings));
     }
   );
 
@@ -126,7 +117,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
       settings: z.record(z.unknown()).describe('Scanner settings to update'),
     },
     async ({ settings }) => {
-      return jsonResponse(await client.put('/api/settings/scanner', settings));
+      return jsonResponse(await client.post('/api/settings/scanner', settings));
     }
   );
 
@@ -199,7 +190,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
   registerTool(server, 'get_batch_operations', 'Get available batch operations',
     {},
     async () => {
-      return jsonResponse(await client.get('/api/batch'));
+      return jsonResponse(await client.post('/api/batch'));
     }
   );
 

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -58,13 +58,6 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_user_mfa_status', 'Get MFA status of a user',
-    { userId: z.number().describe('User ID') },
-    async ({ userId }) => {
-      return jsonResponse(await client.get(`/api/users/${encodePath(userId)}/mfa`));
-    }
-  );
-
   registerTool(server, 'enable_user_mfa', 'Enable MFA for a user',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
@@ -92,7 +85,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       roles: z.array(z.string()).describe('Role names to assign'),
     },
     async ({ userId, roles }) => {
-      return jsonResponse(await client.put(`/api/users/${encodePath(userId)}/roles`, { roles }));
+      return jsonResponse(await client.post(`/api/users/${encodePath(userId)}/roles`, { roles }));
     }
   );
 
@@ -189,7 +182,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       favorites: z.array(z.unknown()).describe('Favorites list'),
     },
     async ({ favorites }) => {
-      return jsonResponse(await client.put('/api/preferences/favorites', favorites));
+      return jsonResponse(await client.post('/api/preferences/favorites', favorites));
     }
   );
 
@@ -205,7 +198,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       groups: z.array(z.unknown()).describe('Favorite groups'),
     },
     async ({ groups }) => {
-      return jsonResponse(await client.put('/api/preferences/favorite-groups', groups));
+      return jsonResponse(await client.post('/api/preferences/favorite-groups', groups));
     }
   );
 
@@ -221,7 +214,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
       preferences: z.record(z.unknown()).describe('Grid preferences'),
     },
     async ({ preferences }) => {
-      return jsonResponse(await client.put('/api/preferences/grid', preferences));
+      return jsonResponse(await client.post('/api/preferences/grid', preferences));
     }
   );
 

--- a/src/tools/volumes.ts
+++ b/src/tools/volumes.ts
@@ -95,7 +95,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
       volumeName: z.string().describe('Volume name'),
     },
     async ({ environmentId, volumeName }) => {
-      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/export`, undefined, { env: environmentId }));
+      return jsonResponse(await client.get(`/api/volumes/${encodePath(volumeName)}/export`, { env: environmentId }));
     }
   );
 


### PR DESCRIPTION
## Summary

- Schema-Validierung (`validate-mcp-tools.mjs`) fand 21 MCP-Tools die nicht-existente API-Endpunkte referenzierten
- **15 Tools**: HTTP-Methode korrigiert (PUT→POST, POST→DELETE, POST→GET, GET→POST)
- **6 Tools**: Entfernt, da der referenzierte Endpunkt in der Dockhand API nicht existiert

### Methoden-Korrekturen (15 Tools)

| Tool | Vorher | Nachher |
|------|--------|---------|
| `set_container_auto_update` | PUT | POST |
| `delete_container_file` | POST | DELETE |
| `set_dashboard_preferences` | PUT | POST |
| `set_environment_timezone` | PUT | POST |
| `set_environment_update_check` | PUT | POST |
| `get_git_preview_env` | GET | POST |
| `export_image` | POST | GET |
| `update_general_settings` | PUT | POST |
| `update_scanner_settings` | PUT | POST |
| `get_batch_operations` | GET | POST |
| `set_user_roles` | PUT | POST |
| `set_favorites` | PUT | POST |
| `set_favorite_groups` | PUT | POST |
| `set_grid_preferences` | PUT | POST |
| `export_volume` | POST | GET |

### Entfernte Tools (6 Tools)

| Tool | Grund |
|------|-------|
| `get_image` | Kein `GET /api/images/{id}` in der API |
| `get_registry_image` | Kein `GET /api/registry/image` (nur DELETE) |
| `get_schedule` | Kein `GET /api/schedules/{type}/{id}` (nur DELETE) |
| `get_stack` | Kein `GET /api/stacks/{name}` (nur DELETE) |
| `update_theme_settings` | Kein PUT/POST für `/api/settings/theme` (nur GET) |
| `get_user_mfa_status` | Kein `GET /api/users/{id}/mfa` (nur DELETE/POST) |

## Test plan

- [x] `node scripts/validate-mcp-tools.mjs` → ORPHANED_TOOL: 0
- [x] `npm run typecheck` → OK
- [x] `npm test` → 176 Tests passed

Closes #27