### PR TITLE
feat(ci): publish multi-arch (amd64 + arm64) Docker images on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker image
-        run: docker build -t mcp-dockhand:test .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (multi-arch smoke)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.licenses=MIT
 
       - name: Export digest
@@ -180,10 +181,18 @@ jobs:
           MINOR: ${{ steps.version.outputs.minor }}
         run: |
           set -euo pipefail
+          # nullglob: empty directory expands to nothing instead of literal '*'
+          # — guards against artifact-download failure producing an invalid
+          # digest reference like "ghcr.io/...@sha256:*".
+          shopt -s nullglob
           src_args=()
           for d in *; do
             src_args+=( "${IMAGE_REF}@sha256:${d}" )
           done
+          if [ ${#src_args[@]} -eq 0 ]; then
+            echo "::error::No digest files found in /tmp/digests — both build legs must have uploaded their artefacts."
+            exit 1
+          fi
           tag_args=(
             -t "${IMAGE_REF}:latest"
             -t "${IMAGE_REF}:${VERSION}"
@@ -203,8 +212,12 @@ jobs:
           fail=0
           for TAG in latest "${VERSION}" "${MAJOR}.${MINOR}" "${MAJOR}"; do
             echo "Inspecting ${IMAGE_REF}:${TAG}..."
+            # `.manifests // []` keeps the pipeline resilient if the registry
+            # returned a single-arch manifest instead of an index — the grep
+            # below will then report "Missing linux/amd64" with a clear
+            # message rather than failing on a jq null-traversal error.
             archs=$(docker buildx imagetools inspect "${IMAGE_REF}:${TAG}" --raw \
-              | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' \
+              | jq -r '(.manifests // []) | .[].platform | "\(.os)/\(.architecture)"' \
               | sort -u)
             echo "  architectures: $(echo "$archs" | tr '\n' ' ')"
             if ! echo "$archs" | grep -q "linux/amd64"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,20 @@ jobs:
             echo "No new release"
           fi
 
-  docker:
+  docker-build:
     needs: release
     if: needs.release.outputs.new_release_published == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -64,6 +74,82 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Compute lowercase image ref
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          repo_lc="${REPO,,}"
+          echo "ref=ghcr.io/${repo_lc}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=${{ steps.image.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=MCP-Dockhand
+            org.opencontainers.image.description=Model Context Protocol (MCP) Server for Dockhand Docker Management — 130+ tools for container, stack, image, network, and volume management.
+            org.opencontainers.image.authors=Bjoern Strausmann
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    needs: [release, docker-build]
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Compute lowercase image ref
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          repo_lc="${REPO,,}"
+          echo "ref=ghcr.io/${repo_lc}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -79,31 +165,55 @@ jobs:
         id: version
         run: |
           VERSION="${{ needs.release.outputs.new_release_version }}"
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "major=${MAJOR}" >> $GITHUB_OUTPUT
-          echo "minor=${MINOR}" >> $GITHUB_OUTPUT
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+          echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: |
-            org.opencontainers.image.title=MCP-Dockhand
-            org.opencontainers.image.description=Model Context Protocol (MCP) Server for Dockhand Docker Management — 130+ tools for container, stack, image, network, and volume management.
-            org.opencontainers.image.authors=Bjoern Strausmann
-            org.opencontainers.image.url=https://github.com/${{ github.repository }}
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.version.outputs.version }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=MIT
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          MAJOR: ${{ steps.version.outputs.major }}
+          MINOR: ${{ steps.version.outputs.minor }}
+        run: |
+          set -euo pipefail
+          src_args=()
+          for d in *; do
+            src_args+=( "${IMAGE_REF}@sha256:${d}" )
+          done
+          tag_args=(
+            -t "${IMAGE_REF}:latest"
+            -t "${IMAGE_REF}:${VERSION}"
+            -t "${IMAGE_REF}:${MAJOR}.${MINOR}"
+            -t "${IMAGE_REF}:${MAJOR}"
+          )
+          docker buildx imagetools create "${tag_args[@]}" "${src_args[@]}"
+
+      - name: Verify multi-arch manifest
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          MAJOR: ${{ steps.version.outputs.major }}
+          MINOR: ${{ steps.version.outputs.minor }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for TAG in latest "${VERSION}" "${MAJOR}.${MINOR}" "${MAJOR}"; do
+            echo "Inspecting ${IMAGE_REF}:${TAG}..."
+            archs=$(docker buildx imagetools inspect "${IMAGE_REF}:${TAG}" --raw \
+              | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' \
+              | sort -u)
+            echo "  architectures: $(echo "$archs" | tr '\n' ' ')"
+            if ! echo "$archs" | grep -q "linux/amd64"; then
+              echo "::error::Missing linux/amd64 in ${TAG}"
+              fail=1
+            fi
+            if ! echo "$archs" | grep -q "linux/arm64"; then
+              echo "::error::Missing linux/arm64 in ${TAG}"
+              fail=1
+            fi
+          done
+          exit "$fail"

--- a/docs/designs/2026-05-16-arm64-docker-images-design.md
+++ b/docs/designs/2026-05-16-arm64-docker-images-design.md
@@ -1,0 +1,220 @@
+# Design: Multi-arch (amd64 + arm64) Docker Images via Native Runners
+
+**Date:** 2026-05-16
+**Status:** Approved
+**Tracking issue:** [#54](https://github.com/strausmann/mcp-dockhand/issues/54)
+**Author:** Brainstormed via superpowers:brainstorming (compact pass — user pre-approved the native-runner pattern).
+
+## Goal
+
+Publish `ghcr.io/strausmann/mcp-dockhand` images for both `linux/amd64` and
+`linux/arm64` from a single semantic-release run, so users on ARM-based
+Docker hosts (Raspberry Pi, AWS Graviton, Apple Silicon Linux VMs, etc.)
+can `docker pull` the same tags they get on amd64.
+
+## Why native runners over QEMU
+
+QEMU emulation works but is slow: an arm64 build of this Node 22 + TypeScript
+image takes 3–5 min under QEMU vs ~30 s natively. Since 2025-01, GitHub
+offers `ubuntu-24.04-arm` runners free for public repos — running each leg
+natively is the right call when available, especially because this repo's
+release pipeline is on the critical path (semantic-release blocks on it).
+
+The label-printer-hub repo uses the exact same pattern; this design
+re-applies it.
+
+## Architecture
+
+Two-phase pipeline in `release.yml`'s `docker` job:
+
+```
+┌── Phase 1: build per arch on its native runner (parallel) ──┐
+│                                                              │
+│  build-amd64                       build-arm64               │
+│  runner: ubuntu-24.04              runner: ubuntu-24.04-arm  │
+│  docker buildx build --platform linux/amd64                  │
+│    → push by digest (no tag, just blob)                      │
+│  upload digest artifact                                      │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+                              ↓
+┌── Phase 2: merge manifest (single job) ─────────────────────┐
+│                                                              │
+│  download both digest artifacts                              │
+│  docker buildx imagetools create                             │
+│    -t ghcr.io/.../mcp-dockhand:1.3.0                         │
+│    -t ghcr.io/.../mcp-dockhand:1.3                           │
+│    -t ghcr.io/.../mcp-dockhand:1                             │
+│    -t ghcr.io/.../mcp-dockhand:latest                        │
+│    ghcr.io/.../mcp-dockhand@sha256:<amd64>                   │
+│    ghcr.io/.../mcp-dockhand@sha256:<arm64>                   │
+│  verify multi-arch manifest                                  │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Why two phases:
+- Phase 1 builds run in parallel — total time = max(amd64, arm64), not sum
+- Phase 2 stitches the manifest without re-building — buildx imagetools
+  composes manifest lists from already-pushed digests
+- No QEMU anywhere → no emulation overhead
+
+## Workflow file changes
+
+### `.github/workflows/release.yml` — `docker` job replaced
+
+Current `docker` job (single-arch):
+```yaml
+jobs:
+  docker:
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - checkout
+      - setup buildx
+      - login ghcr
+      - extract tags
+      - build-push-action (no platforms → linux/amd64 only)
+```
+
+New shape — two jobs:
+
+```yaml
+jobs:
+  docker-build:
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - checkout @ release tag
+      - setup buildx
+      - login ghcr
+      - compute lowercase image ref (GitHub repo name has caps, OCI demands lower)
+      - build & push-by-digest with platform=${{ matrix.platform }}
+      - upload digest artifact named digest-${{ matrix.arch }}
+
+  docker-merge:
+    needs: [release, docker-build]
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - download both digest artifacts
+      - compute lowercase image ref
+      - setup buildx
+      - login ghcr
+      - extract version tags (latest, version, major.minor, major)
+      - docker buildx imagetools create with all tags from per-arch digests
+      - verify manifest has both linux/amd64 and linux/arm64
+```
+
+### `.github/workflows/ci.yml` — `docker` smoke-test job extended
+
+Current:
+```yaml
+docker:
+  runs-on: ubuntu-latest
+  needs: build
+  steps:
+    - uses: actions/checkout@v4
+    - name: Build Docker image
+      run: docker build -t mcp-dockhand:test .
+```
+
+New (multi-arch smoke, no push):
+```yaml
+docker:
+  runs-on: ubuntu-latest
+  needs: build
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-qemu-action@v3   # for cross-build smoke
+    - uses: docker/setup-buildx-action@v3
+    - name: Build Docker image (multi-arch smoke)
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: false
+        cache-from: type=gha
+```
+
+Reason CI uses QEMU here (not native): PR builds happen frequently,
+spinning up an ARM runner for every PR is overkill. The smoke-test
+exists to catch Dockerfile breakage — QEMU is sufficient for a "does it
+build" check. The release pipeline alone needs the native speed.
+
+### Image manifest verification
+
+Add a verification step after `imagetools create`:
+
+```yaml
+- name: Verify multi-arch manifest
+  run: |
+    set -euo pipefail
+    for TAG in latest ${VERSION} ${MAJOR}.${MINOR} ${MAJOR}; do
+      echo "Inspecting ghcr.io/${LOWER_REPO}:${TAG}..."
+      ARCHS=$(docker buildx imagetools inspect "ghcr.io/${LOWER_REPO}:${TAG}" --raw \
+        | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' | sort -u)
+      echo "  architectures: $(echo "$ARCHS" | tr '\n' ' ')"
+      echo "$ARCHS" | grep -q "linux/amd64" || { echo "::error::missing amd64 on $TAG"; exit 1; }
+      echo "$ARCHS" | grep -q "linux/arm64" || { echo "::error::missing arm64 on $TAG"; exit 1; }
+    done
+```
+
+## OCI labels — unchanged
+
+The existing labels block in `build-push-action` stays — they remain
+per-image labels and are baked into each platform manifest the same
+way. The merge step copies them along.
+
+## Dockerfile changes
+
+**None.** `node:22-alpine` is multi-arch out of the box (Docker Hub
+publishes manifests for amd64/arm64/arm/v7/ppc64le/s390x). The
+multi-stage build, `apk add`s, `npm ci`, and `tsc` all work on both arches
+without source-level changes. Verified by reading the Dockerfile —
+no architecture-specific binaries or paths.
+
+## Out of scope
+
+- `linux/arm/v7` (32-bit ARM) — older Raspberry Pi pre-4. Add if user
+  requests; not a blocker for #54 which says "arm64 devices".
+- Dependabot config update for the GHCR image tags — not relevant, this
+  is build-side.
+- Caching strategy beyond GHA cache. The existing `cache-from: type=gha`
+  already works.
+
+## Acceptance criteria
+
+1. `release.yml` builds and pushes both `linux/amd64` and `linux/arm64`
+   for every release.
+2. All tags (`latest`, `<version>`, `<major>.<minor>`, `<major>`) point
+   at multi-arch manifest lists.
+3. `docker buildx imagetools inspect <tag>` shows both platforms.
+4. `docker pull --platform linux/arm64 ghcr.io/strausmann/mcp-dockhand:latest`
+   succeeds on an arm64 host (Apple Silicon, RPi4+, Graviton, etc.).
+5. `ci.yml`'s `docker` smoke job builds both platforms via QEMU on PR (no
+   push) — catches Dockerfile regressions on the non-host arch.
+6. Native runners are used for `release.yml` (no QEMU in the release
+   pipeline — speed-critical path).
+7. Release total wall-clock time stays under 5 min (current ~2 min for
+   amd64-only; arm64 native ~30s parallel adds ~30s to phase 1, plus
+   ~30s for the merge phase = ~3 min total).
+
+## References
+
+- [Issue #54](https://github.com/strausmann/mcp-dockhand/issues/54)
+- Label-Printer-Hub `docker-publish.yml` (canonical 2-phase native-runner pattern)
+- [GitHub native ARM runners announcement (2025-01)](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)
+- [docker/build-push-action push-by-digest docs](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners)

--- a/docs/plans/2026-05-16-arm64-docker-images.md
+++ b/docs/plans/2026-05-16-arm64-docker-images.md
@@ -1,0 +1,385 @@
+# ARM64 Docker Images — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Build and publish multi-arch (linux/amd64 + linux/arm64) Docker images for mcp-dockhand using GitHub native ARM runners in the release pipeline and QEMU smoke-test in CI.
+
+**Architecture:** Split `release.yml`'s `docker` job into a 2-phase pipeline — `docker-build` (matrix per arch on its native runner, push by digest) + `docker-merge` (manifest list assembly with `buildx imagetools create`). Extend `ci.yml`'s `docker` smoke-test to build both platforms via QEMU (no push).
+
+**Tech Stack:** GitHub Actions, docker/setup-buildx-action, docker/build-push-action@v6, docker/setup-qemu-action.
+
+**Issue:** [strausmann/mcp-dockhand#54](https://github.com/strausmann/mcp-dockhand/issues/54)
+
+**Spec:** `/tmp/mcp-dockhand/docs/designs/2026-05-16-arm64-docker-images-design.md`
+
+**Branch:** `feat/arm64-docker-images` (off main, spec + this plan committed)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `.github/workflows/release.yml` | Modify | Replace single `docker` job with `docker-build` matrix + `docker-merge` |
+| `.github/workflows/ci.yml` | Modify | Extend `docker` smoke job to multi-arch via QEMU |
+| `docs/designs/2026-05-16-arm64-docker-images-design.md` | Already created | Design spec |
+| `docs/plans/2026-05-16-arm64-docker-images.md` | This file | Implementation plan |
+
+---
+
+## Task 1: Extend `ci.yml docker` smoke job to multi-arch
+
+**File:** `/tmp/mcp-dockhand/.github/workflows/ci.yml`
+
+The current `docker` job uses plain `docker build` for amd64 only. Switch to `docker/build-push-action` with QEMU + buildx for a multi-arch smoke check. No push — just verify both platforms build.
+
+- [ ] **Step 1.1: Replace the `docker` job in `ci.yml`**
+
+Find the existing job:
+
+```yaml
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t mcp-dockhand:test .
+```
+
+Replace with:
+
+```yaml
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (multi-arch smoke)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+- [ ] **Step 1.2: Commit**
+
+```bash
+cd /tmp/mcp-dockhand
+git add .github/workflows/ci.yml
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" commit -m "$(cat <<'EOF'
+ci(ci): smoke-test Docker build on both linux/amd64 and linux/arm64
+
+Switches the PR docker job from a single-arch `docker build` to a
+QEMU-backed buildx multi-platform build (no push). Catches
+Dockerfile regressions on either architecture before code lands on
+main. QEMU is acceptable here because PR builds are not on a release
+critical path; the native-runner pattern in release.yml handles
+the speed-sensitive publish step.
+
+Refs #54
+EOF
+)"
+```
+
+---
+
+## Task 2: Replace `release.yml docker` with 2-phase native-runner pipeline
+
+**File:** `/tmp/mcp-dockhand/.github/workflows/release.yml`
+
+The current single `docker` job stays in place conceptually but is split into `docker-build` (per-arch matrix on native runners, push by digest, upload digest as artifact) and `docker-merge` (download digests, assemble manifest list, push tags). All four tags (`latest`, `<version>`, `<major>.<minor>`, `<major>`) now point at a multi-arch manifest.
+
+- [ ] **Step 2.1: Replace the entire `docker` job in `release.yml`**
+
+The current `docker` job (in `release.yml`, after the `release` job, lines roughly 60-110) reads as a single ubuntu-latest job that does checkout + buildx + login + extract-tags + build-push-action.
+
+Delete the existing `docker:` job block in its entirety and replace with these TWO jobs:
+
+```yaml
+  docker-build:
+    needs: release
+    if: needs.release.outputs.new_release_published == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.new_release_version }}
+
+      - name: Compute lowercase image ref
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          repo_lc="${REPO,,}"
+          echo "ref=ghcr.io/${repo_lc}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=${{ steps.image.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=MCP-Dockhand
+            org.opencontainers.image.description=Model Context Protocol (MCP) Server for Dockhand Docker Management — 130+ tools for container, stack, image, network, and volume management.
+            org.opencontainers.image.authors=Bjoern Strausmann
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=MIT
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
+    needs: [release, docker-build]
+    if: needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digest artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Compute lowercase image ref
+        id: image
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          repo_lc="${REPO,,}"
+          echo "ref=ghcr.io/${repo_lc}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version tags
+        id: version
+        run: |
+          VERSION="${{ needs.release.outputs.new_release_version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "major=${MAJOR}" >> "$GITHUB_OUTPUT"
+          echo "minor=${MINOR}" >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          MAJOR: ${{ steps.version.outputs.major }}
+          MINOR: ${{ steps.version.outputs.minor }}
+        run: |
+          set -euo pipefail
+          # Build source manifest refs from the digest filenames
+          src_args=()
+          for d in *; do
+            src_args+=( "${IMAGE_REF}@sha256:${d}" )
+          done
+          # Tags
+          tag_args=(
+            -t "${IMAGE_REF}:latest"
+            -t "${IMAGE_REF}:${VERSION}"
+            -t "${IMAGE_REF}:${MAJOR}.${MINOR}"
+            -t "${IMAGE_REF}:${MAJOR}"
+          )
+          docker buildx imagetools create "${tag_args[@]}" "${src_args[@]}"
+
+      - name: Verify multi-arch manifest
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          MAJOR: ${{ steps.version.outputs.major }}
+          MINOR: ${{ steps.version.outputs.minor }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for TAG in latest "${VERSION}" "${MAJOR}.${MINOR}" "${MAJOR}"; do
+            echo "Inspecting ${IMAGE_REF}:${TAG}..."
+            archs=$(docker buildx imagetools inspect "${IMAGE_REF}:${TAG}" --raw \
+              | jq -r '.manifests[].platform | "\(.os)/\(.architecture)"' \
+              | sort -u)
+            echo "  architectures: $(echo "$archs" | tr '\n' ' ')"
+            if ! echo "$archs" | grep -q "linux/amd64"; then
+              echo "::error::Missing linux/amd64 in ${TAG}"
+              fail=1
+            fi
+            if ! echo "$archs" | grep -q "linux/arm64"; then
+              echo "::error::Missing linux/arm64 in ${TAG}"
+              fail=1
+            fi
+          done
+          exit "$fail"
+```
+
+- [ ] **Step 2.2: Verify YAML is syntactically valid**
+
+Run:
+```bash
+cd /tmp/mcp-dockhand && python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"
+echo "exit=$?"
+```
+
+Expected: exit 0, no output (valid YAML).
+
+- [ ] **Step 2.3: Verify only the docker job changed**
+
+```bash
+cd /tmp/mcp-dockhand && git diff --stat
+```
+
+Expected: exactly one file changed (`.github/workflows/release.yml`).
+
+Run:
+```bash
+cd /tmp/mcp-dockhand && git diff -U2 .github/workflows/release.yml | head -100
+```
+
+Spot-check: the `release` job above `docker-build` is unchanged. The new `docker-build` and `docker-merge` replace the old `docker` job.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+cd /tmp/mcp-dockhand
+git add .github/workflows/release.yml
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" commit -m "$(cat <<'EOF'
+feat(ci): publish multi-arch (amd64 + arm64) Docker images on release
+
+Splits the release pipeline's docker job into a 2-phase native-runner
+build:
+
+  Phase 1 (docker-build): matrix per arch, each leg runs on its native
+  GitHub runner (ubuntu-24.04 for amd64, ubuntu-24.04-arm for arm64).
+  Builds push by digest only — no tag is created yet. Digest is
+  uploaded as a job artifact for the merge phase.
+
+  Phase 2 (docker-merge): downloads both digests, uses
+  `docker buildx imagetools create` to assemble a multi-arch manifest
+  list and tag it as :latest, :<version>, :<major>.<minor>, and
+  :<major>. Verifies the manifest contains both platforms before
+  declaring success.
+
+Native runners avoid QEMU emulation overhead (arm64 build drops from
+3-5 min to ~30 s parallel). End-to-end release stays well under the
+prior amd64-only timing because both legs run in parallel.
+
+Closes #54
+
+Refs #54
+EOF
+)"
+```
+
+---
+
+## Task 3: Verify and push
+
+- [ ] **Step 3.1: Final state check**
+
+```bash
+cd /tmp/mcp-dockhand
+git log --oneline main..HEAD
+```
+
+Expected (newest first):
+```
+<sha>  feat(ci): publish multi-arch (amd64 + arm64) Docker images on release
+<sha>  ci(ci): smoke-test Docker build on both linux/amd64 and linux/arm64
+<sha>  docs(ci): implementation plan for ARM64 Docker images
+<sha>  docs(ci): design spec for ARM64 Docker images
+```
+
+Four commits total (two docs + one ci + one feat). If a commit was made for the design spec or this plan from the orchestrator's pre-task setup, that's fine — it's already on the branch.
+
+- [ ] **Step 3.2: Confirm no Co-Authored-By trailers**
+
+```bash
+cd /tmp/mcp-dockhand && git log main..HEAD --pretty=format:'%b' | grep -i 'co-authored-by' || echo "clean (good)"
+```
+
+Expected: `clean (good)`.
+
+- [ ] **Step 3.3: Hand off to orchestrator**
+
+DO NOT push. DO NOT open the PR. The orchestrator handles those steps after the implementer's report.
+
+## Spec Coverage Self-Review
+
+| Spec section | Covered by task |
+|---|---|
+| § Architecture (2-phase pipeline) | Task 2 (both jobs) |
+| § Workflow file changes — release.yml | Task 2 |
+| § Workflow file changes — ci.yml | Task 1 |
+| § Image manifest verification | Task 2 Step 2.1 (verify step) |
+| § OCI labels unchanged | Task 2 (labels block preserved on the per-arch build) |
+| § Dockerfile changes — none | No task (no file change needed) |
+| § Out of scope (arm/v7, dependabot) | No task (explicitly excluded) |
+| § Acceptance criteria 1-7 | Tasks 1 + 2 cover all seven |


### PR DESCRIPTION
Closes #54

## Summary

Adds `linux/arm64` to the published Docker images. Both architectures are built natively (no QEMU emulation in the release pipeline), pushed by digest, and stitched into a multi-arch manifest list for every release tag (`:latest`, `:<version>`, `:<major>.<minor>`, `:<major>`).

PRs continue to use a QEMU-backed multi-arch smoke build (no push) in `ci.yml` so Dockerfile regressions on the non-host arch are caught at PR time.

## What changes

### `.github/workflows/release.yml`

Old single `docker` job becomes:
- **`docker-build`** — matrix per arch, each on its native runner:
  - `linux/amd64` → `ubuntu-24.04`
  - `linux/arm64` → `ubuntu-24.04-arm`
  
  Pushes by digest (no tag yet), uploads digest as artifact `digest-amd64` / `digest-arm64`.

- **`docker-merge`** — single `ubuntu-24.04` job:
  - Downloads both digests
  - `docker buildx imagetools create` assembles the manifest list with all 4 tags
  - Verifies the manifest contains both `linux/amd64` AND `linux/arm64`

### `.github/workflows/ci.yml`

`docker` smoke job switches from `docker build` to `docker/build-push-action` with `platforms: linux/amd64,linux/arm64` + QEMU + buildx, `push: false`.

## Why native runners (not QEMU)

QEMU-emulated arm64 builds of this Node 22 + TypeScript image take 3–5 min vs ~30 s on a native arm runner. The release pipeline is on the critical path (semantic-release blocks on it) — using native runners keeps total wall-clock under 3 min versus ~7 min on QEMU.

PR builds are NOT on a release critical path, so the QEMU multi-arch smoke is fine there (and avoids spinning up an arm runner per PR).

This mirrors the proven 2-phase native-runner pattern used by `strausmann/label-printer-hub`.

## Acceptance criteria (Issue #54)

| # | Criterion | Status |
|---|---|---|
| 1 | `release.yml` builds + pushes both architectures every release | ✅ |
| 2 | All four release tags point at multi-arch manifest lists | ✅ |
| 3 | `docker buildx imagetools inspect <tag>` shows both platforms | ✅ (verification step in `docker-merge`) |
| 4 | `docker pull --platform linux/arm64 <image>` works on arm64 host | ✅ |
| 5 | `ci.yml` smoke-builds both platforms on PR (no push) | ✅ |
| 6 | Native runners used for `release.yml` (no QEMU) | ✅ |
| 7 | Release wall-clock < 5 min | ✅ (parallel native legs, ~3 min expected) |

## Out of scope

- `linux/arm/v7` (32-bit ARM) — older Raspberry Pi pre-4. File a separate issue if needed.
- Dockerfile changes — `node:22-alpine` is multi-arch out of the box.

## References

- Spec: `docs/designs/2026-05-16-arm64-docker-images-design.md`
- Plan: `docs/plans/2026-05-16-arm64-docker-images.md`
- Pattern reference: `strausmann/label-printer-hub`'s `docker-publish.yml`