### PR TITLE
feat(ci): auto-update sticky coverage tracker on every schema sync

### DIFF
--- a/.github/workflows/api-schema-sync.yml
+++ b/.github/workflows/api-schema-sync.yml
@@ -50,6 +50,67 @@ jobs:
         run: node scripts/validate-mcp-tools.mjs
         continue-on-error: true
 
+      - name: Update sticky coverage tracker
+        if: always() && hashFiles('validation-report.md') != ''
+        uses: actions/github-script@v8
+        env:
+          REPORT_PATH: validation-report.md
+          MARKER_START: '<!-- validator-report:start -->'
+          MARKER_END: '<!-- validator-report:end -->'
+        with:
+          script: |
+            const fs = require('fs');
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'coverage-tracker',
+              state: 'open',
+              per_page: 5,
+            });
+
+            if (issues.data.length === 0) {
+              core.warning('No open issue with label "coverage-tracker" found — skipping sticky update.');
+              return;
+            }
+            if (issues.data.length > 1) {
+              const nums = issues.data.map(i => `#${i.number}`).join(', ');
+              core.warning(`Multiple issues carry label "coverage-tracker" (${nums}). Skipping update to avoid clobbering.`);
+              return;
+            }
+
+            const issue = issues.data[0];
+            const body = issue.body || '';
+            const startMarker = process.env.MARKER_START;
+            const endMarker = process.env.MARKER_END;
+            const pattern = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`);
+
+            if (!pattern.test(body)) {
+              core.warning(`Issue #${issue.number} has no validator-report markers — skipping update.`);
+              return;
+            }
+
+            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+            const today = new Date().toISOString().split('T')[0];
+            const runLink = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const stamp = `> _Last sync: ${today} — [run log](${runLink})_\n\n`;
+            const replacement = `${startMarker}\n${stamp}${report}\n${endMarker}`;
+            const newBody = body.replace(pattern, replacement);
+
+            if (newBody === body) {
+              core.info(`Issue #${issue.number} already up to date — no change.`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: newBody,
+            });
+
+            core.info(`Updated sticky coverage tracker issue #${issue.number}`);
+
       - name: Create issue on validation failure
         if: steps.validate.outcome == 'failure'
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary

Extend `api-schema-sync.yml` with a new step that auto-updates a single sticky tracking issue (label `coverage-tracker`, currently #60) after every validator run. The step rewrites only the content between `<!-- validator-report:start -->` and `<!-- validator-report:end -->` markers in the issue body — manual notes around the markers are preserved.

## Why

The validator already produces `validation-report.md` listing every endpoint without an MCP tool, but those gaps exit 0 (informational). The existing `Create issue on validation failure` step only fires for hard schema mismatches (ORPHANED_TOOL / PARAM_MISMATCH / MISSING_ENCODE), so long-standing coverage gaps stayed buried inside the workflow artifact. After this change, the gap count and per-endpoint list are visible on the issue tracker and refreshed daily.

## How

- Single new `Update sticky coverage tracker` step, placed between `Validate MCP tools against schema` and the existing `Create issue on validation failure`.
- Independent from validator exit code (`if: always() && hashFiles('validation-report.md') != ''`).
- Looks up issues by `coverage-tracker` label, expects exactly one open match.
- Replaces marker block via single regex pass; idempotent if nothing changed.

## Safety properties

| Condition | Behaviour |
|-----------|-----------|
| No issue with `coverage-tracker` label | `core.warning`, no failure |
| Multiple matching issues | `core.warning`, no update (prevents clobbering) |
| Issue body missing markers | `core.warning`, no update (preserves any manual layout) |
| Report unchanged since last run | No API call (body comparison short-circuits) |

## Test plan

- [x] YAML syntax validated locally (`python3 -c 'yaml.safe_load(...)'`)
- [ ] After merge: trigger `workflow_dispatch` and confirm #60 body refreshes between markers
- [ ] Confirm `core.warning` paths surface in workflow logs when label/markers are missing

## Refs

Refs #60