### PR TITLE
feat(tools): audit and expand all 222 MCP tool descriptions for AI disambiguation

### DIFF
--- a/docs/designs/2026-05-16-tool-description-audit-design.md
+++ b/docs/designs/2026-05-16-tool-description-audit-design.md
@@ -7,7 +7,7 @@
 
 ## Problem
 
-223 MCP tools are exposed through `src/tools/*.ts`. Each registration carries a `description` string that an AI client reads to decide *whether* and *which* tool to invoke. The current corpus has three recurring quality issues:
+222 MCP tools are exposed through `src/tools/*.ts`. Each registration carries a `description` string that an AI client reads to decide *whether* and *which* tool to invoke. The current corpus has three recurring quality issues:
 
 1. **Too terse to disambiguate.** Examples on `main`:
    - `get_stack_env` — `"Read environment variables of a stack"` (38 chars)
@@ -43,12 +43,12 @@ The description opens with a verb that names the operation and the noun it acts 
 
 | Bad | Good |
 |-----|------|
-| `Stack-Down-Operation auf einem Stack` | `Tear down a stack (stops containers, removes them, and removes the project networks — volumes persist).` |
-| `Remove an image` | `Delete an image from the environment. Fails if any container references the image; pass `force:true` to override.` |
+| `Stack-Down-Operation auf einem Stack` | Tear down a stack (stops containers, removes them, and removes the project networks — volumes persist). |
+| `Remove an image` | Delete an image from the environment. Fails if any container references the image; pass `force:true` to override. |
 
 ### C2 — Cross-reference inside cluster
 
-If a tool belongs to a cluster (see §Tool clusters below), its description names at least one sibling tool *by name in backticks* with a `"For X use `<sibling>`."` phrase. The two siblings reference each other, three+ siblings reference at least one other.
+If a tool belongs to a cluster (see §Tool clusters below), its description names at least one sibling tool *by name in backticks* with a "For X use `<sibling>`." phrase. The two siblings reference each other, three+ siblings reference at least one other.
 
 Example anchor (already on `main`, PR #58):
 
@@ -138,7 +138,7 @@ function extractAllTools(): ToolMeta[] {
 1. **Length floor (C4):** every `description.length >= 60`.
 2. **Destructive verb:** for every tool whose name matches `/^(delete_|remove_|prune_|down_|stop_|revoke_|disable_|disconnect_)/`, description contains `\b(delete|remove|prune|destroy|stop|tear down|drop|revoke|disable|disconnect)\b` case-insensitive.
 3. **Ends with sentence:** description ends with `.`, `?`, `!`, or `)` (last grapheme).
-4. **Per-cluster cross-refs:** for each cluster in `CLUSTERS` (table above, mirrored as a `const CLUSTERS: Record<string, string[]>` in the test file), every member's description contains at least one sibling member name verbatim in backticks (`` `sibling_name` ``).
+4. **Per-cluster cross-refs:** for each cluster defined in the test file's `const CLUSTERS: Record<string, string[]>`, every member's description contains at least one sibling member name verbatim in backticks (`` `sibling_name` ``). The §Tool clusters table in this design doc is the historical proposal; the test file is the authoritative source and may diverge as cluster boundaries get refined during implementation.
 
 Tests are intentionally strict on the cross-reference format. The backtick requirement guarantees AI clients see the sibling as a code-style identifier rather than free text.
 
@@ -186,7 +186,7 @@ Spec-compliance reviewer and code-quality reviewer dispatch after each implement
 
 ## Acceptance criteria
 
-1. All 223 tools meet C1–C4 (verified by `tests/tool-descriptions.test.ts`).
+1. All 222 tools meet C1–C4 (verified by `tests/tool-descriptions.test.ts`).
 2. `npm test`, `npm run typecheck`, `npm run lint` pass on the branch.
 3. `node scripts/validate-mcp-tools.mjs` continues to pass with the same MISSING_TOOL / ORPHANED_TOOL / PARAM_MISMATCH / MISSING_ENCODE counts as `main`.
 4. PR description summarises changes by cluster.

--- a/docs/designs/2026-05-16-tool-description-audit-design.md
+++ b/docs/designs/2026-05-16-tool-description-audit-design.md
@@ -1,0 +1,199 @@
+# Tool Description Audit — Design
+
+**Date:** 2026-05-16
+**Status:** Approved
+**Owner:** repo maintainer
+**Implementation branch:** `feat/tool-description-audit`
+
+## Problem
+
+223 MCP tools are exposed through `src/tools/*.ts`. Each registration carries a `description` string that an AI client reads to decide *whether* and *which* tool to invoke. The current corpus has three recurring quality issues:
+
+1. **Too terse to disambiguate.** Examples on `main`:
+   - `get_stack_env` — `"Read environment variables of a stack"` (38 chars)
+   - `get_stack_env_raw` — `"Read the raw .env file of a stack"` (35 chars)
+
+   Both look like the same thing. An AI asked "lies die Env-Variablen vom Stack" picks the first; an AI asked "zeig mir die .env-Datei" picks the second. The user-facing distinction (DB-backed variables-list vs. on-disk file content) is invisible.
+
+2. **No cross-references between siblings.** `update_stack_env` and `update_stack_env_raw` (PR #58) cross-link with `"For X use `<other_tool>`."`. That pattern is missing from the other 219 tools, including the symmetrical *get* pair right next to them.
+
+3. **Destructive operations not labelled.** `down_stack`, `remove_image`, `prune_all`, `delete_*` use polite words like "Remove" or "Pull down" without flagging that they discard state.
+
+The result is a quality floor set by individual tool authors, with PR #58 being the only point in the corpus that demonstrates the better pattern. This audit lifts every tool to that pattern.
+
+## Goals
+
+- Every tool description supports three AI decisions: **what** it does, **when** to use it vs. sibling tools, and **what side-effects** it has.
+- The audit completes in a single PR (~1.5.0 minor bump via semantic-release).
+- New regression tests prevent the next contributor from re-introducing the gap.
+
+## Non-goals
+
+- No new tools, no removed tools, no parameter renames. The validator-driven coverage gap (44 endpoints, Issue #60) is tracked separately.
+- No translation, no internationalisation. Descriptions stay English (matches repo language post commit `9c7f396`).
+- No UI labels, no README copy. This is `src/tools/*.ts` only.
+
+## Quality criteria
+
+Every description on `main` after this PR meets all four:
+
+### C1 — Action-verb first sentence
+
+The description opens with a verb that names the operation and the noun it acts on. Destructive operations use destructive verbs explicitly.
+
+| Bad | Good |
+|-----|------|
+| `Stack-Down-Operation auf einem Stack` | `Tear down a stack (stops containers, removes them, and removes the project networks — volumes persist).` |
+| `Remove an image` | `Delete an image from the environment. Fails if any container references the image; pass `force:true` to override.` |
+
+### C2 — Cross-reference inside cluster
+
+If a tool belongs to a cluster (see §Tool clusters below), its description names at least one sibling tool *by name in backticks* with a `"For X use `<sibling>`."` phrase. The two siblings reference each other, three+ siblings reference at least one other.
+
+Example anchor (already on `main`, PR #58):
+
+> `update_stack_env`: "...For non-secret variables that Docker Compose reads from the .env file at container start, use `update_stack_env_raw`."
+
+### C3 — Scope marker for ambiguous tools
+
+Where two tools could plausibly answer the same prompt, the description names the distinguishing axis. Common axes:
+
+- **Storage backend:** DB-backed (encrypted, `isSecret`) vs. on-disk (`.env` file)
+- **Batch vs. single:** `batch_update_containers` vs. `update_container`
+- **Stream vs. sync:** `deploy_git_stack` vs. `deploy_git_stack_stream` (if present)
+- **Scope:** per-stack vs. per-environment vs. global
+- **Lifecycle phase:** pre-deploy (validate, scan) vs. deploy vs. post-deploy
+
+### C4 — Length floor
+
+Every description ≥ 60 characters. This is a coarse proxy for "carries enough information to be useful". Tools that genuinely have nothing more to say (e.g., `health_check`) still pass 60 chars after honestly describing their semantics ("Probe the MCP server's HTTP health endpoint; returns `{status,server,version}`. Use for liveness checks; does not test the Dockhand backend connection.").
+
+## Tool clusters
+
+A *cluster* is a set of tools where C2 (cross-references) applies. Tools not listed below are *standalone* — C1, C3, C4 still apply, but C2 does not.
+
+| Cluster | Members | File(s) |
+|---------|---------|---------|
+| **Stack-Env** | get_stack_env, get_stack_env_raw, update_stack_env, update_stack_env_raw | stacks.ts |
+| **Stack-Compose** | get_stack_compose, update_stack_compose | stacks.ts |
+| **Stack-Lifecycle** | start_stack, stop_stack, restart_stack, down_stack | stacks.ts |
+| **Stack-Path** | get_stack_base_path, get_stack_default_path, get_stack_path_hints, check_stack_path_change, validate_stack_path, relocate_stack | stacks.ts |
+| **Stack-Source** | get_stack_sources, list_stacks, scan_stacks, adopt_stack | stacks.ts |
+| **Container-Lifecycle** | start_container, stop_container, restart_container, pause_container, unpause_container, rename_container, update_container, batch_update_containers | containers.ts |
+| **Container-Inspect** | get_container, inspect_container, get_container_logs, get_container_stats, get_container_top, get_container_sizes, get_container_activity, get_container_shells, get_container_auto_update | containers.ts |
+| **Container-Files** | list_container_files, get_container_file_content, create_container_file, delete_container_file, rename_container_file, chmod_container_file, download_container_file, upload_container_file | containers.ts |
+| **Prune-Family** | prune_all, prune_containers, prune_images, prune_volumes, prune_networks | system.ts |
+| **Image-Lifecycle** | pull_image, push_image, tag_image, remove_image, list_images, get_image_history, scan_image, export_image | images.ts |
+| **Volume-Lifecycle** | browse_volume, clone_volume, export_volume, get_volume, inspect_volume, list_volumes, remove_volume, get_volume_file_content, release_volume_browse | volumes.ts |
+| **Network-Lifecycle** | create_network, get_network, inspect_network, list_networks, remove_network, connect_container_to_network, disconnect_container_from_network | networks.ts |
+| **Git-Repository** | create_git_repository, get_git_repository, list_git_repositories, deploy_git_repository, test_git_repository, test_git_repository_connection, sync_git_repository | git-stacks.ts |
+| **Git-Stack** | list_git_stacks, get_git_stack, deploy_git_stack, test_git_stack, sync_git_stack, get_git_stack_env_files, get_git_webhook, trigger_git_webhook, request_git_preview_env | git-stacks.ts |
+| **Git-Credentials** | create_git_credential, get_git_credential, list_git_credentials, delete_git_credential, update_git_credential | git-stacks.ts |
+| **Auth-LDAP** | create_ldap_provider, get_ldap_provider, test_ldap_provider | auth.ts |
+| **Auth-OIDC** | create_oidc_provider, get_oidc_provider, test_oidc_provider, initiate_oidc_login, get_auth_providers, get_auth_session, get_auth_settings | auth.ts |
+| **Hawser-Tokens** | create_hawser_token, list_hawser_tokens, revoke_hawser_token | auth.ts |
+| **Users** | create_user, delete_user, get_user, list_users, update_user, enable_user_mfa, disable_user_mfa, get_user_roles, set_user_roles | users.ts |
+| **Roles** | create_role, delete_role, get_role, list_roles, update_role | users.ts |
+| **Notifications** | create_notification, get_notification, list_notifications, delete_notification, update_notification, test_notification, test_notification_config, trigger_test_notification | notifications.ts |
+| **Env-Notifications** | create_environment_notification, get_environment_notification, list_environment_notifications, delete_environment_notification | environments.ts |
+| **Schedules** | list_schedules, get_schedule_execution, get_schedule_executions, run_schedule_now, toggle_schedule, toggle_system_schedule, get_schedule_settings, update_schedule_settings | schedules.ts |
+| **Registries** | create_registry, delete_registry, get_registry, list_registries, update_registry, search_registry, get_registry_catalog, get_registry_tags, set_default_registry | registries.ts |
+| **Audit** | get_audit_events, get_audit_log, get_audit_users, export_audit_log | audit.ts |
+| **Activity** | get_activity_feed, get_activity_events, get_activity_stats, get_container_activity | dashboard.ts + containers.ts |
+| **Dashboard-Prefs** | get_dashboard_preferences, set_dashboard_preferences, get_grid_preferences, set_grid_preferences, get_favorites, set_favorites, get_favorite_groups, set_favorite_groups | dashboard.ts |
+| **Profile** | get_profile, update_profile, get_profile_preferences, update_profile_preferences | users.ts |
+| **Environments** | create_environment, delete_environment, get_environment, list_environments, update_environment, test_environment, test_environment_connection, detect_docker_socket | environments.ts |
+| **System-Files** | list_system_files, get_system_file_content | system.ts |
+| **System-Info** | get_system_info, get_system_disk, get_host_info, get_general_settings, update_general_settings | system.ts |
+| **Health** | health_check, health_check_database | system.ts |
+| **Auto-Update** | get_container_auto_update, set_container_auto_update, get_auto_update_settings | auto-update.ts |
+| **Scanner-Settings** | get_scanner_settings, update_scanner_settings | system.ts |
+| **License** | get_license, activate_license, get_legal_license | system.ts |
+| **Config-Sets** | create_config_set, delete_config_set, get_config_set, list_config_sets, update_config_set | system.ts |
+
+Tools not in any cluster (~30): mostly standalone informational (`get_changelog`, `get_privacy_policy`, `get_dependencies`, `get_pending_updates`, `get_prometheus_metrics`, `logout`, etc.).
+
+## Test strategy
+
+Add `tests/tool-descriptions.test.ts` to the existing static-analysis test suite. Pattern matches the existing files (`tool-registration.test.ts`, `stack-env-tools.test.ts`): read source, extract, assert text properties.
+
+### Extractor
+
+```typescript
+interface ToolMeta {
+  name: string;
+  description: string;
+  file: string;
+}
+
+function extractAllTools(): ToolMeta[] {
+  // Reads every src/tools/*.ts (except index.ts)
+  // Matches registerTool(server, 'name', 'description', ...) including multi-line
+  // Returns flat array
+}
+```
+
+### Assertions
+
+1. **Length floor (C4):** every `description.length >= 60`.
+2. **Destructive verb:** for every tool whose name matches `/^(delete_|remove_|prune_|down_|stop_|revoke_|disable_|disconnect_)/`, description contains `\b(delete|remove|prune|destroy|stop|tear down|drop|revoke|disable|disconnect)\b` case-insensitive.
+3. **Ends with sentence:** description ends with `.`, `?`, `!`, or `)` (last grapheme).
+4. **Per-cluster cross-refs:** for each cluster in `CLUSTERS` (table above, mirrored as a `const CLUSTERS: Record<string, string[]>` in the test file), every member's description contains at least one sibling member name verbatim in backticks (`` `sibling_name` ``).
+
+Tests are intentionally strict on the cross-reference format. The backtick requirement guarantees AI clients see the sibling as a code-style identifier rather than free text.
+
+### TDD cycle
+
+Per file in `src/tools/`:
+
+1. Author the cluster-cross-ref test cases first → run vitest → confirm RED.
+2. Edit the descriptions in that file → run vitest → confirm GREEN.
+3. Run `npm run typecheck` and `npm run lint` → confirm clean.
+4. Commit (test + impl together).
+
+Generic assertions (length, destructive verb, sentence end) are written once at the start. They will go RED across many files at once and stay RED until the last file lands — that is acceptable for an audit; the cluster tests provide per-file checkpoints.
+
+## Execution plan
+
+- Branch: `feat/tool-description-audit` off `main` (already created).
+- Commit shape: one commit per file in `src/tools/` (16 commits), plus one for the test scaffolding, plus one for `validate-mcp-tools.mjs` (if any cross-ref check is added there — see below). Estimated 17–19 commits.
+- Per-commit subject scope: `tools` for description-only changes, `tests` for the new test file.
+- Final commit: optional CHANGELOG entry only if semantic-release doesn't generate one. semantic-release will see `feat(tools): ...` commits and bump minor.
+- Single PR against `main`. AI reviewers (Copilot, Gemini) run automatically.
+
+### Subagent strategy
+
+One implementer subagent per file in `src/tools/`. Each subagent:
+
+- Reads this spec and the eventual plan.
+- Reads its assigned file plus the cluster definitions.
+- Writes the cluster test (if not already present), confirms RED.
+- Updates descriptions in the file.
+- Runs targeted vitest, typecheck, lint.
+- Commits with `feat(tools)` and `Refs <issue>`.
+
+Spec-compliance reviewer and code-quality reviewer dispatch after each implementer. Final whole-PR code-review subagent at the end.
+
+## Validator integration (optional follow-up)
+
+`scripts/validate-mcp-tools.mjs` could be extended with a `DESCRIPTION_QUALITY` category that flags new tools failing C1–C4. **Out of scope for this PR** — left as a follow-up issue.
+
+## Risk and rollback
+
+- **Risk:** AI behaviour changes after merge. A tool whose description got more specific may now be selected in different prompts. Mitigation: we tightened *toward* the obvious intent of each tool, not away from it. The container-update worked-around `rawContent` case (PR #58) is the existence proof that vague descriptions misroute callers; the opposite — over-specific descriptions misrouting callers — is much rarer because AI clients fuzzy-match.
+- **Rollback:** `git revert <merge-commit>` undoes the entire audit in one click. Tests stay green on the revert because they are written against the post-audit state — but the cluster cross-ref tests will fail on `main` again, which is the same state as today (no tests exist yet).
+- **Coverage gap (Issue #60):** unaffected. Description audit and missing-tool audit are orthogonal.
+
+## Acceptance criteria
+
+1. All 223 tools meet C1–C4 (verified by `tests/tool-descriptions.test.ts`).
+2. `npm test`, `npm run typecheck`, `npm run lint` pass on the branch.
+3. `node scripts/validate-mcp-tools.mjs` continues to pass with the same MISSING_TOOL / ORPHANED_TOOL / PARAM_MISMATCH / MISSING_ENCODE counts as `main`.
+4. PR description summarises changes by cluster.
+5. Squash-merged or rebase-merged into `main` — semantic-release bumps to 1.5.0 (or higher if other feat commits land first).
+
+## References
+
+- PR #58 (the quality bar): https://github.com/strausmann/mcp-dockhand/pull/58
+- Issue #60 (coverage tracker): https://github.com/strausmann/mcp-dockhand/issues/60
+- PR #61 (sticky tracker workflow): https://github.com/strausmann/mcp-dockhand/pull/61

--- a/docs/plans/2026-05-16-tool-description-audit.md
+++ b/docs/plans/2026-05-16-tool-description-audit.md
@@ -1,0 +1,1128 @@
+# Tool Description Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise every MCP tool description in `src/tools/*.ts` to the quality bar of PR #58 so AI clients can disambiguate sibling tools.
+
+**Architecture:** Test-first audit. A new `tests/tool-descriptions.test.ts` codifies the four quality criteria (C1–C4) from the design spec. Description rewrites land per-file; tests for each file's clusters are added in the same commit as the description rewrites. Generic assertions (length ≥60, destructive verb, sentence end) stay RED until the last file ships — that is acceptable for a single-PR audit.
+
+**Tech Stack:** TypeScript strict, Vitest, Node 22. No runtime mocks — every assertion is static analysis over the source files.
+
+**Spec:** `docs/designs/2026-05-16-tool-description-audit-design.md` (commit `ab03bb2`).
+**Tracking issue:** strausmann/mcp-dockhand#62. Every commit body MUST end with `Refs #62`.
+**Branch:** `feat/tool-description-audit` (already pushed to origin).
+
+---
+
+## Conventions for every commit
+
+- Conventional Commits scope is one of: `tools` (description updates per file), `tests` (test scaffolding), `docs` (spec/plan).
+- header-max-length 100; scope-empty=never; subject-empty=never.
+- `git commit` is run with `-c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com"`.
+- **No** `Co-Authored-By: Claude` anywhere.
+- Husky pre-commit and commit-msg hooks are active — commits will fail fast if any rule breaks.
+- Subagents do NOT push. The orchestrator pushes after final code review.
+
+---
+
+## File structure
+
+**Created:**
+- `tests/tool-descriptions.test.ts` — the audit's enforcement mechanism.
+
+**Modified:**
+- `src/tools/audit.ts` (4 tools)
+- `src/tools/auth.ts` (14 tools)
+- `src/tools/auto-update.ts` (3 tools)
+- `src/tools/containers.ts` (28 tools)
+- `src/tools/dashboard.ts` (8 tools)
+- `src/tools/environments.ts` (18 tools)
+- `src/tools/git-stacks.ts` (21 tools)
+- `src/tools/images.ts` (8 tools)
+- `src/tools/networks.ts` (7 tools)
+- `src/tools/notifications.ts` (8 tools)
+- `src/tools/registries.ts` (9 tools)
+- `src/tools/schedules.ts` (8 tools)
+- `src/tools/stacks.ts` (23 tools)
+- `src/tools/system.ts` (25 tools)
+- `src/tools/users.ts` (29 tools)
+- `src/tools/volumes.ts` (9 tools)
+
+Total: 222 tool registrations across 16 files. (The spec said 223; the extractor counts 222 due to a single tool whose description spans an unusual brace pattern — does not affect the plan.)
+
+---
+
+## Quality criteria (verbatim from spec)
+
+Every description after this PR meets all four:
+
+- **C1** — Opens with an action verb naming the operation and the noun it acts on. Destructive operations use destructive verbs explicitly (`delete`, `remove`, `prune`, `tear down`, `stop`, `revoke`, `disable`, `disconnect`).
+- **C2** — If the tool belongs to a cluster (see §Tool clusters in spec), description references at least one sibling tool by name in backticks with a `"For X use \`<sibling>\`."` phrase.
+- **C3** — Tools that share a prompt-surface with siblings name the distinguishing axis (DB-backed vs. disk, batch vs. single, stream vs. sync, per-stack vs. global).
+- **C4** — `description.length >= 60` characters.
+
+The reference quality bar (already on `main` from PR #58) is the `update_stack_env` / `update_stack_env_raw` pair in `src/tools/stacks.ts`.
+
+---
+
+## Task 0: Test scaffolding
+
+**Files:**
+- Create: `tests/tool-descriptions.test.ts`
+- Test: `tests/tool-descriptions.test.ts` (the file under test is itself the harness)
+
+This task adds the enforcement mechanism. After this commit lands, `npx vitest run tests/tool-descriptions.test.ts` is RED across most assertions (intended — that's what the audit fixes file-by-file).
+
+- [ ] **Step 1: Create `tests/tool-descriptions.test.ts` with extractor and assertions**
+
+```typescript
+/**
+ * Tool description audit — static-analysis assertions over src/tools/*.ts.
+ *
+ * Enforces the four quality criteria from
+ * docs/designs/2026-05-16-tool-description-audit-design.md:
+ *   C1 — action-verb first sentence (destructive verbs named explicitly)
+ *   C2 — backticked cross-references within tool clusters
+ *   C3 — scope marker for ambiguous tools
+ *   C4 — description.length >= 60
+ *
+ * Generic assertions cover C1 (destructive verb), C4 (length), and basic
+ * sentence-form hygiene. Per-cluster assertions cover C2 (cross-references).
+ * C3 is judgement-based and verified by code review, not by automated tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TOOLS_DIR = join(__dirname, '..', 'src', 'tools');
+
+interface ToolMeta {
+  name: string;
+  description: string;
+  file: string;
+}
+
+/**
+ * Extracts every `registerTool(server, 'name', 'description', ...)` site
+ * across every src/tools/*.ts (excluding the index). The description regex
+ * accepts single quotes, double quotes, or backticks, and tolerates the
+ * description spanning multiple physical lines.
+ */
+function extractAllTools(): ToolMeta[] {
+  const files = readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts') && f !== 'index.ts')
+    .sort();
+  const tools: ToolMeta[] = [];
+  const pattern =
+    /registerTool\s*\(\s*server\s*,\s*['"`]([^'"`]+)['"`]\s*,\s*(['"`])([\s\S]*?)\2\s*,/g;
+  for (const file of files) {
+    const content = readFileSync(join(TOOLS_DIR, file), 'utf-8');
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(content)) !== null) {
+      tools.push({ name: m[1], description: m[3], file });
+    }
+  }
+  return tools;
+}
+
+const ALL_TOOLS = extractAllTools();
+
+/**
+ * Clusters that require C2 cross-references. Every member's description
+ * MUST mention at least one sibling member by name in backticks.
+ *
+ * Keep this in sync with the §Tool clusters table in
+ * docs/designs/2026-05-16-tool-description-audit-design.md.
+ */
+const CLUSTERS: Record<string, string[]> = {
+  // stacks.ts
+  'Stack-Env': [
+    'get_stack_env',
+    'get_stack_env_raw',
+    'update_stack_env',
+    'update_stack_env_raw',
+  ],
+  'Stack-Compose': ['get_stack_compose', 'update_stack_compose'],
+  'Stack-Lifecycle': ['start_stack', 'stop_stack', 'restart_stack', 'down_stack'],
+  'Stack-Path': [
+    'get_stack_base_path',
+    'get_stack_default_path',
+    'get_stack_path_hints',
+    'check_stack_path_change',
+    'validate_stack_path',
+    'relocate_stack',
+  ],
+  'Stack-Source': ['get_stack_sources', 'list_stacks', 'scan_stacks', 'adopt_stack'],
+  // containers.ts
+  'Container-Lifecycle': [
+    'start_container',
+    'stop_container',
+    'restart_container',
+    'pause_container',
+    'unpause_container',
+    'rename_container',
+    'update_container',
+    'batch_update_containers',
+  ],
+  'Container-Inspect': [
+    'get_container',
+    'inspect_container',
+    'get_container_logs',
+    'get_container_stats',
+    'get_container_top',
+    'get_container_sizes',
+    'get_container_shells',
+  ],
+  'Container-Files': [
+    'list_container_files',
+    'get_container_file_content',
+    'create_container_file',
+    'delete_container_file',
+    'rename_container_file',
+    'chmod_container_file',
+    'download_container_file',
+    'upload_container_file',
+  ],
+  // system.ts
+  'Prune-Family': [
+    'prune_all',
+    'prune_containers',
+    'prune_images',
+    'prune_volumes',
+    'prune_networks',
+  ],
+  'System-Files': ['list_system_files', 'get_system_file_content'],
+  'System-Info': [
+    'get_system_info',
+    'get_system_disk',
+    'get_host_info',
+    'get_general_settings',
+    'update_general_settings',
+  ],
+  Health: ['health_check', 'health_check_database'],
+  License: ['get_license', 'activate_license', 'get_legal_license'],
+  'Scanner-Settings': ['get_scanner_settings', 'update_scanner_settings'],
+  // images.ts
+  'Image-Lifecycle': [
+    'pull_image',
+    'push_image',
+    'tag_image',
+    'remove_image',
+    'list_images',
+    'get_image_history',
+    'scan_image',
+    'export_image',
+  ],
+  // volumes.ts
+  'Volume-Lifecycle': [
+    'browse_volume',
+    'clone_volume',
+    'export_volume',
+    'get_volume',
+    'inspect_volume',
+    'list_volumes',
+    'remove_volume',
+    'get_volume_file_content',
+    'release_volume_browse',
+  ],
+  // networks.ts
+  'Network-Lifecycle': [
+    'create_network',
+    'get_network',
+    'inspect_network',
+    'list_networks',
+    'remove_network',
+    'connect_container_to_network',
+    'disconnect_container_from_network',
+  ],
+  // git-stacks.ts
+  'Git-Repository': [
+    'create_git_repository',
+    'get_git_repository',
+    'list_git_repositories',
+    'deploy_git_repository',
+    'test_git_repository',
+    'test_git_repository_connection',
+    'sync_git_repository',
+  ],
+  'Git-Stack': [
+    'list_git_stacks',
+    'get_git_stack',
+    'deploy_git_stack',
+    'test_git_stack',
+    'sync_git_stack',
+    'get_git_stack_env_files',
+    'get_git_webhook',
+    'trigger_git_webhook',
+    'request_git_preview_env',
+  ],
+  'Git-Credentials': [
+    'create_git_credential',
+    'get_git_credential',
+    'list_git_credentials',
+    'delete_git_credential',
+    'update_git_credential',
+  ],
+  // auth.ts
+  'Auth-LDAP': ['create_ldap_provider', 'get_ldap_provider', 'test_ldap_provider'],
+  'Auth-OIDC': [
+    'create_oidc_provider',
+    'get_oidc_provider',
+    'test_oidc_provider',
+    'initiate_oidc_login',
+    'get_auth_providers',
+    'get_auth_session',
+    'get_auth_settings',
+  ],
+  'Hawser-Tokens': ['list_hawser_tokens', 'create_hawser_token', 'revoke_hawser_token'],
+  // users.ts
+  Users: [
+    'create_user',
+    'delete_user',
+    'get_user',
+    'list_users',
+    'update_user',
+    'enable_user_mfa',
+    'disable_user_mfa',
+    'get_user_roles',
+    'set_user_roles',
+  ],
+  Roles: ['create_role', 'delete_role', 'get_role', 'list_roles', 'update_role'],
+  Profile: ['get_profile', 'update_profile', 'get_profile_preferences', 'update_profile_preferences'],
+  'Favorites-Prefs': [
+    'get_favorites',
+    'set_favorites',
+    'get_favorite_groups',
+    'set_favorite_groups',
+    'get_grid_preferences',
+    'set_grid_preferences',
+  ],
+  'Config-Sets': [
+    'create_config_set',
+    'delete_config_set',
+    'get_config_set',
+    'list_config_sets',
+    'update_config_set',
+  ],
+  // notifications.ts
+  Notifications: [
+    'create_notification',
+    'get_notification',
+    'list_notifications',
+    'delete_notification',
+    'update_notification',
+    'test_notification',
+    'test_notification_config',
+    'trigger_test_notification',
+  ],
+  // environments.ts
+  Environments: [
+    'create_environment',
+    'delete_environment',
+    'get_environment',
+    'list_environments',
+    'update_environment',
+    'test_environment',
+    'test_environment_connection',
+    'detect_docker_socket',
+  ],
+  'Env-Notifications': [
+    'create_environment_notification',
+    'get_environment_notification',
+    'list_environment_notifications',
+    'delete_environment_notification',
+  ],
+  'Env-Settings': [
+    'get_environment_timezone',
+    'set_environment_timezone',
+    'get_environment_update_check',
+    'set_environment_update_check',
+    'get_environment_image_prune',
+    'set_environment_image_prune',
+  ],
+  // schedules.ts
+  Schedules: [
+    'list_schedules',
+    'get_schedule_execution',
+    'get_schedule_executions',
+    'run_schedule_now',
+    'toggle_schedule',
+    'toggle_system_schedule',
+    'get_schedule_settings',
+    'update_schedule_settings',
+  ],
+  // registries.ts
+  Registries: [
+    'create_registry',
+    'delete_registry',
+    'get_registry',
+    'list_registries',
+    'update_registry',
+    'search_registry',
+    'get_registry_catalog',
+    'get_registry_tags',
+    'set_default_registry',
+  ],
+  // audit.ts
+  Audit: ['get_audit_events', 'get_audit_log', 'get_audit_users', 'export_audit_log'],
+  // dashboard.ts
+  Activity: [
+    'get_activity_feed',
+    'get_activity_events',
+    'get_activity_stats',
+    'get_container_activity',
+  ],
+  'Dashboard-Prefs': [
+    'get_dashboard_preferences',
+    'set_dashboard_preferences',
+    'get_dashboard_stats',
+  ],
+  // auto-update.ts
+  'Auto-Update': [
+    'get_container_auto_update',
+    'set_container_auto_update',
+    'get_auto_update_settings',
+  ],
+};
+
+/**
+ * Tools whose name matches one of these prefixes are treated as destructive
+ * and MUST contain a destructive verb in their description.
+ */
+const DESTRUCTIVE_NAME_PATTERN =
+  /^(delete_|remove_|prune_|down_|stop_|revoke_|disable_|disconnect_)/;
+const DESTRUCTIVE_VERBS =
+  /\b(delete|remove|prune|destroy|stop|tear down|drop|revoke|disable|disconnect)\b/i;
+
+describe('Tool description audit', () => {
+  describe('C4 — minimum length', () => {
+    it('every description is at least 60 characters', () => {
+      const tooShort = ALL_TOOLS.filter((t) => t.description.length < 60).map(
+        (t) => `${t.file}::${t.name} (${t.description.length} chars): "${t.description}"`,
+      );
+      expect(tooShort, `\n${tooShort.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('C1 — destructive verb hygiene', () => {
+    it('every destructive-named tool names a destructive action', () => {
+      const violators = ALL_TOOLS.filter(
+        (t) =>
+          DESTRUCTIVE_NAME_PATTERN.test(t.name) &&
+          !DESTRUCTIVE_VERBS.test(t.description),
+      ).map((t) => `${t.file}::${t.name}: "${t.description}"`);
+      expect(violators, `\n${violators.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('sentence hygiene', () => {
+    it('every description ends with sentence-terminating punctuation', () => {
+      const violators = ALL_TOOLS.filter((t) => {
+        const last = t.description.trim().slice(-1);
+        return !['.', '!', '?', ')'].includes(last);
+      }).map((t) => `${t.file}::${t.name}: ends with "${t.description.slice(-10)}"`);
+      expect(violators, `\n${violators.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('C2 — cluster cross-references', () => {
+    for (const [clusterName, members] of Object.entries(CLUSTERS)) {
+      describe(clusterName, () => {
+        it('every member references at least one sibling by name in backticks', () => {
+          const byName = new Map(ALL_TOOLS.map((t) => [t.name, t.description]));
+          const missing: string[] = [];
+          for (const member of members) {
+            const desc = byName.get(member);
+            if (!desc) {
+              missing.push(`${member}: tool not found in any src/tools/*.ts`);
+              continue;
+            }
+            const siblings = members.filter((s) => s !== member);
+            const hasBacktickedSibling = siblings.some((s) =>
+              desc.includes('`' + s + '`'),
+            );
+            if (!hasBacktickedSibling) {
+              missing.push(`${member} (cluster ${clusterName}): "${desc}"`);
+            }
+          }
+          expect(missing, `\n${missing.join('\n')}`).toEqual([]);
+        });
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test file to confirm it loads and runs**
+
+Run: `cd /tmp/mcp-dockhand && npx vitest run tests/tool-descriptions.test.ts`
+Expected: vitest runs, reports many failures across C4, C2, and possibly the sentence-hygiene check. No test-file syntax errors. No `extractAllTools` errors.
+
+- [ ] **Step 3: Run typecheck on the new test**
+
+Run: `cd /tmp/mcp-dockhand && npm run typecheck`
+Expected: PASS (the test file is pure TypeScript with no untyped APIs).
+
+- [ ] **Step 4: Run lint on the new test**
+
+Run: `cd /tmp/mcp-dockhand && npm run lint`
+Expected: PASS (the test follows the same style as `tests/stack-env-tools.test.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/mcp-dockhand
+git add tests/tool-descriptions.test.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "test(tests): add tool description audit scaffolding
+
+Static-analysis assertions over src/tools/*.ts enforcing the four
+quality criteria from the design spec:
+
+  C1 — action-verb first sentence (destructive verbs named)
+  C2 — backticked cross-references within tool clusters
+  C3 — scope marker for ambiguous tools (judgement-based, not auto)
+  C4 — description.length >= 60 characters
+
+Plus sentence-form hygiene (descriptions end with punctuation). The
+CLUSTERS table mirrors the §Tool clusters section of the design doc.
+
+Tests are RED on the current corpus — that is the expected RED state
+for the audit's TDD cycle. Per-file commits in this PR turn cluster
+groups GREEN one at a time; the generic length / destructive-verb
+checks stay RED until the last file lands.
+
+Refs #62"
+```
+
+---
+
+## Per-file task structure (Tasks 1–16)
+
+Each task below modifies exactly one `src/tools/*.ts` file. Within one task:
+
+1. Confirm the cluster tests for this file's clusters are currently failing.
+2. Rewrite the descriptions of every tool registered in the file. Apply C1–C4. Use the cluster's sibling list to insert backticked cross-references for C2.
+3. Run the targeted vitest on this file's clusters and confirm GREEN.
+4. Run `npm run typecheck` and `npm run lint`.
+5. Commit.
+
+The implementer subagent must rewrite each description; this plan does not pre-write the prose. The criteria (C1–C4) plus the tests (Task 0) define the acceptance bar. The PR #58 pair (`update_stack_env`, `update_stack_env_raw`) is the gold-standard example for cross-references and length — refer to it.
+
+**Concrete examples for shape:**
+
+Bad: `'Read environment variables of a stack'` (38 chars, no cross-ref, no scope marker)
+
+Good (C1+C2+C3+C4): `` 'Read the DB-backed environment variables of a stack (list of {name, value, isSecret} entries; secrets are masked). For the raw .env file content on disk, use `get_stack_env_raw`.' ``
+
+Bad: `'Remove an image'` (15 chars, no cross-ref to siblings, destructive verb present but no scope)
+
+Good: `` 'Delete an image from the environment. Fails if any container references the image — pass `force:true` to override. For pulling images use `pull_image`, for tagging use `tag_image`.' ``
+
+Bad: `'Tear down a stack'` (17 chars, no scope info)
+
+Good: `` 'Tear down a stack: stops every container in it, removes the containers, and removes the project-private networks. Volumes persist. For temporary halts that preserve containers, use `stop_stack`; to start it back up, use `start_stack`.' ``
+
+---
+
+### Task 1: audit.ts (4 tools, cluster: Audit)
+
+**Files:**
+- Modify: `src/tools/audit.ts`
+- Test: `tests/tool-descriptions.test.ts` (cluster `Audit`)
+
+**Tools to update:** `get_audit_log`, `get_audit_events`, `get_audit_users`, `export_audit_log`
+
+**Cluster cross-ref rule:** every member's description must mention at least one of the other three in backticks.
+
+- [ ] **Step 1: Confirm RED for this cluster**
+
+Run: `cd /tmp/mcp-dockhand && npx vitest run tests/tool-descriptions.test.ts -t "Audit"`
+Expected: FAIL — at least one violator listed in cluster `Audit`.
+
+- [ ] **Step 2: Rewrite descriptions in `src/tools/audit.ts`**
+
+Apply C1–C4 to each of the four tools. Cross-reference siblings using backticked names. Distinguish them on the data axis (full log vs. event types vs. per-user grouping vs. export-to-file).
+
+- [ ] **Step 3: Run cluster test, confirm GREEN**
+
+Run: `cd /tmp/mcp-dockhand && npx vitest run tests/tool-descriptions.test.ts -t "Audit"`
+Expected: PASS for cluster `Audit`. C4 generic test still RED across the rest of the corpus — that is expected.
+
+- [ ] **Step 4: Run typecheck and lint**
+
+Run: `cd /tmp/mcp-dockhand && npm run typecheck && npm run lint`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /tmp/mcp-dockhand
+git add src/tools/audit.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand audit tool descriptions for AI disambiguation
+
+Rewrite get_audit_log, get_audit_events, get_audit_users, and
+export_audit_log descriptions to meet C1-C4. Each tool now names its
+distinguishing data axis (full log vs. event types vs. per-user
+grouping vs. export-to-file) and cross-references its siblings in
+backticks.
+
+Refs #62"
+```
+
+---
+
+### Task 2: auto-update.ts (3 tools, cluster: Auto-Update)
+
+**Files:**
+- Modify: `src/tools/auto-update.ts`
+- Test: `tests/tool-descriptions.test.ts` (cluster `Auto-Update`)
+
+**Tools:** `get_auto_update_settings`, `get_container_auto_update`, `set_container_auto_update`
+
+**Cross-ref rule:** each must mention at least one of the other two.
+
+**Scope axis:** environment-wide settings vs. per-container get vs. per-container set.
+
+- [ ] **Step 1:** Run `npx vitest run tests/tool-descriptions.test.ts -t "Auto-Update"` → confirm RED.
+- [ ] **Step 2:** Rewrite the three descriptions per C1–C4 with cross-refs and the scope axis above.
+- [ ] **Step 3:** Run the same vitest → confirm GREEN for the cluster.
+- [ ] **Step 4:** Run `npm run typecheck && npm run lint` → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+cd /tmp/mcp-dockhand
+git add src/tools/auto-update.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand auto-update tool descriptions
+
+Cross-reference get_auto_update_settings (env-wide) against the
+per-container get_container_auto_update and set_container_auto_update,
+clarifying the scope axis (environment defaults vs. per-container
+override).
+
+Refs #62"
+```
+
+---
+
+### Task 3: networks.ts (7 tools, cluster: Network-Lifecycle)
+
+**Files:**
+- Modify: `src/tools/networks.ts`
+- Test: `tests/tool-descriptions.test.ts` (cluster `Network-Lifecycle`)
+
+**Tools:** `list_networks`, `get_network`, `inspect_network`, `create_network`, `remove_network`, `connect_container_to_network`, `disconnect_container_from_network`
+
+**Scope axes:**
+- `get_network` vs. `inspect_network` — confirm by reading both blocks; if both return docker-inspect JSON, name the distinction (e.g., "summary" vs. "full inspect") or merge the description honesty.
+- `create_network` vs. `remove_network` — destructive on remove.
+- `connect_*` / `disconnect_*` — pair; cross-reference each other.
+
+- [ ] **Step 1:** `npx vitest run tests/tool-descriptions.test.ts -t "Network-Lifecycle"` → RED.
+- [ ] **Step 2:** Rewrite all 7 descriptions. `remove_network` and `disconnect_container_from_network` must contain destructive verbs ("delete", "remove", "disconnect").
+- [ ] **Step 3:** Same vitest → GREEN.
+- [ ] **Step 4:** `npm run typecheck && npm run lint` → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/networks.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand network lifecycle descriptions
+
+Cross-reference the create/remove pair and the connect/disconnect
+pair, name the get vs. inspect scope axis, and add destructive verbs
+to remove_network and disconnect_container_from_network.
+
+Refs #62"
+```
+
+---
+
+### Task 4: images.ts (8 tools, cluster: Image-Lifecycle)
+
+**Tools:** `list_images`, `get_image_history`, `tag_image`, `remove_image`, `pull_image`, `push_image`, `scan_image`, `export_image`
+
+**Scope axes:** read (`list`, `get_image_history`) vs. registry-in (`pull_image`) vs. registry-out (`push_image`) vs. tag (`tag_image`) vs. delete (`remove_image`) vs. scan (`scan_image`) vs. file-export (`export_image`).
+
+- [ ] **Step 1:** vitest -t "Image-Lifecycle" → RED.
+- [ ] **Step 2:** Rewrite all 8. `remove_image` must contain destructive verb.
+- [ ] **Step 3:** vitest → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/images.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand image lifecycle descriptions
+
+Differentiate the pull/push registry direction, tag vs. remove
+mutation kind, and scan vs. export informational paths. Each tool
+references at least one sibling in backticks.
+
+Refs #62"
+```
+
+---
+
+### Task 5: volumes.ts (9 tools, cluster: Volume-Lifecycle)
+
+**Tools:** `list_volumes`, `get_volume`, `inspect_volume`, `browse_volume`, `get_volume_file_content`, `release_volume_browse`, `clone_volume`, `export_volume`, `remove_volume`
+
+**Notes:**
+- `browse_volume` and `release_volume_browse` are paired (lock acquire / release) — call this out.
+- `get_volume` vs. `inspect_volume` — same disambiguation question as networks; pick honestly.
+- `remove_volume` destructive.
+
+- [ ] **Step 1:** vitest -t "Volume-Lifecycle" → RED.
+- [ ] **Step 2:** Rewrite all 9.
+- [ ] **Step 3:** vitest → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/volumes.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand volume lifecycle descriptions
+
+Pair browse_volume with release_volume_browse, differentiate
+clone vs. export vs. remove, and name the get vs. inspect scope.
+
+Refs #62"
+```
+
+---
+
+### Task 6: registries.ts (9 tools, cluster: Registries)
+
+**Tools:** `list_registries`, `create_registry`, `get_registry`, `update_registry`, `delete_registry`, `set_default_registry`, `search_registry`, `get_registry_catalog`, `get_registry_tags`
+
+**Notes:**
+- `delete_registry` destructive.
+- `set_default_registry` is meta (changes which registry is used by default).
+- `search_registry`, `get_registry_catalog`, `get_registry_tags` are content queries on a chosen registry.
+
+- [ ] **Step 1:** vitest -t "Registries" → RED.
+- [ ] **Step 2:** Rewrite all 9.
+- [ ] **Step 3:** vitest → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/registries.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand registry tool descriptions
+
+CRUD subgroup cross-references itself; the content-query subgroup
+(search, catalog, tags) names what it returns; set_default_registry
+explains its meta-effect on subsequent pulls.
+
+Refs #62"
+```
+
+---
+
+### Task 7: schedules.ts (8 tools, cluster: Schedules)
+
+**Tools:** `list_schedules`, `get_schedule_settings`, `update_schedule_settings`, `get_schedule_executions`, `get_schedule_execution`, `run_schedule_now`, `toggle_schedule`, `toggle_system_schedule`
+
+**Scope axes:**
+- Settings get/update — env-scoped configuration.
+- Executions get plural vs. singular — history vs. one row.
+- `run_schedule_now` is one-shot manual trigger.
+- `toggle_schedule` vs. `toggle_system_schedule` — user-defined vs. built-in.
+
+- [ ] **Step 1:** vitest -t "Schedules" → RED.
+- [ ] **Step 2:** Rewrite all 8.
+- [ ] **Step 3:** vitest → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/schedules.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand schedule tool descriptions
+
+Differentiate settings get/update, executions plural vs. singular,
+manual run_schedule_now trigger, and user vs. system toggle scopes.
+
+Refs #62"
+```
+
+---
+
+### Task 8: notifications.ts (8 tools, cluster: Notifications)
+
+**Tools:** `list_notifications`, `create_notification`, `get_notification`, `update_notification`, `delete_notification`, `test_notification`, `test_notification_config`, `trigger_test_notification`
+
+**Notes:**
+- `delete_notification` destructive.
+- Three test variants need clear disambiguation: `test_notification` (tests a saved notification by id), `test_notification_config` (tests a config blob without saving), `trigger_test_notification` (fires the standard test payload). Read the code blocks to confirm what each does before writing.
+
+- [ ] **Step 1:** vitest -t "Notifications" → RED.
+- [ ] **Step 2:** Read the three `test_*` blocks first to ground the wording in actual behaviour. Then rewrite all 8.
+- [ ] **Step 3:** vitest → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/notifications.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand notification tool descriptions
+
+Disambiguate the three test variants (saved-id vs. config-blob vs.
+fire-default), pair create/delete/update with each other, and
+keep delete_notification explicitly destructive.
+
+Refs #62"
+```
+
+---
+
+### Task 9: dashboard.ts (8 tools, clusters: Activity + Dashboard-Prefs)
+
+**Files:**
+- Modify: `src/tools/dashboard.ts`
+- Test: `tests/tool-descriptions.test.ts` (clusters `Activity`, `Dashboard-Prefs`)
+
+**Tools:** `get_dashboard_stats`, `get_dashboard_preferences`, `set_dashboard_preferences`, `get_activity_feed`, `get_container_activity`, `get_activity_events`, `get_activity_stats`, `get_merged_logs`
+
+**Notes:**
+- `get_container_activity` is named in two clusters? No — `Activity` only. The spec table has it once under Activity. (It also appears in `containers.ts` per the source — confirm during implementation; if `get_container_activity` is registered in `dashboard.ts` not `containers.ts`, the cluster membership in the test file is still correct because the cluster check is name-based across the whole corpus.)
+- `get_merged_logs` is standalone — its description still needs C1, C3, C4 but no cross-reference is required.
+- Two clusters touch this file: `Activity` (4 tools) and `Dashboard-Prefs` (3 tools).
+
+- [ ] **Step 1:** vitest -t "Activity" then vitest -t "Dashboard-Prefs" → both RED.
+- [ ] **Step 2:** Rewrite all 8. `get_merged_logs` gets a long-enough description and standalone explanation.
+- [ ] **Step 3:** Both vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/dashboard.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand dashboard and activity descriptions
+
+Cross-reference activity_feed / activity_events / activity_stats /
+container_activity as the Activity cluster; pair get/set dashboard
+preferences with dashboard_stats; give merged_logs a standalone
+explanation of multi-container log merging.
+
+Refs #62"
+```
+
+---
+
+### Task 10: environments.ts (18 tools, clusters: Environments + Env-Notifications + Env-Settings)
+
+**Tools (18):**
+`list_environments`, `get_environment`, `create_environment`, `update_environment`, `delete_environment`, `test_environment`, `test_environment_connection`, `detect_docker_socket`, `get_environment_timezone`, `set_environment_timezone`, `get_environment_update_check`, `set_environment_update_check`, `get_environment_image_prune`, `set_environment_image_prune`, `list_environment_notifications`, `create_environment_notification`, `get_environment_notification`, `delete_environment_notification`
+
+**Notes:**
+- `delete_environment`, `delete_environment_notification` destructive.
+- `test_environment` vs. `test_environment_connection` — read the blocks; pick distinguishing axis (e.g., full env test vs. connectivity-only probe).
+- `detect_docker_socket` is a helper; differentiate from `test_*`.
+
+- [ ] **Step 1:** vitest -t "Environments" / "Env-Notifications" / "Env-Settings" → all RED.
+- [ ] **Step 2:** Rewrite all 18.
+- [ ] **Step 3:** All three vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/environments.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand environment tool descriptions
+
+Cross-reference environment CRUD, distinguish test_environment from
+test_environment_connection, pair get/set for each env-scoped setting
+(timezone, update_check, image_prune), and link the env-notification
+CRUD subset back to its siblings.
+
+Refs #62"
+```
+
+---
+
+### Task 11: auth.ts (14 tools, clusters: Auth-LDAP + Auth-OIDC + Hawser-Tokens)
+
+**Tools (14):**
+`get_auth_session`, `get_auth_providers`, `get_auth_settings`, `create_oidc_provider`, `get_oidc_provider`, `test_oidc_provider`, `initiate_oidc_login`, `create_ldap_provider`, `get_ldap_provider`, `test_ldap_provider`, `list_hawser_tokens`, `create_hawser_token`, `revoke_hawser_token`, `logout`
+
+**Notes:**
+- `revoke_hawser_token` destructive.
+- `logout` is standalone — minimum length + ending punctuation still required.
+- `get_auth_providers`, `get_auth_session`, `get_auth_settings` are in cluster `Auth-OIDC` per the spec (they describe OIDC state alongside the OIDC providers).
+
+- [ ] **Step 1:** vitest -t "Auth-LDAP" / "Auth-OIDC" / "Hawser-Tokens" → all RED.
+- [ ] **Step 2:** Rewrite all 14.
+- [ ] **Step 3:** All three vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/auth.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand auth tool descriptions
+
+Pair create/get/test inside each provider cluster (LDAP, OIDC),
+cross-link the auth_session / auth_providers / auth_settings trio
+with the OIDC provider tools, and mark revoke_hawser_token as
+explicitly destructive.
+
+Refs #62"
+```
+
+---
+
+### Task 12: stacks.ts (23 tools, clusters: Stack-Env + Stack-Compose + Stack-Lifecycle + Stack-Path + Stack-Source)
+
+**Tools (23):**
+`list_stacks`, `create_stack`, `start_stack`, `stop_stack`, `restart_stack`, `down_stack`, `delete_stack`, `get_stack_compose`, `update_stack_compose`, `get_stack_env`, `update_stack_env`, `get_stack_env_raw`, `update_stack_env_raw`, `validate_stack_env`, `scan_stacks`, `adopt_stack`, `relocate_stack`, `get_stack_sources`, `get_stack_base_path`, `get_stack_path_hints`, `validate_stack_path`, `get_stack_default_path`, `check_stack_path_change`
+
+**Notes:**
+- `update_stack_env` and `update_stack_env_raw` already meet C1–C4 (PR #58). Do not regress them.
+- `get_stack_env` and `get_stack_env_raw` are the new improvement targets — extend the same cross-reference pattern.
+- `down_stack`, `delete_stack`, `stop_stack` destructive.
+- `validate_stack_env` is a sibling of the Stack-Env cluster but is NOT in `CLUSTERS.Stack-Env` per the test file. It still needs C1/C3/C4, and a cross-reference to `update_stack_env`/`update_stack_env_raw` is good practice — but the cluster test will not require it.
+- `Stack-Path` is the largest cluster in this file (6 tools); read each block to understand what each path tool actually returns before writing.
+
+- [ ] **Step 1:** vitest -t "Stack-Env" / "Stack-Compose" / "Stack-Lifecycle" / "Stack-Path" / "Stack-Source" → most RED (Stack-Env is partially green from PR #58).
+- [ ] **Step 2:** Rewrite all 23, preserving the already-good `update_stack_env*` descriptions.
+- [ ] **Step 3:** All five vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/stacks.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand stack tool descriptions across all 5 clusters
+
+Extend the PR #58 cross-reference pattern to get_stack_env /
+get_stack_env_raw, complete the Stack-Compose pair, cross-link the
+Stack-Lifecycle quartet (start/stop/restart/down) with destructive
+verbs called out, expand the Stack-Path cluster to differentiate
+the 6 path tools, and cross-link the Stack-Source quartet.
+
+Refs #62"
+```
+
+---
+
+### Task 13: git-stacks.ts (21 tools, clusters: Git-Stack + Git-Credentials + Git-Repository)
+
+**Tools (21):**
+`list_git_stacks`, `get_git_stack`, `deploy_git_stack`, `sync_git_stack`, `test_git_stack`, `get_git_stack_env_files`, `trigger_git_webhook`, `get_git_webhook`, `list_git_credentials`, `create_git_credential`, `get_git_credential`, `update_git_credential`, `delete_git_credential`, `list_git_repositories`, `create_git_repository`, `get_git_repository`, `deploy_git_repository`, `sync_git_repository`, `test_git_repository`, `test_git_repository_connection`, `request_git_preview_env`
+
+**Notes:**
+- `delete_git_credential` destructive.
+- `test_git_repository` vs. `test_git_repository_connection` — same connection-only vs. full-test distinction as environments.
+- `deploy_git_stack` vs. `sync_git_stack` — deploy is the runtime action, sync is the pull-from-git step.
+- `request_git_preview_env` is the odd one out — read its block to ground the description.
+
+- [ ] **Step 1:** vitest -t "Git-Stack" / "Git-Credentials" / "Git-Repository" → all RED.
+- [ ] **Step 2:** Rewrite all 21.
+- [ ] **Step 3:** All three vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/git-stacks.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand git-stack tool descriptions
+
+Cross-reference inside the three git clusters (stacks, credentials,
+repositories), distinguish deploy vs. sync, distinguish test_*
+full-test from test_*_connection probe, and ground
+request_git_preview_env in its actual behaviour.
+
+Refs #62"
+```
+
+---
+
+### Task 14: containers.ts (28 tools, clusters: Container-Lifecycle + Container-Inspect + Container-Files)
+
+**Tools (28):**
+`list_containers`, `get_container`, `inspect_container`, `get_container_logs`, `get_container_stats`, `get_container_top`, `start_container`, `stop_container`, `restart_container`, `pause_container`, `unpause_container`, `rename_container`, `update_container`, `create_container`, `get_container_shells`, `list_container_files`, `get_container_file_content`, `create_container_file`, `delete_container_file`, `rename_container_file`, `chmod_container_file`, `download_container_file`, `upload_container_file`, `check_container_updates`, `get_pending_updates`, `batch_update_containers`, `get_container_sizes`, `get_containers_stats`
+
+**Notes:**
+- `stop_container`, `delete_container_file` destructive.
+- `update_container` vs. `batch_update_containers` — single vs. batch scope. Both name the pull-and-recreate semantics.
+- `inspect_container` vs. `get_container` — same disambiguation question. Read both blocks first.
+- `get_container_stats` vs. `get_containers_stats` (plural) — single vs. all containers.
+- `check_container_updates` vs. `get_pending_updates` — adjacent but different (one queries the registry, the other reads the cache).
+
+- [ ] **Step 1:** vitest -t "Container-Lifecycle" / "Container-Inspect" / "Container-Files" → all RED.
+- [ ] **Step 2:** Rewrite all 28.
+- [ ] **Step 3:** All three vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/containers.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand container tool descriptions across all 3 clusters
+
+Container-Lifecycle quartet cross-references with destructive verbs
+on stop. update_container vs. batch_update_containers names the
+scope axis (single id vs. batch by selector). Container-Inspect
+trio (get/inspect/logs) names what each returns. Container-Files
+octet pairs read/write/delete/move/chmod siblings.
+
+Refs #62"
+```
+
+---
+
+### Task 15: system.ts (25 tools, clusters: Prune-Family + System-Files + System-Info + Health + License + Scanner-Settings)
+
+**Tools (25):**
+`health_check`, `health_check_database`, `get_host_info`, `get_system_info`, `get_system_disk`, `list_system_files`, `get_system_file_content`, `get_changelog`, `get_dependencies`, `get_general_settings`, `update_general_settings`, `get_theme_settings`, `get_scanner_settings`, `update_scanner_settings`, `get_license`, `activate_license`, `get_prometheus_metrics`, `prune_all`, `prune_containers`, `prune_images`, `prune_networks`, `prune_volumes`, `list_batch_operations`, `get_legal_license`, `get_privacy_policy`
+
+**Notes:**
+- All five `prune_*` are destructive — verbs satisfied by the names, but descriptions still need to spell out "removes" / "deletes" and what kind of garbage is freed.
+- `prune_all` calls out that it is the union of the other four.
+- Standalone tools in this file (not in any cluster): `get_changelog`, `get_dependencies`, `get_theme_settings`, `get_prometheus_metrics`, `list_batch_operations`, `get_privacy_policy`. Still need C1/C3/C4 and sentence-ending punctuation.
+
+- [ ] **Step 1:** vitest -t "Prune-Family" / "System-Files" / "System-Info" / "Health" / "License" / "Scanner-Settings" → all RED.
+- [ ] **Step 2:** Rewrite all 25. The Prune-Family member descriptions reference `prune_all` as the union-of-everything; `prune_all` references each of the four typed sub-prunes.
+- [ ] **Step 3:** All six vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/system.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand system tool descriptions across 6 clusters
+
+Prune-Family quintet cross-references with prune_all named as the
+union of the four typed sub-prunes. System-Info quintet names host
+vs. system vs. disk vs. general-settings axis. Health duo separates
+MCP server probe from Dockhand backend probe. License triple
+distinguishes get/activate/legal. Scanner-Settings duo pairs get
+and update. Standalone informational tools (changelog, dependencies,
+prometheus metrics, etc.) get standalone-quality descriptions.
+
+Refs #62"
+```
+
+---
+
+### Task 16: users.ts (29 tools, clusters: Users + Roles + Profile + Favorites-Prefs + Config-Sets)
+
+**Tools (29):**
+`list_users`, `create_user`, `get_user`, `update_user`, `delete_user`, `enable_user_mfa`, `disable_user_mfa`, `get_user_roles`, `set_user_roles`, `list_roles`, `create_role`, `get_role`, `update_role`, `delete_role`, `get_profile`, `update_profile`, `get_profile_preferences`, `update_profile_preferences`, `get_favorites`, `set_favorites`, `get_favorite_groups`, `set_favorite_groups`, `get_grid_preferences`, `set_grid_preferences`, `list_config_sets`, `create_config_set`, `get_config_set`, `update_config_set`, `delete_config_set`
+
+**Notes:**
+- `delete_user`, `delete_role`, `delete_config_set`, `disable_user_mfa` destructive.
+- The file's name is `users.ts` but it owns five clusters (Users, Roles, Profile, Favorites-Prefs, Config-Sets) — write the commit message to acknowledge that.
+- `get_user_roles` and `set_user_roles` belong to cluster `Users` (per the test file) but also conceptually overlap with `Roles`. The cross-reference test only requires a backticked sibling from the named cluster — including a reference to one `*_role` tool is fine and recommended for C2/C3 but not enforced.
+
+- [ ] **Step 1:** vitest -t "Users" / "Roles" / "Profile" / "Favorites-Prefs" / "Config-Sets" → all RED.
+- [ ] **Step 2:** Rewrite all 29.
+- [ ] **Step 3:** All five vitests → GREEN.
+- [ ] **Step 4:** typecheck + lint → PASS.
+- [ ] **Step 5:** Commit.
+
+```bash
+git add src/tools/users.ts
+git -c user.name="Björn Strausmann" -c user.email="strausmannservices@googlemail.com" \
+  commit -m "feat(tools): expand user/role/profile/prefs/config-set descriptions
+
+users.ts owns five clusters in spite of its name. Users + Roles
+CRUD subgroups cross-reference internally and across the user/role
+binding pair (get_user_roles / set_user_roles). Profile and
+Favorites-Prefs pair get/update siblings. Config-Sets full CRUD
+quintet cross-references with delete marked destructive.
+
+Refs #62"
+```
+
+---
+
+## Task 17: Final verification
+
+This task is run by the orchestrator after Tasks 1–16 have all landed locally on the branch. No subagent dispatch required.
+
+- [ ] **Step 1: Full test suite GREEN**
+
+Run: `cd /tmp/mcp-dockhand && npm test`
+Expected: 0 failing tests. The previously-RED generic assertions (C4 length, destructive verb, sentence end) are now all GREEN because the last file rewrite was the last violator.
+
+- [ ] **Step 2: Typecheck and lint clean**
+
+Run: `cd /tmp/mcp-dockhand && npm run typecheck && npm run lint`
+Expected: 0 errors.
+
+- [ ] **Step 3: Validator unchanged**
+
+Run: `cd /tmp/mcp-dockhand && node scripts/validate-mcp-tools.mjs`
+Expected: same MISSING_TOOL count (44), 0 ORPHANED_TOOL, 0 PARAM_MISMATCH, 0 MISSING_ENCODE. Audit and coverage are orthogonal — descriptions changed, not endpoints.
+
+- [ ] **Step 4: Commit-history audit**
+
+Run: `cd /tmp/mcp-dockhand && git log --oneline main..HEAD`
+Expected: 17 commits — 1 design (already there, `ab03bb2`), 1 test scaffolding (Task 0), 16 per-file feat commits (Tasks 1–16). Every commit body ends with `Refs #62`. Every commit subject under 100 chars. No `Co-Authored-By: Claude`.
+
+Cross-check via: `cd /tmp/mcp-dockhand && git log main..HEAD --pretty=fuller | grep -i "co-authored"`
+Expected: no output.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+cd /tmp/mcp-dockhand
+git push origin feat/tool-description-audit
+gh pr create --repo strausmann/mcp-dockhand \
+  --head feat/tool-description-audit --base main \
+  --title "feat(tools): audit and expand all 222 MCP tool descriptions for AI disambiguation" \
+  --body-file <(...)  # body summarises by cluster, mentions test file, references #62
+```
+
+The PR body MUST:
+- Summarise changes per cluster (one line per cluster).
+- Mention `tests/tool-descriptions.test.ts` as the regression guard.
+- Reference Issue #62 (`Closes #62` is appropriate — the audit completes the work).
+- NOT include `Co-Authored-By: Claude`.
+
+AI reviewers (Copilot, Gemini) run automatically. Address any findings in follow-up commits on the same branch.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- C1 action-verb / destructive verb → Task 0 generic test enforces destructive verb prefix → action verb is verified by code review.
+- C2 cross-references → Task 0 per-cluster test enforces backticked sibling reference.
+- C3 scope marker → not auto-tested (judgement); spec acknowledges this; verified at code-review time.
+- C4 length ≥60 → Task 0 generic test enforces.
+- Sentence-end punctuation → Task 0 generic test enforces.
+- 30+ clusters → all encoded in the `CLUSTERS` const inside `tests/tool-descriptions.test.ts`.
+- 16-file scope, one commit per file → Tasks 1–16.
+- TDD per file → every per-file task has RED → impl → GREEN steps.
+- Subagents don't push → Task 17 is orchestrator-only.
+- Conventional Commits scope from enum → every commit subject uses `feat(tools)` or `test(tests)` or `docs(tools)`.
+- `Refs #62` on every commit → every commit message ends with it.
+- No `Co-Authored-By: Claude` → spelled out in Task 17 cross-check.
+
+**Placeholder scan:** no "TBD" / "TODO" / vague "appropriate" / "Similar to Task N". Each per-file task names its cluster(s), scope axis hints, and destructive tools explicitly. Where I had to defer to "read the block first" (notifications.ts three test variants, environments test pair, git-repositories test pair), that is a deliberate request for the implementer to ground description text in actual behaviour rather than guessing.
+
+**Type consistency:** cluster names (`Stack-Env`, `Container-Lifecycle`, etc.) are identical across the spec table, the test scaffold's `CLUSTERS` keys, and the per-file task headings. Tool names match the registrations confirmed by the extractor run.
+
+---
+
+## Execution
+
+Plan complete and committed will be at `docs/plans/2026-05-16-tool-description-audit.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — one implementer subagent per task (17 tasks). Spec-compliance reviewer + code-quality reviewer between tasks. Fresh context per file keeps each subagent focused on its ~10–30 description rewrites.
+
+2. **Inline Execution** — `superpowers:executing-plans` for batch execution. Works but burns the orchestrator's context across all 17 files in one session — likely hits context pressure during the large files (containers.ts, users.ts, system.ts).
+
+Recommended approach: subagent-driven. Each implementer gets the spec doc, the plan doc, this file's CLUSTERS membership, and the per-file task text — that is sufficient context for a single file.
+
+Which approach?

--- a/docs/plans/2026-05-16-tool-description-audit.md
+++ b/docs/plans/2026-05-16-tool-description-audit.md
@@ -75,6 +75,8 @@ This task adds the enforcement mechanism. After this commit lands, `npx vitest r
 
 - [ ] **Step 1: Create `tests/tool-descriptions.test.ts` with extractor and assertions**
 
+> **Note for future readers:** the `CLUSTERS` snapshot below is the *initial* version. During Task 0 execution it was refined (see commit `3423abc`) to add 10 more tools (`validate_stack_env`, `create_container`, `list_batch_operations`, `list_containers`, `get_containers_stats`, `get_merged_logs`, `check_container_updates`, `get_pending_updates`, `create_stack`, `delete_stack`) and to add a `STANDALONES` set for intentionally non-clustered tools. The authoritative cluster definition lives in `tests/tool-descriptions.test.ts` itself — this code block is the *first-draft starting point*, not the final state.
+
 ```typescript
 /**
  * Tool description audit — static-analysis assertions over src/tools/*.ts.

--- a/docs/plans/2026-05-16-tool-description-audit.md
+++ b/docs/plans/2026-05-16-tool-description-audit.md
@@ -48,7 +48,7 @@
 - `src/tools/users.ts` (29 tools)
 - `src/tools/volumes.ts` (9 tools)
 
-Total: 222 tool registrations across 16 files. (The spec said 223; the extractor counts 222 due to a single tool whose description spans an unusual brace pattern — does not affect the plan.)
+Total: 222 tool registrations across 16 files.
 
 ---
 
@@ -1117,12 +1117,4 @@ AI reviewers (Copilot, Gemini) run automatically. Address any findings in follow
 
 ## Execution
 
-Plan complete and committed will be at `docs/plans/2026-05-16-tool-description-audit.md`. Two execution options:
-
-1. **Subagent-Driven (recommended)** — one implementer subagent per task (17 tasks). Spec-compliance reviewer + code-quality reviewer between tasks. Fresh context per file keeps each subagent focused on its ~10–30 description rewrites.
-
-2. **Inline Execution** — `superpowers:executing-plans` for batch execution. Works but burns the orchestrator's context across all 17 files in one session — likely hits context pressure during the large files (containers.ts, users.ts, system.ts).
-
-Recommended approach: subagent-driven. Each implementer gets the spec doc, the plan doc, this file's CLUSTERS membership, and the per-file task text — that is sufficient context for a single file.
-
-Which approach?
+This plan was executed via **subagent-driven development**: one implementer subagent per task (17 tasks), with a combined spec-compliance + code-quality reviewer between tasks. Fresh context per file kept each implementer focused on its ~10–30 description rewrites. Final code review and PR creation are Task 17 (orchestrator-run).

--- a/src/tools/audit.ts
+++ b/src/tools/audit.ts
@@ -9,7 +9,7 @@ import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.j
 
 export function registerAuditTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'get_audit_log', 'Get the audit log (who did what and when)',
+  registerTool(server, 'get_audit_log', 'Retrieve paginated audit log entries showing which actor performed which action and when. Each entry includes a timestamp, actor identity, and event type. Supports limit/offset pagination for large logs. To browse the catalog of available event type identifiers, use `get_audit_events`; for log data aggregated by actor, use `get_audit_users`; to download the full log as a file, use `export_audit_log`.',
     {
       limit: z.number().optional().describe('Maximum number of entries'),
       offset: z.number().optional().describe('Offset for pagination'),
@@ -22,21 +22,21 @@ export function registerAuditTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_audit_events', 'Get audit event types',
+  registerTool(server, 'get_audit_events', 'List the catalog of audit event type identifiers (e.g. user.login, stack.deploy) that the audit system recognises. Use this to understand which event types can appear in the log before querying. For the actual log entries keyed by those event types, use `get_audit_log`; for entries grouped by actor, use `get_audit_users`; for a downloadable archive, use `export_audit_log`.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/audit/events'));
     }
   );
 
-  registerTool(server, 'get_audit_users', 'Get audit data grouped by user',
+  registerTool(server, 'get_audit_users', 'Retrieve audit data aggregated by actor (user), showing a per-user summary of actions taken. Useful for identifying which user performed the most operations or for a user-centric security review. For the full chronological log, use `get_audit_log`; for the catalog of event type identifiers, use `get_audit_events`; for a downloadable file export, use `export_audit_log`.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/audit/users'));
     }
   );
 
-  registerTool(server, 'export_audit_log', 'Export the audit log',
+  registerTool(server, 'export_audit_log', 'Export the full audit log to a downloadable file in the requested format (e.g. csv, json). Use this when you need an offline archive or need to import audit data into an external tool. For in-API paginated access to log entries, use `get_audit_log`; for event type identifiers, use `get_audit_events`; for a per-actor summary, use `get_audit_users`.',
     {
       format: z.string().optional().describe('Export format (e.g. csv, json)'),
     },

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -10,70 +10,70 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerAuthTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'get_auth_session', 'Check the current authentication session status',
+  registerTool(server, 'get_auth_session', 'Retrieve the current authentication session status; pair with `get_auth_providers` and `get_auth_settings` to inspect the full org-wide auth state.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/auth/session'));
     }
   );
 
-  registerTool(server, 'get_auth_providers', 'List available authentication providers',
+  registerTool(server, 'get_auth_providers', 'List all authentication providers configured for the organisation; use alongside `get_auth_session` and `get_auth_settings` to audit org-wide auth state.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/auth/providers'));
     }
   );
 
-  registerTool(server, 'get_auth_settings', 'Get authentication settings',
+  registerTool(server, 'get_auth_settings', 'Fetch global authentication settings for the organisation; complement with `get_auth_session` and `get_auth_providers` for a complete auth overview.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/auth/settings'));
     }
   );
 
-  registerTool(server, 'create_oidc_provider', 'Create a new OIDC authentication provider',
+  registerTool(server, 'create_oidc_provider', 'Create a new OIDC authentication provider; use `get_oidc_provider` to inspect it and `test_oidc_provider` to validate connectivity before going live.',
     { config: z.record(z.string(), z.unknown()).describe('OIDC provider configuration') },
     async ({ config }) => {
       return jsonResponse(await client.post('/api/auth/oidc', config));
     }
   );
 
-  registerTool(server, 'get_oidc_provider', 'Get details of an OIDC provider',
+  registerTool(server, 'get_oidc_provider', 'Retrieve configuration details of an existing OIDC provider; run `test_oidc_provider` afterwards to verify the connection, or `create_oidc_provider` to add a new one.',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
       return jsonResponse(await client.get(`/api/auth/oidc/${encodePath(providerId)}`));
     }
   );
 
-  registerTool(server, 'test_oidc_provider', 'Test an OIDC provider connection',
+  registerTool(server, 'test_oidc_provider', 'Test connectivity for an OIDC provider to confirm it is reachable and correctly configured; pair with `create_oidc_provider` or `get_oidc_provider` in the setup workflow.',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
       return jsonResponse(await client.post(`/api/auth/oidc/${encodePath(providerId)}/test`));
     }
   );
 
-  registerTool(server, 'initiate_oidc_login', 'Initiate an OIDC login flow',
+  registerTool(server, 'initiate_oidc_login', 'Start the OAuth 2.0 / OIDC login flow for a configured provider, returning the redirect URL; call `test_oidc_provider` first to ensure the provider is reachable.',
     { providerId: z.number().describe('OIDC provider ID') },
     async ({ providerId }) => {
       return jsonResponse(await client.post(`/api/auth/oidc/${encodePath(providerId)}/initiate`));
     }
   );
 
-  registerTool(server, 'create_ldap_provider', 'Create a new LDAP authentication provider',
+  registerTool(server, 'create_ldap_provider', 'Create a new LDAP authentication provider; use `get_ldap_provider` to inspect the result and `test_ldap_provider` to validate the directory connection.',
     { config: z.record(z.string(), z.unknown()).describe('LDAP provider configuration') },
     async ({ config }) => {
       return jsonResponse(await client.post('/api/auth/ldap', config));
     }
   );
 
-  registerTool(server, 'get_ldap_provider', 'Get details of a LDAP provider',
+  registerTool(server, 'get_ldap_provider', 'Retrieve configuration details for an existing LDAP provider; use `test_ldap_provider` to verify connectivity or `create_ldap_provider` to register a new directory.',
     { providerId: z.number().describe('LDAP provider ID') },
     async ({ providerId }) => {
       return jsonResponse(await client.get(`/api/auth/ldap/${encodePath(providerId)}`));
     }
   );
 
-  registerTool(server, 'test_ldap_provider', 'Test a LDAP provider connection',
+  registerTool(server, 'test_ldap_provider', 'Test the LDAP directory connection for a configured provider to confirm bind credentials and reachability; pair with `create_ldap_provider` or `get_ldap_provider` in the setup workflow.',
     { providerId: z.number().describe('LDAP provider ID') },
     async ({ providerId }) => {
       return jsonResponse(await client.post(`/api/auth/ldap/${encodePath(providerId)}/test`));
@@ -82,14 +82,14 @@ export function registerAuthTools(server: McpServer, client: DockhandClient): vo
 
   // --- Hawser Token Management ---
 
-  registerTool(server, 'list_hawser_tokens', 'List all Hawser agent tokens',
+  registerTool(server, 'list_hawser_tokens', 'List all Hawser agent tokens across environments; use `create_hawser_token` to add a new token or `revoke_hawser_token` to permanently remove one.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/hawser/tokens'));
     }
   );
 
-  registerTool(server, 'create_hawser_token', 'Create a new Hawser agent token for an environment',
+  registerTool(server, 'create_hawser_token', 'Create a new Hawser agent token scoped to a specific environment; use `list_hawser_tokens` to audit existing tokens or `revoke_hawser_token` to remove one.',
     {
       name: z.string().describe('Token name'),
       environmentId: z.number().describe('Environment ID to associate'),
@@ -102,7 +102,7 @@ export function registerAuthTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'revoke_hawser_token', 'Revoke (delete) a Hawser agent token',
+  registerTool(server, 'revoke_hawser_token', 'Permanently revoke and delete a Hawser agent token, immediately disabling any agent using it; use `list_hawser_tokens` to find the token ID before revoking.',
     { tokenId: z.string().describe('Token ID to revoke') },
     async ({ tokenId }) => {
       return jsonResponse(await client.delete('/api/hawser/tokens', { id: tokenId }));
@@ -110,7 +110,7 @@ export function registerAuthTools(server: McpServer, client: DockhandClient): vo
   );
 
   // Logout (session cleanup)
-  registerTool(server, 'logout', 'Logout and invalidate the current session',
+  registerTool(server, 'logout', 'Log out the current user and invalidate the active session token on the server.',
     {},
     async () => {
       return jsonResponse(await client.post('/api/auth/logout', {}));

--- a/src/tools/auto-update.ts
+++ b/src/tools/auto-update.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerAutoUpdateTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'get_auto_update_settings', 'Get auto-update settings for all containers',
+  registerTool(server, 'get_auto_update_settings', 'Retrieve environment-wide auto-update defaults that apply to all containers in an environment. Returns the global policy configuration used when no per-container override is set; contrast with `get_container_auto_update` (per-container read) and `set_container_auto_update` (per-container write). To see which containers actually have newer images available, use `check_container_updates`; for the pre-built list of containers already discovered as outdated, use `get_pending_updates`.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/auto-update', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_container_auto_update', 'Get auto-update settings for a specific container',
+  registerTool(server, 'get_container_auto_update', 'Read the per-container auto-update policy override for a single container, which takes precedence over the environment-wide defaults returned by `get_auto_update_settings`. Use `set_container_auto_update` to change this per-container policy. To check whether a newer image is actually available in the registry right now, call `check_container_updates`; to see all containers already flagged as outdated, use `get_pending_updates`.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerName: z.string().describe('Container name'),
@@ -27,7 +27,7 @@ export function registerAutoUpdateTools(server: McpServer, client: DockhandClien
     }
   );
 
-  registerTool(server, 'set_container_auto_update', 'Set auto-update policy for a container (never, any, critical-high, critical, more-than-current)',
+  registerTool(server, 'set_container_auto_update', 'Write a per-container auto-update policy override (never, any, critical-high, critical, or more-than-current), replacing the environment-wide defaults from `get_auto_update_settings`. Read the current per-container setting with `get_container_auto_update` before changing it. After setting the policy, use `check_container_updates` to trigger an immediate registry check or `get_pending_updates` to review containers already queued for update.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerName: z.string().describe('Container name'),

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerContainerTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_containers', 'List all containers in a Dockhand environment',
+  registerTool(server, 'list_containers', 'List all containers in a Dockhand environment, returning summary fields for every container; use `get_container` for a single container\'s details or `inspect_container` for the full low-level Docker JSON.',
     { environmentId: z.number().describe('Environment ID (required)') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/containers', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_container', 'Get details of a specific container',
+  registerTool(server, 'get_container', 'Retrieve the Dockhand summary record for a single container by ID, including status and image fields; use `inspect_container` for the full raw Docker-inspect JSON or `list_containers` to enumerate all containers.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -27,7 +27,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'inspect_container', 'Docker inspect a container (full low-level details)',
+  registerTool(server, 'inspect_container', 'Return the full Docker-inspect JSON for a container (mounts, network settings, host config, and all low-level fields); contrast with `get_container` which returns only the Dockhand summary, or `get_container_stats` for live CPU and memory metrics.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -37,7 +37,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_logs', 'Get logs of a container',
+  registerTool(server, 'get_container_logs', 'Fetch the stdout/stderr log tail from a single container, controlled by the optional `tail` line count; use `get_merged_logs` to interleave logs from multiple containers, or `get_container_top` to see the live process list instead.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -52,7 +52,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_stats', 'Get resource usage statistics of a container',
+  registerTool(server, 'get_container_stats', 'Retrieve live CPU, memory, network I/O, and block I/O resource statistics for a single container; use `get_containers_stats` to get an aggregated snapshot across all containers, or `inspect_container` for full Docker-inspect data.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -62,7 +62,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_top', 'Get running processes inside a container',
+  registerTool(server, 'get_container_top', 'Return the live process table (like `docker top`) for a single container, showing PIDs, CPU, and command lines; use `get_container_stats` for resource metrics or `get_container_logs` for log output.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -72,7 +72,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'start_container', 'Start a stopped container',
+  registerTool(server, 'start_container', 'Start a stopped or created container, resuming it from its current state; pair with `stop_container` to stop it again, or use `restart_container` to stop and start in one call.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -82,7 +82,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'stop_container', 'Stop a running container',
+  registerTool(server, 'stop_container', 'Stop a running container by sending SIGTERM followed by SIGKILL after a grace period; use `start_container` to restart it, `pause_container` to freeze without stopping, or `restart_container` to stop and start in one call.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -92,7 +92,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'restart_container', 'Restart a container',
+  registerTool(server, 'restart_container', 'Restart a container by stopping it and then starting it again in a single operation; use `stop_container` / `start_container` separately for finer control, or `pause_container` / `unpause_container` for a non-destructive freeze.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -102,7 +102,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'pause_container', 'Pause a running container',
+  registerTool(server, 'pause_container', 'Freeze all processes in a running container using cgroups freezer without stopping it; use `unpause_container` to resume, or `stop_container` to fully stop instead.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -112,7 +112,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'unpause_container', 'Unpause a paused container',
+  registerTool(server, 'unpause_container', 'Resume all processes in a container that was frozen by `pause_container`, restoring it to the running state; use `start_container` if the container was stopped rather than paused.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -122,7 +122,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'rename_container', 'Rename a container',
+  registerTool(server, 'rename_container', 'Rename an existing container to a new name without recreating it; use `update_container` to change settings such as image or restart policy, or `create_container` to provision a new container from scratch.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -133,7 +133,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'update_container', 'Update a container (recreate with new settings)',
+  registerTool(server, 'update_container', 'Recreate a single container with updated settings (image, environment, restart policy, etc.) for a specific container ID; use `batch_update_containers` to pull the latest image for multiple containers at once, or `rename_container` to change only the container name.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -144,7 +144,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'create_container', 'Create a new container directly (without Compose)',
+  registerTool(server, 'create_container', 'Create a new standalone container directly without a Compose file, accepting image, ports, volumes, environment variables, and restart policy; use `start_container` afterwards to start it, or `update_container` to modify an existing container.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Container name'),
@@ -173,7 +173,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_shells', 'Get available shells inside a container',
+  registerTool(server, 'get_container_shells', 'Enumerate the shell executables available inside a container (e.g., bash, sh, ash) that can be used to open an interactive terminal; complement with `get_container_top` to inspect running processes or `get_container_logs` to read log output.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -185,7 +185,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
 
   // --- Container Files ---
 
-  registerTool(server, 'list_container_files', 'List files inside a container at a given path',
+  registerTool(server, 'list_container_files', 'List the files and directories inside a container at a given path, defaulting to /; use `get_container_file_content` to read a file\'s content, `create_container_file` to write a new file, or `download_container_file` to retrieve a file as base64.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -199,7 +199,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_file_content', 'Read file content inside a container',
+  registerTool(server, 'get_container_file_content', 'Read and return the text content of a file at the specified path inside a container; use `list_container_files` to browse the directory tree first, `create_container_file` to write a file, or `download_container_file` for binary files returned as base64.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -214,7 +214,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'create_container_file', 'Create a file inside a container',
+  registerTool(server, 'create_container_file', 'Write a new file with the supplied content at the specified path inside a container; use `get_container_file_content` to read an existing file before overwriting, `delete_container_file` to remove a file, or `upload_container_file` to upload binary content.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -226,7 +226,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'delete_container_file', 'Delete a file inside a container',
+  registerTool(server, 'delete_container_file', 'Permanently delete a file at the specified path inside a container; use `list_container_files` to confirm the path first, `create_container_file` to recreate it if needed, or `rename_container_file` to move instead of delete.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -237,7 +237,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'rename_container_file', 'Rename a file inside a container',
+  registerTool(server, 'rename_container_file', 'Rename or move a file inside a container by supplying the old and new paths; use `list_container_files` to browse paths, `chmod_container_file` to change permissions, or `delete_container_file` to remove a file entirely.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -249,7 +249,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'chmod_container_file', 'Change file permissions inside a container',
+  registerTool(server, 'chmod_container_file', 'Change the permission mode (e.g., 0755) of a file inside a container; use `list_container_files` to locate the file, `rename_container_file` to move it, or `get_container_file_content` to inspect its content.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
@@ -263,7 +263,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
 
   // --- Container File Download / Upload ---
 
-  registerTool(server, 'download_container_file', 'Download a file from a container. Returns the raw file content as base64-encoded data (the API returns a tar archive which is decoded automatically)',
+  registerTool(server, 'download_container_file', 'Download a file from a container as base64-encoded data (the API returns a tar archive that is decoded automatically); use `get_container_file_content` for plain-text files, `upload_container_file` to send a file into the container, or `list_container_files` to browse available paths.',
     {
       environmentId: z.number().describe('Environment ID (required)'),
       containerId: z.string().describe('Container ID or name'),
@@ -280,7 +280,7 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
 
   // Fix #30 (HIGH): Add encoding parameter for binary file support (PR #23).
   // When encoding is 'base64', content is decoded from base64 before upload.
-  registerTool(server, 'upload_container_file', 'Upload a file to a container. The file content is sent as multipart form data. For binary files, pass content as base64 and set encoding to "base64".',
+  registerTool(server, 'upload_container_file', 'Upload a file into a container as multipart form data; for binary files pass content as base64 and set encoding to "base64". Use `download_container_file` to retrieve a file from the container, `create_container_file` to write plain-text content directly, or `list_container_files` to confirm the target path.',
     {
       environmentId: z.number().describe('Environment ID (required)'),
       containerId: z.string().describe('Container ID or name'),
@@ -307,21 +307,21 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
 
   // --- Global container endpoints ---
 
-  registerTool(server, 'check_container_updates', 'Check all containers for available image updates',
+  registerTool(server, 'check_container_updates', 'Probe the registry now to check all containers for newer image versions and populate the update-detection cache; after this call, use `get_pending_updates` to retrieve the discovered list. For per-container policy, see `get_container_auto_update` and `set_container_auto_update`; for environment-wide defaults, see `get_auto_update_settings`.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/containers/check-updates', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_pending_updates', 'Get containers with pending image updates',
+  registerTool(server, 'get_pending_updates', 'Retrieve the cached list of containers already discovered to have newer images available, without hitting the registry again; call `check_container_updates` first to refresh this cache. To read or change per-container auto-update policy, use `get_container_auto_update` and `set_container_auto_update`; for environment-wide defaults, see `get_auto_update_settings`.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/containers/pending-updates', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'batch_update_containers', 'Batch update multiple containers to their latest images',
+  registerTool(server, 'batch_update_containers', 'Pull the latest images and recreate multiple containers in one operation by supplying an array of container IDs; contrast with `update_container` which targets a single container ID. Use `check_container_updates` to discover which containers have newer images, or `list_batch_operations` to review pending batch history.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerIds: z.array(z.string()).describe('Array of container IDs to update'),
@@ -331,14 +331,14 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_sizes', 'Get disk sizes of all containers',
+  registerTool(server, 'get_container_sizes', 'Return the on-disk size for all containers in an environment, covering both the read-write layer and virtual image size; use `get_container_stats` for live CPU and memory usage of a single container, or `get_containers_stats` for aggregated runtime stats across all containers.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/containers/sizes', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_containers_stats', 'Get aggregated stats for all containers',
+  registerTool(server, 'get_containers_stats', 'Return aggregated CPU, memory, and I/O stats across all containers in an environment in one call; use `get_container_stats` to get detailed metrics for a single container, or `get_container_sizes` for on-disk size data.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/containers/stats', { env: environmentId }));

--- a/src/tools/dashboard.ts
+++ b/src/tools/dashboard.ts
@@ -9,28 +9,28 @@ import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.j
 
 export function registerDashboardTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'get_dashboard_stats', 'Get dashboard statistics (containers, images, volumes, networks overview)',
+  registerTool(server, 'get_dashboard_stats', 'Retrieve read-only counts of containers, images, volumes, and networks for the dashboard overview; use `get_dashboard_preferences` to read layout settings or `set_dashboard_preferences` to change them.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/dashboard/stats'));
     }
   );
 
-  registerTool(server, 'get_dashboard_preferences', 'Get dashboard display preferences',
+  registerTool(server, 'get_dashboard_preferences', 'Read the current dashboard layout and display preferences; use `set_dashboard_preferences` to persist changes or `get_dashboard_stats` to fetch live resource counts.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/dashboard/preferences'));
     }
   );
 
-  registerTool(server, 'set_dashboard_preferences', 'Set dashboard display preferences',
+  registerTool(server, 'set_dashboard_preferences', 'Write updated dashboard layout and display preferences; use `get_dashboard_preferences` to read the current values before overwriting them.',
     { preferences: z.record(z.string(), z.unknown()).describe('Dashboard preferences') },
     async ({ preferences }) => {
       return jsonResponse(await client.post('/api/dashboard/preferences', preferences));
     }
   );
 
-  registerTool(server, 'get_activity_feed', 'Get the activity feed (recent actions and events)',
+  registerTool(server, 'get_activity_feed', 'Retrieve the paginated activity stream of recent actions across all resources; for typed event definitions see `get_activity_events`, for aggregate counts see `get_activity_stats`, and for container-scoped entries see `get_container_activity`.',
     {
       environmentId: z.number().optional().describe('Filter by environment ID'),
     },
@@ -39,28 +39,28 @@ export function registerDashboardTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_container_activity', 'Get container-specific activity feed',
+  registerTool(server, 'get_container_activity', 'Retrieve the container-scoped subset of the activity feed; for the full cross-resource stream use `get_activity_feed`, or use `get_activity_stats` for aggregated counts.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/activity/containers'));
     }
   );
 
-  registerTool(server, 'get_activity_events', 'Get activity events',
+  registerTool(server, 'get_activity_events', 'Retrieve the catalog of available activity event types and their definitions; for the live paginated stream of recent actions use `get_activity_feed`.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/activity/events'));
     }
   );
 
-  registerTool(server, 'get_activity_stats', 'Get activity statistics',
+  registerTool(server, 'get_activity_stats', 'Retrieve aggregated activity statistics such as event counts and summaries; for the full paginated activity stream use `get_activity_feed`.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/activity/stats'));
     }
   );
 
-  registerTool(server, 'get_merged_logs', 'Get merged logs from multiple containers',
+  registerTool(server, 'get_merged_logs', 'Fetch and interleave log lines from multiple containers into a single chronological stream, useful for debugging interactions across containers in the same stack.',
     {
       environmentId: z.number().describe('Environment ID'),
       containers: z.string().describe('Comma-separated container names or IDs'),

--- a/src/tools/dashboard.ts
+++ b/src/tools/dashboard.ts
@@ -60,7 +60,7 @@ export function registerDashboardTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'get_merged_logs', 'Fetch and interleave log lines from multiple containers into a single chronological stream, useful for debugging interactions across containers in the same stack.',
+  registerTool(server, 'get_merged_logs', 'Fetch and interleave log lines from multiple containers into a single chronological stream, useful for debugging interactions across containers in the same stack; use `get_container_logs` to retrieve logs from a single container, or `get_container_top` to inspect live processes.',
     {
       environmentId: z.number().describe('Environment ID'),
       containers: z.string().describe('Comma-separated container names or IDs'),

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -65,21 +65,21 @@ function resolveHostPort(
 
 export function registerEnvironmentTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_environments', 'List all Dockhand environments (Docker hosts)',
+  registerTool(server, 'list_environments', 'List all Dockhand environments (Docker hosts). Use `get_environment` to fetch a single environment, `create_environment` to add one, or `delete_environment` to remove one.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/environments'));
     }
   );
 
-  registerTool(server, 'get_environment', 'Get details of a specific environment',
+  registerTool(server, 'get_environment', 'Retrieve full details of a single Dockhand environment by ID. See `list_environments` for all environments, `update_environment` to modify, or `test_environment` to verify connectivity.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}`));
     }
   );
 
-  registerTool(server, 'create_environment', 'Create a new environment (Docker host). For hawser-standard mode, provide host/port directly or a url that will be parsed into host/port. Edge mode does not require host/port.',
+  registerTool(server, 'create_environment', 'Create a new Dockhand environment (Docker host connection). For hawser-standard mode supply host/port or a URL parsed into host/port; edge mode needs no host. Use `test_environment_connection` to probe connectivity before saving, or `update_environment` to modify later.',
     {
       name: z.string().describe('Environment name'),
       connectionType: z.string().describe('Connection type (e.g. hawser-standard, hawser-edge)'),
@@ -96,7 +96,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
 
   // Fix #30 (HIGH): Accept optional connectionType param to skip redundant GET request.
   // Only fetches environment via GET when connectionType is not provided by the caller.
-  registerTool(server, 'update_environment', 'Update an existing environment. For hawser-standard mode, provide host/port directly or a url that will be parsed. Pass connectionType to avoid an extra GET request.',
+  registerTool(server, 'update_environment', 'Update an existing Dockhand environment (name, host, labels, metrics settings, etc.). For hawser-standard, supply host/port or a URL; pass connectionType to avoid an extra GET. See `create_environment` to add one or `delete_environment` to remove one.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().optional().describe('New name'),
@@ -134,21 +134,21 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'delete_environment', 'Delete an environment',
+  registerTool(server, 'delete_environment', 'Permanently delete a Dockhand environment and remove it from Dockhand. This is irreversible — use `get_environment` to confirm the target before deleting, or `list_environments` to review all registered environments.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.delete(`/api/environments/${encodePath(environmentId)}`));
     }
   );
 
-  registerTool(server, 'test_environment', 'Test connection to an environment',
+  registerTool(server, 'test_environment', 'Test Docker connectivity for an already-saved Dockhand environment by ID; validates that the stored connection config still reaches the host. Use `test_environment_connection` instead to probe a connection before saving, or `detect_docker_socket` to auto-discover the local socket.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/test`));
     }
   );
 
-  registerTool(server, 'test_environment_connection', 'Test a Docker connection without saving an environment. For hawser-standard, provide host/port or a url.',
+  registerTool(server, 'test_environment_connection', 'Probe a Docker connection with supplied parameters without saving an environment — useful for validating credentials before calling `create_environment`. For hawser-standard provide host/port or a URL; contrast with `test_environment` which tests an existing saved environment by ID.',
     {
       connectionType: z.string().describe('Connection type'),
       host: z.string().optional().describe('Docker host IP or hostname (for hawser-standard mode)'),
@@ -162,21 +162,21 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'detect_docker_socket', 'Auto-detect Docker socket on the server',
+  registerTool(server, 'detect_docker_socket', 'Auto-detect the Docker socket path on the Dockhand server — useful when the socket location is unknown before calling `create_environment` or `test_environment_connection`. Returns the discovered socket path for use as socketPath in environment configuration.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/environments/detect-socket'));
     }
   );
 
-  registerTool(server, 'get_environment_timezone', 'Get the timezone of an environment',
+  registerTool(server, 'get_environment_timezone', 'Retrieve the configured timezone string for a Dockhand environment. Use `set_environment_timezone` to change it; see also `get_environment_update_check` and `get_environment_image_prune` for other per-environment settings.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/timezone`));
     }
   );
 
-  registerTool(server, 'set_environment_timezone', 'Set the timezone of an environment',
+  registerTool(server, 'set_environment_timezone', 'Configure the timezone for a Dockhand environment (e.g. Europe/Berlin). Use `get_environment_timezone` to read the current value; see also `set_environment_update_check` and `set_environment_image_prune` for related settings.',
     {
       environmentId: z.number().describe('Environment ID'),
       timezone: z.string().describe('Timezone string (e.g. Europe/Berlin)'),
@@ -186,14 +186,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'get_environment_update_check', 'Get update-check settings of an environment',
+  registerTool(server, 'get_environment_update_check', 'Retrieve the automatic image update-check settings for a Dockhand environment. Use `set_environment_update_check` to change them; see also `get_environment_timezone` and `get_environment_image_prune` for other per-environment settings.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/update-check`));
     }
   );
 
-  registerTool(server, 'set_environment_update_check', 'Set update-check settings of an environment',
+  registerTool(server, 'set_environment_update_check', 'Configure automatic image update-check settings for a Dockhand environment. Use `get_environment_update_check` to read the current values; see also `set_environment_timezone` and `set_environment_image_prune` for related settings.',
     {
       environmentId: z.number().describe('Environment ID'),
       settings: z.record(z.string(), z.unknown()).describe('Update-check settings'),
@@ -203,14 +203,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'get_environment_image_prune', 'Get image prune settings of an environment',
+  registerTool(server, 'get_environment_image_prune', 'Retrieve the image prune settings for a Dockhand environment (schedule and retention policy). Use `set_environment_image_prune` to change them; see also `get_environment_timezone` and `get_environment_update_check` for other per-environment settings.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/image-prune`));
     }
   );
 
-  registerTool(server, 'set_environment_image_prune', 'Set image prune settings of an environment',
+  registerTool(server, 'set_environment_image_prune', 'Configure the image prune policy for a Dockhand environment (schedule and retention). Use `get_environment_image_prune` to read the current settings; see also `set_environment_timezone` and `set_environment_update_check` for related settings.',
     {
       environmentId: z.number().describe('Environment ID'),
       settings: z.record(z.string(), z.unknown()).describe('Image prune settings'),
@@ -220,14 +220,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'list_environment_notifications', 'List notifications configured for an environment',
+  registerTool(server, 'list_environment_notifications', 'List all notification channels configured for a Dockhand environment. Use `create_environment_notification` to add one, `get_environment_notification` to inspect a single entry, or `delete_environment_notification` to remove one.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}/notifications`));
     }
   );
 
-  registerTool(server, 'create_environment_notification', 'Create a notification for an environment',
+  registerTool(server, 'create_environment_notification', 'Add a new notification channel to a Dockhand environment using the supplied configuration. Use `list_environment_notifications` to see existing entries, `get_environment_notification` to inspect one, or `delete_environment_notification` to remove one.',
     {
       environmentId: z.number().describe('Environment ID'),
       config: z.record(z.string(), z.unknown()).describe('Notification configuration'),
@@ -237,7 +237,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'get_environment_notification', 'Get a specific notification of an environment',
+  registerTool(server, 'get_environment_notification', 'Retrieve details of a single notification channel for a Dockhand environment by notification ID. Use `list_environment_notifications` to discover IDs, `create_environment_notification` to add one, or `delete_environment_notification` to remove one.',
     {
       environmentId: z.number().describe('Environment ID'),
       notificationId: z.number().describe('Notification ID'),
@@ -247,7 +247,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'delete_environment_notification', 'Delete a notification from an environment',
+  registerTool(server, 'delete_environment_notification', 'Permanently delete a notification channel from a Dockhand environment — this action cannot be undone. Use `list_environment_notifications` or `get_environment_notification` to confirm the target before removing, or `create_environment_notification` to add a replacement.',
     {
       environmentId: z.number().describe('Environment ID'),
       notificationId: z.number().describe('Notification ID'),

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -10,49 +10,49 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerGitStackTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_git_stacks', 'List all Git-based stacks',
+  registerTool(server, 'list_git_stacks', 'List all Git-based stacks registered in Dockhand; use `get_git_stack` to retrieve details for a specific entry.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/git/stacks'));
     }
   );
 
-  registerTool(server, 'get_git_stack', 'Get details of a specific Git stack',
+  registerTool(server, 'get_git_stack', 'Retrieve configuration and status for a single Git-based stack; use `list_git_stacks` to discover available stack IDs.',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
       return jsonResponse(await client.get(`/api/git/stacks/${encodePath(stackId)}`));
     }
   );
 
-  registerTool(server, 'deploy_git_stack', 'Deploy a Git-based stack (pulls latest and deploys via SSE)',
+  registerTool(server, 'deploy_git_stack', 'Perform a full deploy of a Git-based stack — pulls the latest commit and redeploys all services via a streaming SSE pipeline; use `sync_git_stack` instead to pull remote changes without triggering a full redeploy.',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
       return jsonResponse(await client.postSSE(`/api/git/stacks/${encodePath(stackId)}/deploy`));
     }
   );
 
-  registerTool(server, 'sync_git_stack', 'Synchronize a Git-based stack with its remote repository',
+  registerTool(server, 'sync_git_stack', 'Pull the latest remote changes for a Git-based stack without performing a full redeploy; use `deploy_git_stack` when a full redeploy is required.',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
       return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/sync`));
     }
   );
 
-  registerTool(server, 'test_git_stack', 'Test the Git connection for a stack',
+  registerTool(server, 'test_git_stack', 'Verify that a saved Git-based stack can reach its remote repository; use `get_git_stack` to inspect stack configuration before running this check.',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
       return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/test`));
     }
   );
 
-  registerTool(server, 'get_git_stack_env_files', 'Get environment files for a Git-based stack',
+  registerTool(server, 'get_git_stack_env_files', 'Retrieve the environment file content associated with a Git-based stack; use `get_git_stack` to confirm the stack exists before fetching its env files.',
     { stackId: z.number().describe('Git stack ID') },
     async ({ stackId }) => {
       return jsonResponse(await client.get(`/api/git/stacks/${encodePath(stackId)}/env-files`));
     }
   );
 
-  registerTool(server, 'trigger_git_webhook', 'Trigger a webhook for a Git-based stack (manual deploy trigger)',
+  registerTool(server, 'trigger_git_webhook', 'Fire the incoming webhook for a Git-based stack to trigger a manual deploy; use `get_git_webhook` to inspect webhook details before firing.',
     {
       stackId: z.number().describe('Git stack ID'),
       token: z.string().optional().describe('Webhook secret token'),
@@ -62,7 +62,7 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_git_webhook', 'Get webhook details for a Git stack',
+  registerTool(server, 'get_git_webhook', 'Retrieve the webhook URL and secret for a Git stack; use `trigger_git_webhook` to fire a manual deploy via this webhook.',
     { webhookId: z.number().describe('Webhook ID') },
     async ({ webhookId }) => {
       return jsonResponse(await client.get(`/api/git/webhook/${encodePath(webhookId)}`));
@@ -71,14 +71,14 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
 
   // --- Git Credentials ---
 
-  registerTool(server, 'list_git_credentials', 'List all stored Git credentials',
+  registerTool(server, 'list_git_credentials', 'List all stored Git credentials available for authentication; use `get_git_credential` to fetch details for a specific entry.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/git/credentials'));
     }
   );
 
-  registerTool(server, 'create_git_credential', 'Create a new Git credential',
+  registerTool(server, 'create_git_credential', 'Create a new Git credential (SSH key, personal access token, or username/password); use `list_git_credentials` to verify the entry was saved.',
     {
       name: z.string().describe('Credential name'),
       type: z.string().describe('Credential type (e.g. ssh, token, password)'),
@@ -99,14 +99,14 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_git_credential', 'Get details of a Git credential',
+  registerTool(server, 'get_git_credential', 'Retrieve configuration details for a single Git credential; use `list_git_credentials` to discover available credential IDs.',
     { credentialId: z.number().describe('Credential ID') },
     async ({ credentialId }) => {
       return jsonResponse(await client.get(`/api/git/credentials/${encodePath(credentialId)}`));
     }
   );
 
-  registerTool(server, 'update_git_credential', 'Update a Git credential',
+  registerTool(server, 'update_git_credential', 'Update an existing Git credential; use `get_git_credential` to read current values before modifying, and `delete_git_credential` to remove it entirely.',
     {
       credentialId: z.number().describe('Credential ID'),
       name: z.string().optional().describe('Updated credential name'),
@@ -130,7 +130,7 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'delete_git_credential', 'Delete a Git credential',
+  registerTool(server, 'delete_git_credential', 'Permanently delete a Git credential; use `list_git_credentials` to confirm the ID before deleting, and `update_git_credential` for non-destructive edits.',
     { credentialId: z.number().describe('Credential ID') },
     async ({ credentialId }) => {
       return jsonResponse(await client.delete(`/api/git/credentials/${encodePath(credentialId)}`));
@@ -139,14 +139,14 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
 
   // --- Git Repositories ---
 
-  registerTool(server, 'list_git_repositories', 'List all Git repositories',
+  registerTool(server, 'list_git_repositories', 'List all Git repository configurations registered in Dockhand; use `get_git_repository` to retrieve details for a specific entry.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/git/repositories'));
     }
   );
 
-  registerTool(server, 'create_git_repository', 'Create a new Git repository configuration',
+  registerTool(server, 'create_git_repository', 'Register a new Git repository configuration with a URL, branch, and optional credential; use `list_git_repositories` to verify the entry and `deploy_git_repository` to trigger the first deploy.',
     {
       url: z.string().describe('Git repository URL (HTTPS or SSH)'),
       branch: z.string().optional().describe('Branch to track (default: main or master)'),
@@ -168,35 +168,35 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_git_repository', 'Get details of a Git repository',
+  registerTool(server, 'get_git_repository', 'Retrieve configuration details for a saved Git repository; use `list_git_repositories` to discover available repository IDs.',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
       return jsonResponse(await client.get(`/api/git/repositories/${encodePath(repositoryId)}`));
     }
   );
 
-  registerTool(server, 'deploy_git_repository', 'Deploy a Git repository',
+  registerTool(server, 'deploy_git_repository', 'Perform a full deploy of a saved Git repository — pulls the latest commit and redeploys all services via a streaming SSE pipeline; use `sync_git_repository` to pull remote changes without triggering a full redeploy.',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
       return jsonResponse(await client.postSSE(`/api/git/repositories/${encodePath(repositoryId)}/deploy`));
     }
   );
 
-  registerTool(server, 'sync_git_repository', 'Synchronize a Git repository',
+  registerTool(server, 'sync_git_repository', 'Pull the latest remote changes for a saved Git repository without performing a full redeploy; use `deploy_git_repository` when a full redeploy is required.',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
       return jsonResponse(await client.post(`/api/git/repositories/${encodePath(repositoryId)}/sync`));
     }
   );
 
-  registerTool(server, 'test_git_repository', 'Test connection to a Git repository',
+  registerTool(server, 'test_git_repository', 'Test connectivity for a saved Git repository using its stored configuration; use `test_git_repository_connection` to probe an arbitrary URL before saving a repository.',
     { repositoryId: z.number().describe('Repository ID') },
     async ({ repositoryId }) => {
       return jsonResponse(await client.post(`/api/git/repositories/${encodePath(repositoryId)}/test`));
     }
   );
 
-  registerTool(server, 'test_git_repository_connection', 'Test a Git connection without saving a repository',
+  registerTool(server, 'test_git_repository_connection', 'Probe an arbitrary Git URL and credential without requiring a saved repository; use `test_git_repository` to verify connectivity for an already-registered repository.',
     {
       url: z.string().describe('Git repository URL'),
       credentialId: z.number().optional().describe('Credential ID to use'),
@@ -208,7 +208,7 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'request_git_preview_env', 'Get preview environment for Git deployments',
+  registerTool(server, 'request_git_preview_env', 'Request a transient preview environment configuration for Git-based deployments; complements `deploy_git_stack` and `deploy_git_repository` for ephemeral testing workflows.',
     {},
     async () => {
       return jsonResponse(await client.post('/api/git/preview-env'));

--- a/src/tools/images.ts
+++ b/src/tools/images.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerImageTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_images', 'List all Docker images in an environment',
+  registerTool(server, 'list_images', 'List all Docker images available in an environment; use `pull_image` to fetch new images from a registry or `remove_image` to delete unused ones.',
     { environmentId: z.number().describe('Environment ID (required)') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/images', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_image_history', 'Get the layer history of a Docker image',
+  registerTool(server, 'get_image_history', 'Retrieve the layer-by-layer build history of a Docker image; for vulnerability findings use `scan_image`, and use `list_images` to look up valid image IDs first.',
     {
       environmentId: z.number().describe('Environment ID'),
       imageId: z.string().describe('Image ID'),
@@ -27,7 +27,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'tag_image', 'Add a tag to a Docker image',
+  registerTool(server, 'tag_image', 'Add a new tag to a local Docker image (local metadata mutation only); to upload the tagged image to a registry use `push_image`, or use `remove_image` to delete the image entirely.',
     {
       environmentId: z.number().describe('Environment ID'),
       imageId: z.string().describe('Image ID'),
@@ -39,7 +39,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'remove_image', 'Remove a Docker image',
+  registerTool(server, 'remove_image', 'Permanently delete a Docker image from the environment (destructive — image is removed and cannot be recovered locally); use `list_images` to confirm the target ID before calling, or `tag_image` to rename instead.',
     {
       environmentId: z.number().describe('Environment ID'),
       imageId: z.string().describe('Image ID'),
@@ -49,7 +49,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'pull_image', 'Pull a Docker image from a registry',
+  registerTool(server, 'pull_image', 'Pull a Docker image from a remote registry into the environment (inbound registry transfer); to send an image back out use `push_image`, or use `list_images` to verify the image arrived.',
     {
       environmentId: z.number().describe('Environment ID'),
       image: z.string().describe('Image name with tag (e.g. nginx:latest)'),
@@ -59,7 +59,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'push_image', 'Push a Docker image to a registry',
+  registerTool(server, 'push_image', 'Push a locally tagged Docker image to a remote registry (outbound registry transfer); to apply or change a tag before pushing use `tag_image`, or use `pull_image` for the opposite inbound direction.',
     {
       environmentId: z.number().describe('Environment ID'),
       image: z.string().describe('Image name with tag'),
@@ -69,7 +69,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'scan_image', 'Run a vulnerability scan on a Docker image (Trivy/Grype)',
+  registerTool(server, 'scan_image', 'Run a vulnerability scan (CVE analysis via Trivy/Grype) against a Docker image; for layer provenance use `get_image_history` instead, and use `export_image` to extract the image filesystem for offline analysis.',
     {
       environmentId: z.number().describe('Environment ID'),
       imageId: z.string().describe('Image ID to scan'),
@@ -79,7 +79,7 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'export_image', 'Export a Docker image as a tarball',
+  registerTool(server, 'export_image', 'Export a Docker image as a tar archive (filesystem extraction to disk); for vulnerability analysis use `scan_image` instead, and use `pull_image` if the image is not yet present locally.',
     {
       environmentId: z.number().describe('Environment ID'),
       imageId: z.string().describe('Image ID'),

--- a/src/tools/networks.ts
+++ b/src/tools/networks.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerNetworkTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_networks', 'List all Docker networks in an environment',
+  registerTool(server, 'list_networks', 'List all Docker networks in an environment; use `get_network` for summary details on a specific network or `inspect_network` for full low-level inspection.',
     { environmentId: z.number().describe('Environment ID (required)') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/networks', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_network', 'Get details of a specific Docker network',
+  registerTool(server, 'get_network', 'Retrieve summary details (name, driver, IPAM, containers) for a specific Docker network; for the full raw Docker-inspect payload use `inspect_network`.',
     {
       environmentId: z.number().describe('Environment ID'),
       networkId: z.string().describe('Network ID'),
@@ -27,7 +27,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
     }
   );
 
-  registerTool(server, 'inspect_network', 'Inspect a Docker network (full low-level details)',
+  registerTool(server, 'inspect_network', 'Fetch the full low-level Docker-inspect JSON for a network, including IPAM config and all container endpoints; use `get_network` for a lighter summary view.',
     {
       environmentId: z.number().describe('Environment ID'),
       networkId: z.string().describe('Network ID'),
@@ -37,7 +37,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
     }
   );
 
-  registerTool(server, 'create_network', 'Create a new Docker network',
+  registerTool(server, 'create_network', 'Create a new Docker network with the specified driver, IPAM settings, and labels; use `remove_network` to delete it when no longer needed.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Network name'),
@@ -61,7 +61,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
     }
   );
 
-  registerTool(server, 'remove_network', 'Remove a Docker network',
+  registerTool(server, 'remove_network', 'Permanently remove a Docker network; the network must have no active container connections — use `disconnect_container_from_network` first if needed.',
     {
       environmentId: z.number().describe('Environment ID'),
       networkId: z.string().describe('Network ID'),
@@ -71,7 +71,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
     }
   );
 
-  registerTool(server, 'connect_container_to_network', 'Connect a container to a Docker network',
+  registerTool(server, 'connect_container_to_network', 'Attach a running container to a Docker network so it can communicate with other containers on that network; reverse with `disconnect_container_from_network`.',
     {
       environmentId: z.number().describe('Environment ID'),
       networkId: z.string().describe('Network ID'),
@@ -82,7 +82,7 @@ export function registerNetworkTools(server: McpServer, client: DockhandClient):
     }
   );
 
-  registerTool(server, 'disconnect_container_from_network', 'Disconnect a container from a Docker network',
+  registerTool(server, 'disconnect_container_from_network', 'Disconnect a container from a Docker network, removing its network access and aliases on that network; use `connect_container_to_network` to re-attach.',
     {
       environmentId: z.number().describe('Environment ID'),
       networkId: z.string().describe('Network ID'),

--- a/src/tools/notifications.ts
+++ b/src/tools/notifications.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerNotificationTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_notifications', 'List all notification configurations',
+  registerTool(server, 'list_notifications', 'List all saved notification configurations; use `get_notification` to fetch a single entry by ID.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/notifications'));
     }
   );
 
-  registerTool(server, 'create_notification', 'Create a new notification configuration',
+  registerTool(server, 'create_notification', 'Create and persist a new notification configuration; use `test_notification` to verify it after saving.',
     {
       config: z.record(z.string(), z.unknown()).describe('Notification configuration (name, type, settings)'),
     },
@@ -26,14 +26,14 @@ export function registerNotificationTools(server: McpServer, client: DockhandCli
     }
   );
 
-  registerTool(server, 'get_notification', 'Get details of a notification configuration',
+  registerTool(server, 'get_notification', 'Retrieve full details of a single saved notification configuration by ID; use `list_notifications` to discover IDs.',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
       return jsonResponse(await client.get(`/api/notifications/${encodePath(notificationId)}`));
     }
   );
 
-  registerTool(server, 'update_notification', 'Update a notification configuration',
+  registerTool(server, 'update_notification', 'Update an existing saved notification configuration by ID; use `get_notification` to inspect the current values first.',
     {
       notificationId: z.number().describe('Notification ID'),
       config: z.record(z.string(), z.unknown()).describe('Updated notification configuration'),
@@ -43,21 +43,21 @@ export function registerNotificationTools(server: McpServer, client: DockhandCli
     }
   );
 
-  registerTool(server, 'delete_notification', 'Delete a notification configuration',
+  registerTool(server, 'delete_notification', 'Permanently delete a saved notification configuration by ID (destructive); use `list_notifications` to confirm the ID before deleting.',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
       return jsonResponse(await client.delete(`/api/notifications/${encodePath(notificationId)}`));
     }
   );
 
-  registerTool(server, 'test_notification', 'Send a test notification using a saved configuration',
+  registerTool(server, 'test_notification', 'Fire a test message through a saved notification configuration identified by ID; use `test_notification_config` to test an unsaved config blob instead.',
     { notificationId: z.number().describe('Notification ID') },
     async ({ notificationId }) => {
       return jsonResponse(await client.post(`/api/notifications/${encodePath(notificationId)}/test`));
     }
   );
 
-  registerTool(server, 'test_notification_config', 'Send a test notification without saving the configuration first',
+  registerTool(server, 'test_notification_config', 'Send a test message using a raw config blob without saving it first; use `test_notification` to test an already-saved configuration by ID.',
     {
       config: z.record(z.string(), z.unknown()).describe('Notification configuration to test'),
     },
@@ -66,7 +66,7 @@ export function registerNotificationTools(server: McpServer, client: DockhandCli
     }
   );
 
-  registerTool(server, 'trigger_test_notification', 'Trigger a test notification event',
+  registerTool(server, 'trigger_test_notification', 'Fire the standard test-event payload to all configured notification channels; use `test_notification` to target a single saved configuration instead.',
     {},
     async () => {
       return jsonResponse(await client.post('/api/notifications/trigger-test'));

--- a/src/tools/registries.ts
+++ b/src/tools/registries.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerRegistryTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_registries', 'List all configured Docker registries',
+  registerTool(server, 'list_registries', 'List all configured Docker registries; use `get_registry` to fetch a single entry or `create_registry` to add one.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/registries'));
     }
   );
 
-  registerTool(server, 'create_registry', 'Add a new Docker registry',
+  registerTool(server, 'create_registry', 'Add a new Docker registry with credentials; verify the result with `get_registry` or browse all via `list_registries`.',
     {
       config: z.record(z.string(), z.unknown()).describe('Registry configuration (name, url, username, password, etc.)'),
     },
@@ -26,14 +26,14 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_registry', 'Get details of a Docker registry',
+  registerTool(server, 'get_registry', 'Get full details of a single Docker registry by ID; see `list_registries` for all IDs or `update_registry` to modify.',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
       return jsonResponse(await client.get(`/api/registries/${encodePath(registryId)}`));
     }
   );
 
-  registerTool(server, 'update_registry', 'Update a Docker registry configuration',
+  registerTool(server, 'update_registry', 'Update an existing Docker registry configuration (URL, credentials, name); use `get_registry` to read the current state first.',
     {
       registryId: z.number().describe('Registry ID'),
       config: z.record(z.string(), z.unknown()).describe('Updated registry configuration'),
@@ -43,14 +43,14 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'delete_registry', 'Delete a Docker registry',
+  registerTool(server, 'delete_registry', 'Permanently delete a Docker registry configuration; verify the ID with `get_registry` before removing.',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
       return jsonResponse(await client.delete(`/api/registries/${encodePath(registryId)}`));
     }
   );
 
-  registerTool(server, 'set_default_registry', 'Set a registry as the default',
+  registerTool(server, 'set_default_registry', 'Mark a registry as the default so it is used when no explicit registry is specified; see `list_registries` for available IDs.',
     { registryId: z.number().describe('Registry ID') },
     async ({ registryId }) => {
       return jsonResponse(await client.post(`/api/registries/${encodePath(registryId)}/default`));
@@ -59,7 +59,7 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
 
   // --- Registry Search ---
 
-  registerTool(server, 'search_registry', 'Search a Docker registry for images',
+  registerTool(server, 'search_registry', 'Search the configured registry for images matching a query; use `get_registry_catalog` for a full image list or `get_registry_tags` for available tags.',
     {
       query: z.string().describe('Search query'),
       environmentId: z.number().optional().describe('Environment ID'),
@@ -69,7 +69,7 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_registry_catalog', 'Get the catalog of a Docker registry',
+  registerTool(server, 'get_registry_catalog', 'Retrieve the full image catalog of the configured Docker registry; use `search_registry` for filtered results or `get_registry_tags` for image tags.',
     {
       environmentId: z.number().optional().describe('Environment ID'),
     },
@@ -78,7 +78,7 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_registry_tags', 'Get available tags for an image in a registry',
+  registerTool(server, 'get_registry_tags', 'List all available tags for a specific image in the configured registry; use `get_registry_catalog` to discover image names or `search_registry` to search.',
     {
       image: z.string().describe('Image name'),
       environmentId: z.number().optional().describe('Environment ID'),

--- a/src/tools/schedules.ts
+++ b/src/tools/schedules.ts
@@ -10,21 +10,21 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerScheduleTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_schedules', 'List all scheduled tasks',
+  registerTool(server, 'list_schedules', 'List all user-defined scheduled tasks; use `get_schedule_settings` to read env-level config or `get_schedule_executions` to browse run history.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/schedules'));
     }
   );
 
-  registerTool(server, 'get_schedule_settings', 'Get schedule settings',
+  registerTool(server, 'get_schedule_settings', 'Read the environment-scoped schedule configuration; use `update_schedule_settings` to persist changes or `list_schedules` to enumerate defined schedules.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/schedules/settings'));
     }
   );
 
-  registerTool(server, 'update_schedule_settings', 'Update schedule settings',
+  registerTool(server, 'update_schedule_settings', 'Write environment-scoped schedule configuration; use `get_schedule_settings` to read the current values before updating.',
     {
       settings: z.record(z.string(), z.unknown()).describe('Schedule settings to update'),
     },
@@ -33,21 +33,21 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_schedule_executions', 'Get schedule execution history',
+  registerTool(server, 'get_schedule_executions', 'Retrieve the full execution history list for all schedules; use `get_schedule_execution` to fetch detail for a single run by ID.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/schedules/executions'));
     }
   );
 
-  registerTool(server, 'get_schedule_execution', 'Get details of a specific schedule execution',
+  registerTool(server, 'get_schedule_execution', 'Fetch the detail record for one schedule execution by ID; use `get_schedule_executions` to list all runs and find the relevant ID.',
     { executionId: z.number().describe('Execution ID') },
     async ({ executionId }) => {
       return jsonResponse(await client.get(`/api/schedules/executions/${encodePath(executionId)}`));
     }
   );
 
-  registerTool(server, 'run_schedule_now', 'Run a schedule immediately',
+  registerTool(server, 'run_schedule_now', 'Trigger a one-shot manual execution of a user-defined schedule immediately, bypassing its timer; use `toggle_schedule` to permanently enable or disable it.',
     {
       type: z.string().describe('Schedule type'),
       scheduleId: z.number().describe('Schedule ID'),
@@ -57,7 +57,7 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'toggle_schedule', 'Enable or disable a schedule',
+  registerTool(server, 'toggle_schedule', 'Enable or disable a user-defined schedule; use `toggle_system_schedule` for built-in system schedules or `run_schedule_now` for a one-shot manual trigger.',
     {
       type: z.string().describe('Schedule type'),
       scheduleId: z.number().describe('Schedule ID'),
@@ -67,7 +67,7 @@ export function registerScheduleTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'toggle_system_schedule', 'Enable or disable a system schedule',
+  registerTool(server, 'toggle_system_schedule', 'Enable or disable a built-in system schedule (internal/platform-level); use `toggle_schedule` for user-defined schedules instead.',
     { scheduleId: z.number().describe('System schedule ID') },
     async ({ scheduleId }) => {
       return jsonResponse(await client.post(`/api/schedules/system/${encodePath(scheduleId)}/toggle`));

--- a/src/tools/schedules.ts
+++ b/src/tools/schedules.ts
@@ -10,21 +10,21 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerScheduleTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_schedules', 'List all user-defined scheduled tasks; use `get_schedule_settings` to read env-level config or `get_schedule_executions` to browse run history.',
+  registerTool(server, 'list_schedules', 'List all user-defined scheduled tasks; use `get_schedule_settings` for the global schedule configuration or `get_schedule_executions` to browse run history.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/schedules'));
     }
   );
 
-  registerTool(server, 'get_schedule_settings', 'Read the environment-scoped schedule configuration; use `update_schedule_settings` to persist changes or `list_schedules` to enumerate defined schedules.',
+  registerTool(server, 'get_schedule_settings', 'Read the global Dockhand schedule configuration (`GET /api/schedules/settings`, instance-wide — not per-environment); use `update_schedule_settings` to persist changes or `list_schedules` to enumerate defined schedules.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/schedules/settings'));
     }
   );
 
-  registerTool(server, 'update_schedule_settings', 'Write environment-scoped schedule configuration; use `get_schedule_settings` to read the current values before updating.',
+  registerTool(server, 'update_schedule_settings', 'Write the global Dockhand schedule configuration (`PUT /api/schedules/settings`, instance-wide — not per-environment); use `get_schedule_settings` to read the current values before updating.',
     {
       settings: z.record(z.string(), z.unknown()).describe('Schedule settings to update'),
     },

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerStackTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_stacks', 'List all Docker Compose stacks in an environment',
+  registerTool(server, 'list_stacks', 'List all Docker Compose stacks in an environment; use `create_stack` to add a new stack or `scan_stacks` to discover untracked ones.',
     { environmentId: z.number().describe('Environment ID (required)') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/stacks', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'create_stack', 'Create a new Docker Compose stack and optionally deploy it',
+  registerTool(server, 'create_stack', 'Create a new Docker Compose stack and optionally deploy it; use `delete_stack` to remove it or `adopt_stack` for pre-existing stacks.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -40,7 +40,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'start_stack', 'Start a stack (docker compose up -d)',
+  registerTool(server, 'start_stack', 'Start a stopped stack (docker compose up -d); use `stop_stack` to stop or `restart_stack` for a quick cycle without going down.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -50,7 +50,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'stop_stack', 'Stop a stack (docker compose stop)',
+  registerTool(server, 'stop_stack', 'Stop running containers in a stack without removing them (docker compose stop); use `down_stack` to also remove containers, or `start_stack` to restart.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -60,7 +60,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'restart_stack', 'Restart a stack (docker compose restart)',
+  registerTool(server, 'restart_stack', 'Restart all containers in a stack in one step (docker compose restart); convenience alternative to calling `stop_stack` then `start_stack` separately.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -70,7 +70,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'down_stack', 'Take down a stack (docker compose down)',
+  registerTool(server, 'down_stack', 'Tear down and remove containers for a stack (docker compose down); more destructive than `stop_stack` — containers are removed, though volumes are preserved unless removeVolumes is true.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -82,7 +82,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'delete_stack', 'Delete a stack completely',
+  registerTool(server, 'delete_stack', 'Permanently delete a stack and its configuration from Dockhand (irreversible); use `down_stack` first to stop containers, or `list_stacks` to confirm the stack name before deletion.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -96,7 +96,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack_compose', 'Read the docker-compose.yml content of a stack',
+  registerTool(server, 'get_stack_compose', 'Read the current docker-compose.yml content of a stack; use `update_stack_compose` to modify the compose definition.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -106,7 +106,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'update_stack_compose', 'Update the docker-compose.yml of a stack and optionally redeploy',
+  registerTool(server, 'update_stack_compose', 'Update the docker-compose.yml of a stack and optionally redeploy; use `get_stack_compose` to read the current content before making changes.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -125,7 +125,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack_env', 'Read environment variables of a stack',
+  registerTool(server, 'get_stack_env', 'Read the database-backed environment variables of a stack (structured list with secret flags); use `get_stack_env_raw` to read the plain .env file instead, or `update_stack_env` to modify.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -136,7 +136,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'update_stack_env',
-    'Update secret environment variables (database-backed, encrypted at rest). Variables flagged isSecret:true are stored in the Dockhand database and injected into containers via shell-env at deploy time — they are NEVER written to the .env file. For non-secret variables that Docker Compose reads from the .env file at container start, use update_stack_env_raw.',
+    'Update secret environment variables (database-backed, encrypted at rest). Variables flagged isSecret:true are stored in the Dockhand database and injected into containers via shell-env at deploy time — they are NEVER written to the .env file. For non-secret variables that Docker Compose reads from the .env file at container start, use `update_stack_env_raw`.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -151,7 +151,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack_env_raw', 'Read the raw .env file of a stack',
+  registerTool(server, 'get_stack_env_raw', 'Read the raw .env file of a stack directly from disk; use `get_stack_env` for the structured database-backed view, or `validate_stack_env` to check for issues.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -162,7 +162,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'update_stack_env_raw',
-    'Write the raw .env file of a stack to disk. Use this for non-secret variables that Docker Compose reads at container start. For secrets that should be encrypted in the Dockhand database and injected via shell-env at deploy time, use update_stack_env with isSecret:true on each variable.',
+    'Write the raw .env file of a stack to disk. Use this for non-secret variables that Docker Compose reads at container start. For secrets that should be encrypted in the Dockhand database and injected via shell-env at deploy time, use `update_stack_env` with isSecret:true on each variable.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -173,7 +173,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'validate_stack_env', 'Validate environment variables of a stack',
+  registerTool(server, 'validate_stack_env', 'Validate the environment variables of a stack for completeness and correctness without mutating; use `update_stack_env` or `update_stack_env_raw` to fix any reported issues.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -183,14 +183,14 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'scan_stacks', 'Scan filesystem for existing Docker Compose stacks',
+  registerTool(server, 'scan_stacks', 'Scan the filesystem for existing Docker Compose stacks not yet tracked by Dockhand; use `adopt_stack` to import a discovered stack, or `list_stacks` to see already-managed stacks.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/stacks/scan', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'adopt_stack', 'Adopt an existing untracked stack into Dockhand management',
+  registerTool(server, 'adopt_stack', 'Adopt an existing untracked stack into Dockhand management; use `scan_stacks` to discover candidates or `create_stack` to create a brand-new managed stack.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name to adopt'),
@@ -203,7 +203,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'relocate_stack', 'Move a stack to a different filesystem path',
+  registerTool(server, 'relocate_stack', 'Move a stack to a different filesystem path on the host; use `check_stack_path_change` to verify the move is safe before calling this, or `validate_stack_path` to pre-validate the destination.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -214,28 +214,28 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack_sources', 'Get available stack sources',
+  registerTool(server, 'get_stack_sources', 'Retrieve the available stack source types (e.g. compose, git) supported by this environment; use `create_stack` to create a plain-compose stack or `list_git_stacks` for git-backed stacks.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/stacks/sources', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_stack_base_path', 'Get the base path for stacks on an environment',
+  registerTool(server, 'get_stack_base_path', 'Retrieve the configured base directory under which all stacks are stored on this environment; see `get_stack_default_path` for the suggested path for a new stack, or `get_stack_path_hints` for a list of candidate paths.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/stacks/base-path', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_stack_path_hints', 'Get path suggestions for new stacks',
+  registerTool(server, 'get_stack_path_hints', 'Retrieve a list of suggested filesystem paths for placing a new stack; complements `get_stack_default_path` (single default) and `get_stack_base_path` (root base dir).',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/stacks/path-hints', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'validate_stack_path', 'Validate a filesystem path for a new stack',
+  registerTool(server, 'validate_stack_path', 'Validate that a filesystem path is acceptable for a new stack without creating anything; use `get_stack_path_hints` for suggested paths, or `check_stack_path_change` to validate moving an existing stack.',
     {
       environmentId: z.number().describe('Environment ID'),
       path: z.string().describe('Path to validate'),
@@ -247,14 +247,14 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
 
   // --- Missing endpoints ---
 
-  registerTool(server, 'get_stack_default_path', 'Get the default path for new stacks',
+  registerTool(server, 'get_stack_default_path', 'Retrieve the default suggested path for a new stack on this environment; use `get_stack_path_hints` for multiple alternatives, or `validate_stack_path` to confirm a chosen path.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/stacks/default-path', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'check_stack_path_change', 'Check if a stack path change is safe',
+  registerTool(server, 'check_stack_path_change', 'Check whether moving a stack to a new filesystem path is safe (e.g. no conflicts, writable); call before `relocate_stack` to avoid data issues, or use `validate_stack_path` for a new-stack path check.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -11,14 +11,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Health ---
 
-  registerTool(server, 'health_check', 'Check Dockhand server health',
+  registerTool(server, 'health_check', 'Probe the MCP server liveness endpoint and return its overall health status; use `health_check_database` to probe the Dockhand backend database connection separately.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/health'));
     }
   );
 
-  registerTool(server, 'health_check_database', 'Check Dockhand database health',
+  registerTool(server, 'health_check_database', 'Probe the Dockhand backend database connection and return its health status; use `health_check` to check overall MCP server liveness instead.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/health/database'));
@@ -27,28 +27,28 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- System Info ---
 
-  registerTool(server, 'get_host_info', 'Get host information of the Dockhand server',
+  registerTool(server, 'get_host_info', 'Retrieve OS-level host details (hostname, OS, CPU, memory) of the Dockhand server; pair with `get_system_info` for application-level data or `get_system_disk` for storage capacity.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/host'));
     }
   );
 
-  registerTool(server, 'get_system_info', 'Get Dockhand system information',
+  registerTool(server, 'get_system_info', 'Retrieve Dockhand application system information such as version, build, and runtime details; use `get_host_info` for underlying OS/hardware data or `get_system_disk` for disk usage.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/system'));
     }
   );
 
-  registerTool(server, 'get_system_disk', 'Get disk usage on the Dockhand server',
+  registerTool(server, 'get_system_disk', 'Retrieve disk usage statistics for the Dockhand server host; use `get_host_info` for OS-level details or `get_general_settings` to read application-level configuration.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/system/disk'));
     }
   );
 
-  registerTool(server, 'list_system_files', 'List system files on the Dockhand server',
+  registerTool(server, 'list_system_files', 'List the file and directory entries at a given path on the Dockhand server host; use `get_system_file_content` to read the contents of a specific file.',
     {
       path: z.string().optional().describe('Directory path'),
     },
@@ -57,7 +57,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'get_system_file_content', 'Read a system file on the Dockhand server',
+  registerTool(server, 'get_system_file_content', 'Read and return the raw text content of a specific file on the Dockhand server host; use `list_system_files` to discover available files and paths first.',
     {
       path: z.string().describe('File path'),
     },
@@ -66,14 +66,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'get_changelog', 'Get the Dockhand changelog',
+  registerTool(server, 'get_changelog', 'Retrieve the Dockhand release changelog, listing version history, new features, and bug fixes for the running instance.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/changelog'));
     }
   );
 
-  registerTool(server, 'get_dependencies', 'Get Dockhand dependencies',
+  registerTool(server, 'get_dependencies', 'Retrieve the list of third-party software dependencies bundled with the running Dockhand instance, including versions and licenses.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/dependencies'));
@@ -82,14 +82,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Settings ---
 
-  registerTool(server, 'get_general_settings', 'Get general Dockhand settings',
+  registerTool(server, 'get_general_settings', 'Read the current general application settings for Dockhand; use `update_general_settings` to modify them, or `get_system_info` for read-only runtime/version data.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/settings/general'));
     }
   );
 
-  registerTool(server, 'update_general_settings', 'Update general Dockhand settings',
+  registerTool(server, 'update_general_settings', 'Write updated general application settings to Dockhand; use `get_general_settings` to read the current values before making changes.',
     {
       settings: z.record(z.string(), z.unknown()).describe('Settings to update'),
     },
@@ -98,21 +98,21 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'get_theme_settings', 'Get Dockhand theme settings',
+  registerTool(server, 'get_theme_settings', 'Retrieve the current UI theme configuration for the Dockhand dashboard, including color scheme and appearance preferences.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/settings/theme'));
     }
   );
 
-  registerTool(server, 'get_scanner_settings', 'Get vulnerability scanner settings (Trivy/Grype)',
+  registerTool(server, 'get_scanner_settings', 'Read the current vulnerability scanner configuration (Trivy/Grype) for Dockhand; use `update_scanner_settings` to change scanner behaviour or database paths.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/settings/scanner'));
     }
   );
 
-  registerTool(server, 'update_scanner_settings', 'Update vulnerability scanner settings',
+  registerTool(server, 'update_scanner_settings', 'Write updated vulnerability scanner settings (Trivy/Grype) to Dockhand; use `get_scanner_settings` to read the current configuration before applying changes.',
     {
       settings: z.record(z.string(), z.unknown()).describe('Scanner settings to update'),
     },
@@ -123,14 +123,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- License ---
 
-  registerTool(server, 'get_license', 'Get Dockhand license information',
+  registerTool(server, 'get_license', 'Read the current operational license information for Dockhand (tier, expiry, seat count); use `activate_license` to register a new key or `get_legal_license` for open-source license text.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/license'));
     }
   );
 
-  registerTool(server, 'activate_license', 'Activate a Dockhand license',
+  registerTool(server, 'activate_license', 'Activate a new Dockhand license key, registering it with the backend to unlock the corresponding feature tier; use `get_license` to verify the result after activation.',
     {
       licenseKey: z.string().describe('License key'),
     },
@@ -141,7 +141,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Metrics ---
 
-  registerTool(server, 'get_prometheus_metrics', 'Get Prometheus metrics from Dockhand',
+  registerTool(server, 'get_prometheus_metrics', 'Retrieve the Prometheus metrics exposition from Dockhand in text/plain format, suitable for scraping by a Prometheus server or quick manual inspection.',
     {},
     async () => {
       return textResponse(await client.get('/api/metrics'));
@@ -150,35 +150,35 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Pruning ---
 
-  registerTool(server, 'prune_all', 'Prune all unused Docker resources (containers, images, networks, volumes) - DESTRUCTIVE!',
+  registerTool(server, 'prune_all', 'Delete all unused Docker resources in one operation — combines `prune_containers`, `prune_images`, `prune_volumes`, and `prune_networks`; DESTRUCTIVE and cannot be undone.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/prune/all', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'prune_containers', 'Prune stopped containers - DESTRUCTIVE!',
+  registerTool(server, 'prune_containers', 'Remove all stopped Docker containers to reclaim disk space; DESTRUCTIVE — use `prune_all` to delete containers together with images, volumes, and networks in one call.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/prune/containers', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'prune_images', 'Prune unused Docker images - DESTRUCTIVE!',
+  registerTool(server, 'prune_images', 'Delete unused (dangling and unreferenced) Docker images to reclaim disk space; DESTRUCTIVE — use `prune_all` to also remove stopped containers, volumes, and networks in one call.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/prune/images', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'prune_networks', 'Prune unused Docker networks',
+  registerTool(server, 'prune_networks', 'Remove unused Docker networks that are not referenced by any container; DESTRUCTIVE — use `prune_all` to also prune containers, images, and volumes in a single operation.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/prune/networks', undefined, { env: environmentId }));
     }
   );
 
-  registerTool(server, 'prune_volumes', 'Prune unused Docker volumes - DESTRUCTIVE! Data will be lost!',
+  registerTool(server, 'prune_volumes', 'Delete unused Docker volumes and permanently destroy their stored data; DESTRUCTIVE and unrecoverable — use `prune_all` to also remove stopped containers, images, and networks in one call.',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
       return jsonResponse(await client.post('/api/prune/volumes', undefined, { env: environmentId }));
@@ -196,14 +196,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Legal ---
 
-  registerTool(server, 'get_legal_license', 'Get legal license information',
+  registerTool(server, 'get_legal_license', 'Retrieve the full open-source legal license text for Dockhand; for operational license tier and expiry see `get_license`, or use `activate_license` to register a key.',
     {},
     async () => {
       return textResponse(await client.get('/api/legal/license'));
     }
   );
 
-  registerTool(server, 'get_privacy_policy', 'Get privacy policy',
+  registerTool(server, 'get_privacy_policy', 'Retrieve the full privacy policy text describing how Dockhand collects and handles user data.',
     {},
     async () => {
       return textResponse(await client.get('/api/legal/privacy'));

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -11,14 +11,14 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Health ---
 
-  registerTool(server, 'health_check', 'Probe the MCP server liveness endpoint and return its overall health status; use `health_check_database` to probe the Dockhand backend database connection separately.',
+  registerTool(server, 'health_check', 'Probe the Dockhand backend overall health endpoint (`GET /api/health`) and return its status; use `health_check_database` to specifically test database-layer connectivity inside the backend.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/health'));
     }
   );
 
-  registerTool(server, 'health_check_database', 'Probe the Dockhand backend database connection and return its health status; use `health_check` to check overall MCP server liveness instead.',
+  registerTool(server, 'health_check_database', 'Probe specifically the Dockhand backend database connection (`GET /api/health/database`) and return its health status; use `health_check` for the broader backend health check across all subsystems.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/health/database'));

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -187,7 +187,7 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
 
   // --- Batch ---
 
-  registerTool(server, 'list_batch_operations', 'Get available batch operations',
+  registerTool(server, 'list_batch_operations', 'List the batch operations that have been submitted or completed, providing a history view of bulk container actions; use `batch_update_containers` to start a new batch update, or `start_container` / `stop_container` for single-container lifecycle actions.',
     {},
     async () => {
       return jsonResponse(await client.post('/api/batch'));

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -12,14 +12,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- Users ---
 
-  registerTool(server, 'list_users', 'List all Dockhand users',
+  registerTool(server, 'list_users', 'List all Dockhand users; pair with `create_user` to provision new accounts.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/users'));
     }
   );
 
-  registerTool(server, 'create_user', 'Create a new Dockhand user',
+  registerTool(server, 'create_user', 'Create a new Dockhand user account with username and password; use `set_user_roles` to assign roles afterwards.',
     {
       username: z.string().describe('Username'),
       password: z.string().describe('Password'),
@@ -34,14 +34,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_user', 'Get details of a Dockhand user',
+  registerTool(server, 'get_user', 'Fetch details of a specific Dockhand user by ID; see `list_users` to discover user IDs.',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
       return jsonResponse(await client.get(`/api/users/${encodePath(userId)}`));
     }
   );
 
-  registerTool(server, 'update_user', 'Update a Dockhand user',
+  registerTool(server, 'update_user', 'Update settings for any Dockhand user by ID (admin operation); use `get_user` to inspect current values before changing them.',
     {
       userId: z.number().describe('User ID'),
       settings: z.record(z.string(), z.unknown()).describe('User settings to update'),
@@ -51,35 +51,35 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'delete_user', 'Delete a Dockhand user',
+  registerTool(server, 'delete_user', 'Permanently delete a Dockhand user account by ID; use `list_users` to confirm the target before removing.',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
       return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}`));
     }
   );
 
-  registerTool(server, 'enable_user_mfa', 'Enable MFA for a user',
+  registerTool(server, 'enable_user_mfa', 'Enable multi-factor authentication for a user account; pair with `disable_user_mfa` to toggle MFA status.',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
       return jsonResponse(await client.post(`/api/users/${encodePath(userId)}/mfa`));
     }
   );
 
-  registerTool(server, 'disable_user_mfa', 'Disable MFA for a user',
+  registerTool(server, 'disable_user_mfa', 'Disable multi-factor authentication for a user, reducing account security; use `enable_user_mfa` to restore MFA.',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
       return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}/mfa`));
     }
   );
 
-  registerTool(server, 'get_user_roles', 'Get roles assigned to a user',
+  registerTool(server, 'get_user_roles', 'Retrieve the roles currently assigned to a user; use `set_user_roles` to update the assignment.',
     { userId: z.number().describe('User ID') },
     async ({ userId }) => {
       return jsonResponse(await client.get(`/api/users/${encodePath(userId)}/roles`));
     }
   );
 
-  registerTool(server, 'set_user_roles', 'Set roles for a user',
+  registerTool(server, 'set_user_roles', 'Assign a list of roles to a user, replacing the current assignment; see `get_user_roles` to inspect existing roles before overwriting.',
     {
       userId: z.number().describe('User ID'),
       roles: z.array(z.string()).describe('Role names to assign'),
@@ -91,14 +91,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- Roles ---
 
-  registerTool(server, 'list_roles', 'List all Dockhand roles',
+  registerTool(server, 'list_roles', 'List all Dockhand roles available for assignment; use `create_role` to define new ones.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/roles'));
     }
   );
 
-  registerTool(server, 'create_role', 'Create a new Dockhand role',
+  registerTool(server, 'create_role', 'Create a new Dockhand role with a name and optional permissions; use `list_roles` to avoid duplicate role names.',
     {
       name: z.string().describe('Role name'),
       permissions: z.array(z.string()).optional().describe('Permissions to grant'),
@@ -110,14 +110,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_role', 'Get details of a Dockhand role',
+  registerTool(server, 'get_role', 'Fetch details and permissions of a specific Dockhand role by ID; see `list_roles` to discover role IDs.',
     { roleId: z.number().describe('Role ID') },
     async ({ roleId }) => {
       return jsonResponse(await client.get(`/api/roles/${encodePath(roleId)}`));
     }
   );
 
-  registerTool(server, 'update_role', 'Update a Dockhand role',
+  registerTool(server, 'update_role', 'Update the configuration of an existing Dockhand role; use `get_role` to inspect current settings before modifying.',
     {
       roleId: z.number().describe('Role ID'),
       config: z.record(z.string(), z.unknown()).describe('Role configuration to update'),
@@ -127,7 +127,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'delete_role', 'Delete a Dockhand role',
+  registerTool(server, 'delete_role', 'Permanently delete a Dockhand role by ID; use `list_roles` to confirm the target before removing.',
     { roleId: z.number().describe('Role ID') },
     async ({ roleId }) => {
       return jsonResponse(await client.delete(`/api/roles/${encodePath(roleId)}`));
@@ -136,14 +136,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- Profile ---
 
-  registerTool(server, 'get_profile', 'Get the current user profile',
+  registerTool(server, 'get_profile', 'Fetch the calling user\'s own profile data; use `update_profile` to modify self-service settings.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/profile'));
     }
   );
 
-  registerTool(server, 'update_profile', 'Update the current user profile',
+  registerTool(server, 'update_profile', 'Update the current (self) user profile settings; see `get_profile` to read current values first.',
     {
       settings: z.record(z.string(), z.unknown()).describe('Profile settings to update'),
     },
@@ -152,14 +152,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_profile_preferences', 'Get profile preferences',
+  registerTool(server, 'get_profile_preferences', 'Retrieve the current user\'s own profile preferences; use `update_profile_preferences` to change them.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/profile/preferences'));
     }
   );
 
-  registerTool(server, 'update_profile_preferences', 'Update profile preferences',
+  registerTool(server, 'update_profile_preferences', 'Update the self-user\'s own profile preferences; see `get_profile_preferences` to inspect current values.',
     {
       preferences: z.record(z.string(), z.unknown()).describe('Preferences to update'),
     },
@@ -170,14 +170,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- UI Preferences ---
 
-  registerTool(server, 'get_favorites', 'Get favorite containers/stacks',
+  registerTool(server, 'get_favorites', 'Retrieve the UI favorite containers and stacks; use `set_favorites` to update the list.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/preferences/favorites'));
     }
   );
 
-  registerTool(server, 'set_favorites', 'Set favorite containers/stacks',
+  registerTool(server, 'set_favorites', 'Replace the UI favorites list with the provided containers/stacks; see `get_favorites` to read current entries before overwriting.',
     {
       favorites: z.array(z.unknown()).describe('Favorites list'),
     },
@@ -186,14 +186,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_favorite_groups', 'Get favorite groups',
+  registerTool(server, 'get_favorite_groups', 'Retrieve the named groups used to organise UI favorites; use `set_favorite_groups` to save changes.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/preferences/favorite-groups'));
     }
   );
 
-  registerTool(server, 'set_favorite_groups', 'Set favorite groups',
+  registerTool(server, 'set_favorite_groups', 'Replace the UI favorite groups definition; see `get_favorite_groups` to read the existing groups before overwriting.',
     {
       groups: z.array(z.unknown()).describe('Favorite groups'),
     },
@@ -202,14 +202,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_grid_preferences', 'Get grid display preferences',
+  registerTool(server, 'get_grid_preferences', 'Retrieve the UI grid display preferences (column widths, sort order, etc.); use `set_grid_preferences` to update them.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/preferences/grid'));
     }
   );
 
-  registerTool(server, 'set_grid_preferences', 'Set grid display preferences',
+  registerTool(server, 'set_grid_preferences', 'Save UI grid display preferences such as column layout and sort order; see `get_grid_preferences` to read current settings.',
     {
       preferences: z.record(z.string(), z.unknown()).describe('Grid preferences'),
     },
@@ -220,14 +220,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- Config Sets ---
 
-  registerTool(server, 'list_config_sets', 'List all config sets',
+  registerTool(server, 'list_config_sets', 'List all reusable config sets defined in Dockhand; use `create_config_set` to add new ones.',
     {},
     async () => {
       return jsonResponse(await client.get('/api/config-sets'));
     }
   );
 
-  registerTool(server, 'create_config_set', 'Create a new config set',
+  registerTool(server, 'create_config_set', 'Create a new named config set for reuse across stacks; use `list_config_sets` to verify the name is unique.',
     {
       config: z.record(z.string(), z.unknown()).describe('Config set data'),
     },
@@ -236,14 +236,14 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'get_config_set', 'Get a specific config set',
+  registerTool(server, 'get_config_set', 'Fetch the content of a specific config set by ID; use `list_config_sets` to discover available IDs.',
     { configSetId: z.number().describe('Config set ID') },
     async ({ configSetId }) => {
       return jsonResponse(await client.get(`/api/config-sets/${encodePath(configSetId)}`));
     }
   );
 
-  registerTool(server, 'update_config_set', 'Update a config set',
+  registerTool(server, 'update_config_set', 'Update an existing config set with new data; use `get_config_set` to read current values before overwriting.',
     {
       configSetId: z.number().describe('Config set ID'),
       config: z.record(z.string(), z.unknown()).describe('Updated config set data'),
@@ -253,7 +253,7 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'delete_config_set', 'Delete a config set',
+  registerTool(server, 'delete_config_set', 'Permanently delete a config set by ID; use `list_config_sets` to confirm the target before removing.',
     { configSetId: z.number().describe('Config set ID') },
     async ({ configSetId }) => {
       return jsonResponse(await client.delete(`/api/config-sets/${encodePath(configSetId)}`));

--- a/src/tools/volumes.ts
+++ b/src/tools/volumes.ts
@@ -10,14 +10,14 @@ import { encodePath } from '../utils/encode-path.js';
 
 export function registerVolumeTools(server: McpServer, client: DockhandClient): void {
 
-  registerTool(server, 'list_volumes', 'List all Docker volumes in an environment',
+  registerTool(server, 'list_volumes', 'List all Docker volumes in an environment; use `get_volume` for a single volume summary or `inspect_volume` for full JSON details.',
     { environmentId: z.number().describe('Environment ID (required)') },
     async ({ environmentId }) => {
       return jsonResponse(await client.get('/api/volumes', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'get_volume', 'Get details of a specific Docker volume',
+  registerTool(server, 'get_volume', 'Return a summary of a named Docker volume (name, driver, mountpoint, labels); use `inspect_volume` for the full low-level docker-inspect JSON payload.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -27,7 +27,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'inspect_volume', 'Inspect a Docker volume (full low-level details)',
+  registerTool(server, 'inspect_volume', 'Return the full docker-inspect JSON for a volume, including scope, options, and status fields not exposed by `get_volume`.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -37,7 +37,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'browse_volume', 'Browse files inside a Docker volume',
+  registerTool(server, 'browse_volume', 'Acquire a browse session and list files inside a Docker volume at a given path; call `release_volume_browse` when done to tear down the helper container.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -51,7 +51,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'get_volume_file_content', 'Read file content from a Docker volume',
+  registerTool(server, 'get_volume_file_content', 'Read the text content of a single file inside a Docker volume; requires an active `browse_volume` session on the same volume.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -66,7 +66,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'release_volume_browse', 'Release a volume browse session (cleanup helper container)',
+  registerTool(server, 'release_volume_browse', 'Release the browse session opened by `browse_volume`, stopping and removing the ephemeral helper container to free resources.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -76,7 +76,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'clone_volume', 'Clone a Docker volume',
+  registerTool(server, 'clone_volume', 'Create a new Docker volume as a full data copy of the source volume; unlike `export_volume` this produces a live volume rather than a tar archive.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Source volume name'),
@@ -89,7 +89,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'export_volume', 'Export a Docker volume as a tarball',
+  registerTool(server, 'export_volume', 'Export the contents of a Docker volume as a downloadable tar archive; use `clone_volume` instead to duplicate data into a new live volume.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),
@@ -99,7 +99,7 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'remove_volume', 'Remove a Docker volume (DESTRUCTIVE - data will be lost!)',
+  registerTool(server, 'remove_volume', 'Permanently delete a Docker volume and all its data (destructive, irreversible); ensure no containers are using it before calling; see `list_volumes` to confirm the volume name.',
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Volume name'),

--- a/tests/tool-descriptions.test.ts
+++ b/tests/tool-descriptions.test.ts
@@ -61,14 +61,25 @@ const ALL_TOOLS = extractAllTools();
  * boundaries get refined during implementation. When in doubt, trust
  * this file.
  */
-// Tools intentionally outside every cluster — C1, C3, C4 still apply,
-// but C2 does not (no semantic siblings to cross-reference):
-//   logout, get_changelog, get_dependencies, get_privacy_policy,
-//   get_prometheus_metrics, get_theme_settings
-//
-// If a new tool is added to src/tools/*.ts that does not fit any
-// existing cluster and is not in this list, the audit has a coverage
-// gap — either add it to a cluster or extend this list.
+/**
+ * Tools intentionally outside every cluster — C1, C3, C4 still apply,
+ * but C2 does not (no semantic siblings to cross-reference).
+ *
+ * The coverage-completeness test below asserts that every extracted
+ * tool is either listed in a CLUSTERS array or in this STANDALONES
+ * set. Adding a new tool to src/tools/*.ts without putting it in one
+ * of the two will fail that test — the right fix is to add it to a
+ * cluster (preferred) or to extend this list with rationale.
+ */
+const STANDALONES: ReadonlySet<string> = new Set([
+  'logout',
+  'get_changelog',
+  'get_dependencies',
+  'get_privacy_policy',
+  'get_prometheus_metrics',
+  'get_theme_settings',
+]);
+
 const CLUSTERS: Record<string, string[]> = {
   // stacks.ts
   'Stack-Env': [
@@ -347,7 +358,14 @@ describe('Tool description audit', () => {
     });
   });
 
-  describe('C1 — destructive verb hygiene', () => {
+  // Partial C1 enforcement: this block only checks the *destructive-verb*
+  // half of the criterion. The "action-verb first sentence" half of C1
+  // is judgement-based (an LLM that opens with "Retrieve" satisfies the
+  // intent; one that opens with "This is a tool that retrieves..." does
+  // not — but a regex cannot reliably tell them apart). Code review
+  // catches the action-verb part during PR review, similar to how C3
+  // (scope-marker) is review-only.
+  describe('destructive verb hygiene (partial C1)', () => {
     it('every destructive-named tool names a destructive action', () => {
       const violators = ALL_TOOLS.filter(
         (t) =>
@@ -355,6 +373,51 @@ describe('Tool description audit', () => {
           !DESTRUCTIVE_VERBS.test(t.description),
       ).map((t) => `${t.file}::${t.name}: "${t.description}"`);
       expect(violators, `\n${violators.join('\n')}`).toEqual([]);
+    });
+  });
+
+  // Closes the audit-coverage loophole: a new tool that lands in
+  // src/tools/*.ts without a cluster home AND without explicit
+  // standalone declaration will fail this test, surfacing the gap
+  // before the PR merges instead of silently bypassing C2.
+  describe('coverage completeness', () => {
+    it('every extracted tool is in a CLUSTERS array or in STANDALONES', () => {
+      const clusterMembers = new Set(
+        Object.values(CLUSTERS).flatMap((arr) => arr),
+      );
+      const uncovered = ALL_TOOLS.filter(
+        (t) => !clusterMembers.has(t.name) && !STANDALONES.has(t.name),
+      ).map(
+        (t) =>
+          `${t.file}::${t.name} — neither in any CLUSTERS array nor in STANDALONES`,
+      );
+      expect(uncovered, `\n${uncovered.join('\n')}`).toEqual([]);
+    });
+
+    it('every CLUSTERS member maps to an actually-registered tool', () => {
+      const allNames = new Set(ALL_TOOLS.map((t) => t.name));
+      const dangling: string[] = [];
+      for (const [clusterName, members] of Object.entries(CLUSTERS)) {
+        for (const member of members) {
+          if (!allNames.has(member)) {
+            dangling.push(
+              `${clusterName}::${member} — listed in CLUSTERS but not found in any src/tools/*.ts`,
+            );
+          }
+        }
+      }
+      expect(dangling, `\n${dangling.join('\n')}`).toEqual([]);
+    });
+
+    it('every STANDALONES entry maps to an actually-registered tool', () => {
+      const allNames = new Set(ALL_TOOLS.map((t) => t.name));
+      const dangling = [...STANDALONES]
+        .filter((name) => !allNames.has(name))
+        .map(
+          (name) =>
+            `${name} — listed in STANDALONES but not found in any src/tools/*.ts`,
+        );
+      expect(dangling, `\n${dangling.join('\n')}`).toEqual([]);
     });
   });
 

--- a/tests/tool-descriptions.test.ts
+++ b/tests/tool-descriptions.test.ts
@@ -55,9 +55,20 @@ const ALL_TOOLS = extractAllTools();
  * Clusters that require C2 cross-references. Every member's description
  * MUST mention at least one sibling member by name in backticks.
  *
- * Keep this in sync with the §Tool clusters table in
- * docs/designs/2026-05-16-tool-description-audit-design.md.
+ * This file is the authoritative cluster definition. The §Tool clusters
+ * table in docs/designs/2026-05-16-tool-description-audit-design.md is
+ * the historical proposal; the test file may diverge as cluster
+ * boundaries get refined during implementation. When in doubt, trust
+ * this file.
  */
+// Tools intentionally outside every cluster — C1, C3, C4 still apply,
+// but C2 does not (no semantic siblings to cross-reference):
+//   logout, get_changelog, get_dependencies, get_privacy_policy,
+//   get_prometheus_metrics, get_theme_settings
+//
+// If a new tool is added to src/tools/*.ts that does not fit any
+// existing cluster and is not in this list, the audit has a coverage
+// gap — either add it to a cluster or extend this list.
 const CLUSTERS: Record<string, string[]> = {
   // stacks.ts
   'Stack-Env': [
@@ -65,6 +76,7 @@ const CLUSTERS: Record<string, string[]> = {
     'get_stack_env_raw',
     'update_stack_env',
     'update_stack_env_raw',
+    'validate_stack_env',
   ],
   'Stack-Compose': ['get_stack_compose', 'update_stack_compose'],
   'Stack-Lifecycle': ['start_stack', 'stop_stack', 'restart_stack', 'down_stack'],
@@ -76,9 +88,10 @@ const CLUSTERS: Record<string, string[]> = {
     'validate_stack_path',
     'relocate_stack',
   ],
-  'Stack-Source': ['get_stack_sources', 'list_stacks', 'scan_stacks', 'adopt_stack'],
+  'Stack-Source': ['create_stack', 'delete_stack', 'get_stack_sources', 'list_stacks', 'scan_stacks', 'adopt_stack'],
   // containers.ts
   'Container-Lifecycle': [
+    'create_container',
     'start_container',
     'stop_container',
     'restart_container',
@@ -87,15 +100,19 @@ const CLUSTERS: Record<string, string[]> = {
     'rename_container',
     'update_container',
     'batch_update_containers',
+    'list_batch_operations',
   ],
   'Container-Inspect': [
     'get_container',
     'inspect_container',
+    'list_containers',
     'get_container_logs',
     'get_container_stats',
+    'get_containers_stats',
     'get_container_top',
     'get_container_sizes',
     'get_container_shells',
+    'get_merged_logs',
   ],
   'Container-Files': [
     'list_container_files',
@@ -306,6 +323,8 @@ const CLUSTERS: Record<string, string[]> = {
     'get_container_auto_update',
     'set_container_auto_update',
     'get_auto_update_settings',
+    'check_container_updates',
+    'get_pending_updates',
   ],
 };
 

--- a/tests/tool-descriptions.test.ts
+++ b/tests/tool-descriptions.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tool description audit — static-analysis assertions over src/tools/*.ts.
+ *
+ * Enforces the four quality criteria from
+ * docs/designs/2026-05-16-tool-description-audit-design.md:
+ *   C1 — action-verb first sentence (destructive verbs named explicitly)
+ *   C2 — backticked cross-references within tool clusters
+ *   C3 — scope marker for ambiguous tools
+ *   C4 — description.length >= 60
+ *
+ * Generic assertions cover C1 (destructive verb), C4 (length), and basic
+ * sentence-form hygiene. Per-cluster assertions cover C2 (cross-references).
+ * C3 is judgement-based and verified by code review, not by automated tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TOOLS_DIR = join(__dirname, '..', 'src', 'tools');
+
+interface ToolMeta {
+  name: string;
+  description: string;
+  file: string;
+}
+
+/**
+ * Extracts every `registerTool(server, 'name', 'description', ...)` site
+ * across every src/tools/*.ts (excluding the index). The description regex
+ * accepts single quotes, double quotes, or backticks, and tolerates the
+ * description spanning multiple physical lines.
+ */
+function extractAllTools(): ToolMeta[] {
+  const files = readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts') && f !== 'index.ts')
+    .sort();
+  const tools: ToolMeta[] = [];
+  const pattern =
+    /registerTool\s*\(\s*server\s*,\s*['"`]([^'"`]+)['"`]\s*,\s*(['"`])([\s\S]*?)\2\s*,/g;
+  for (const file of files) {
+    const content = readFileSync(join(TOOLS_DIR, file), 'utf-8');
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(content)) !== null) {
+      tools.push({ name: m[1], description: m[3], file });
+    }
+  }
+  return tools;
+}
+
+const ALL_TOOLS = extractAllTools();
+
+/**
+ * Clusters that require C2 cross-references. Every member's description
+ * MUST mention at least one sibling member by name in backticks.
+ *
+ * Keep this in sync with the §Tool clusters table in
+ * docs/designs/2026-05-16-tool-description-audit-design.md.
+ */
+const CLUSTERS: Record<string, string[]> = {
+  // stacks.ts
+  'Stack-Env': [
+    'get_stack_env',
+    'get_stack_env_raw',
+    'update_stack_env',
+    'update_stack_env_raw',
+  ],
+  'Stack-Compose': ['get_stack_compose', 'update_stack_compose'],
+  'Stack-Lifecycle': ['start_stack', 'stop_stack', 'restart_stack', 'down_stack'],
+  'Stack-Path': [
+    'get_stack_base_path',
+    'get_stack_default_path',
+    'get_stack_path_hints',
+    'check_stack_path_change',
+    'validate_stack_path',
+    'relocate_stack',
+  ],
+  'Stack-Source': ['get_stack_sources', 'list_stacks', 'scan_stacks', 'adopt_stack'],
+  // containers.ts
+  'Container-Lifecycle': [
+    'start_container',
+    'stop_container',
+    'restart_container',
+    'pause_container',
+    'unpause_container',
+    'rename_container',
+    'update_container',
+    'batch_update_containers',
+  ],
+  'Container-Inspect': [
+    'get_container',
+    'inspect_container',
+    'get_container_logs',
+    'get_container_stats',
+    'get_container_top',
+    'get_container_sizes',
+    'get_container_shells',
+  ],
+  'Container-Files': [
+    'list_container_files',
+    'get_container_file_content',
+    'create_container_file',
+    'delete_container_file',
+    'rename_container_file',
+    'chmod_container_file',
+    'download_container_file',
+    'upload_container_file',
+  ],
+  // system.ts
+  'Prune-Family': [
+    'prune_all',
+    'prune_containers',
+    'prune_images',
+    'prune_volumes',
+    'prune_networks',
+  ],
+  'System-Files': ['list_system_files', 'get_system_file_content'],
+  'System-Info': [
+    'get_system_info',
+    'get_system_disk',
+    'get_host_info',
+    'get_general_settings',
+    'update_general_settings',
+  ],
+  Health: ['health_check', 'health_check_database'],
+  License: ['get_license', 'activate_license', 'get_legal_license'],
+  'Scanner-Settings': ['get_scanner_settings', 'update_scanner_settings'],
+  // images.ts
+  'Image-Lifecycle': [
+    'pull_image',
+    'push_image',
+    'tag_image',
+    'remove_image',
+    'list_images',
+    'get_image_history',
+    'scan_image',
+    'export_image',
+  ],
+  // volumes.ts
+  'Volume-Lifecycle': [
+    'browse_volume',
+    'clone_volume',
+    'export_volume',
+    'get_volume',
+    'inspect_volume',
+    'list_volumes',
+    'remove_volume',
+    'get_volume_file_content',
+    'release_volume_browse',
+  ],
+  // networks.ts
+  'Network-Lifecycle': [
+    'create_network',
+    'get_network',
+    'inspect_network',
+    'list_networks',
+    'remove_network',
+    'connect_container_to_network',
+    'disconnect_container_from_network',
+  ],
+  // git-stacks.ts
+  'Git-Repository': [
+    'create_git_repository',
+    'get_git_repository',
+    'list_git_repositories',
+    'deploy_git_repository',
+    'test_git_repository',
+    'test_git_repository_connection',
+    'sync_git_repository',
+  ],
+  'Git-Stack': [
+    'list_git_stacks',
+    'get_git_stack',
+    'deploy_git_stack',
+    'test_git_stack',
+    'sync_git_stack',
+    'get_git_stack_env_files',
+    'get_git_webhook',
+    'trigger_git_webhook',
+    'request_git_preview_env',
+  ],
+  'Git-Credentials': [
+    'create_git_credential',
+    'get_git_credential',
+    'list_git_credentials',
+    'delete_git_credential',
+    'update_git_credential',
+  ],
+  // auth.ts
+  'Auth-LDAP': ['create_ldap_provider', 'get_ldap_provider', 'test_ldap_provider'],
+  'Auth-OIDC': [
+    'create_oidc_provider',
+    'get_oidc_provider',
+    'test_oidc_provider',
+    'initiate_oidc_login',
+    'get_auth_providers',
+    'get_auth_session',
+    'get_auth_settings',
+  ],
+  'Hawser-Tokens': ['list_hawser_tokens', 'create_hawser_token', 'revoke_hawser_token'],
+  // users.ts
+  Users: [
+    'create_user',
+    'delete_user',
+    'get_user',
+    'list_users',
+    'update_user',
+    'enable_user_mfa',
+    'disable_user_mfa',
+    'get_user_roles',
+    'set_user_roles',
+  ],
+  Roles: ['create_role', 'delete_role', 'get_role', 'list_roles', 'update_role'],
+  Profile: ['get_profile', 'update_profile', 'get_profile_preferences', 'update_profile_preferences'],
+  'Favorites-Prefs': [
+    'get_favorites',
+    'set_favorites',
+    'get_favorite_groups',
+    'set_favorite_groups',
+    'get_grid_preferences',
+    'set_grid_preferences',
+  ],
+  'Config-Sets': [
+    'create_config_set',
+    'delete_config_set',
+    'get_config_set',
+    'list_config_sets',
+    'update_config_set',
+  ],
+  // notifications.ts
+  Notifications: [
+    'create_notification',
+    'get_notification',
+    'list_notifications',
+    'delete_notification',
+    'update_notification',
+    'test_notification',
+    'test_notification_config',
+    'trigger_test_notification',
+  ],
+  // environments.ts
+  Environments: [
+    'create_environment',
+    'delete_environment',
+    'get_environment',
+    'list_environments',
+    'update_environment',
+    'test_environment',
+    'test_environment_connection',
+    'detect_docker_socket',
+  ],
+  'Env-Notifications': [
+    'create_environment_notification',
+    'get_environment_notification',
+    'list_environment_notifications',
+    'delete_environment_notification',
+  ],
+  'Env-Settings': [
+    'get_environment_timezone',
+    'set_environment_timezone',
+    'get_environment_update_check',
+    'set_environment_update_check',
+    'get_environment_image_prune',
+    'set_environment_image_prune',
+  ],
+  // schedules.ts
+  Schedules: [
+    'list_schedules',
+    'get_schedule_execution',
+    'get_schedule_executions',
+    'run_schedule_now',
+    'toggle_schedule',
+    'toggle_system_schedule',
+    'get_schedule_settings',
+    'update_schedule_settings',
+  ],
+  // registries.ts
+  Registries: [
+    'create_registry',
+    'delete_registry',
+    'get_registry',
+    'list_registries',
+    'update_registry',
+    'search_registry',
+    'get_registry_catalog',
+    'get_registry_tags',
+    'set_default_registry',
+  ],
+  // audit.ts
+  Audit: ['get_audit_events', 'get_audit_log', 'get_audit_users', 'export_audit_log'],
+  // dashboard.ts
+  Activity: [
+    'get_activity_feed',
+    'get_activity_events',
+    'get_activity_stats',
+    'get_container_activity',
+  ],
+  'Dashboard-Prefs': [
+    'get_dashboard_preferences',
+    'set_dashboard_preferences',
+    'get_dashboard_stats',
+  ],
+  // auto-update.ts
+  'Auto-Update': [
+    'get_container_auto_update',
+    'set_container_auto_update',
+    'get_auto_update_settings',
+  ],
+};
+
+/**
+ * Tools whose name matches one of these prefixes are treated as destructive
+ * and MUST contain a destructive verb in their description.
+ */
+const DESTRUCTIVE_NAME_PATTERN =
+  /^(delete_|remove_|prune_|down_|stop_|revoke_|disable_|disconnect_)/;
+const DESTRUCTIVE_VERBS =
+  /\b(delete|remove|prune|destroy|stop|tear down|drop|revoke|disable|disconnect)\b/i;
+
+describe('Tool description audit', () => {
+  describe('C4 — minimum length', () => {
+    it('every description is at least 60 characters', () => {
+      const tooShort = ALL_TOOLS.filter((t) => t.description.length < 60).map(
+        (t) => `${t.file}::${t.name} (${t.description.length} chars): "${t.description}"`,
+      );
+      expect(tooShort, `\n${tooShort.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('C1 — destructive verb hygiene', () => {
+    it('every destructive-named tool names a destructive action', () => {
+      const violators = ALL_TOOLS.filter(
+        (t) =>
+          DESTRUCTIVE_NAME_PATTERN.test(t.name) &&
+          !DESTRUCTIVE_VERBS.test(t.description),
+      ).map((t) => `${t.file}::${t.name}: "${t.description}"`);
+      expect(violators, `\n${violators.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('sentence hygiene', () => {
+    it('every description ends with sentence-terminating punctuation', () => {
+      const violators = ALL_TOOLS.filter((t) => {
+        const last = t.description.trim().slice(-1);
+        return !['.', '!', '?', ')'].includes(last);
+      }).map((t) => `${t.file}::${t.name}: ends with "${t.description.slice(-10)}"`);
+      expect(violators, `\n${violators.join('\n')}`).toEqual([]);
+    });
+  });
+
+  describe('C2 — cluster cross-references', () => {
+    for (const [clusterName, members] of Object.entries(CLUSTERS)) {
+      describe(clusterName, () => {
+        it('every member references at least one sibling by name in backticks', () => {
+          const byName = new Map(ALL_TOOLS.map((t) => [t.name, t.description]));
+          const missing: string[] = [];
+          for (const member of members) {
+            const desc = byName.get(member);
+            if (!desc) {
+              missing.push(`${member}: tool not found in any src/tools/*.ts`);
+              continue;
+            }
+            const siblings = members.filter((s) => s !== member);
+            const hasBacktickedSibling = siblings.some((s) =>
+              desc.includes('`' + s + '`'),
+            );
+            if (!hasBacktickedSibling) {
+              missing.push(`${member} (cluster ${clusterName}): "${desc}"`);
+            }
+          }
+          expect(missing, `\n${missing.join('\n')}`).toEqual([]);
+        });
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Raises every tool description in \`src/tools/*.ts\` to the quality bar set by PR #58 (the \`update_stack_env\` / \`update_stack_env_raw\` cross-referenced pair). Before this PR, 208 of 222 descriptions were under 60 characters and ~all clustered tools lacked cross-references — an AI client routing decisions between sibling tools had to guess.

After: every description meets four enforceable quality criteria, codified in a new static-analysis test:

- **C1** — Action-verb first sentence (destructive verbs named explicitly — \`delete\`, \`remove\`, \`prune\`, \`tear down\`, \`stop\`, \`revoke\`, \`disable\`, \`disconnect\`).
- **C2** — Backticked cross-references inside tool clusters (38 clusters defined; every cluster member references at least one sibling by name in backticks).
- **C3** — Scope marker for ambiguous tools (DB-backed vs. on-disk; batch vs. single; summary vs. full JSON; settings vs. detection vs. execution; etc.).
- **C4** — Minimum 60 characters.

## What changed

**Test scaffolding** (\`tests/tool-descriptions.test.ts\`, 2 commits): an \`extractAllTools()\` helper that reads every \`src/tools/*.ts\`, a \`CLUSTERS\` record mapping 38 cluster names to their members, four describe blocks enforcing C1/C4/sentence-end + per-cluster C2. The 6 intentional standalones (\`logout\`, \`get_changelog\`, \`get_dependencies\`, \`get_privacy_policy\`, \`get_prometheus_metrics\`, \`get_theme_settings\`) are documented in a comment block so the audit gap is visible the next time a new tool lands without a cluster home.

**Per-file rewrites** (16 commits, one per \`src/tools/*.ts\`), in size-ascending order:

| Cluster | Tools | File |
|---|---|---|
| Audit | 4 | audit.ts |
| Auto-Update (3 in this file, 2 completed in containers.ts) | 3 | auto-update.ts |
| Network-Lifecycle | 7 | networks.ts |
| Image-Lifecycle | 8 | images.ts |
| Volume-Lifecycle | 9 | volumes.ts |
| Registries | 9 | registries.ts |
| Schedules | 8 | schedules.ts |
| Notifications | 8 | notifications.ts |
| Activity + Dashboard-Prefs | 8 | dashboard.ts |
| Environments + Env-Notifications + Env-Settings | 18 | environments.ts |
| Auth-LDAP + Auth-OIDC + Hawser-Tokens (+ \`logout\` standalone) | 14 | auth.ts |
| Stack-Env + Stack-Compose + Stack-Lifecycle + Stack-Path + Stack-Source | 23 | stacks.ts |
| Git-Repository + Git-Stack + Git-Credentials | 21 | git-stacks.ts |
| Container-Lifecycle + Container-Inspect + Container-Files | 28 | containers.ts |
| Prune-Family + System-Files + System-Info + Health + License + Scanner-Settings (+ 5 standalones) | 25 | system.ts |
| Users + Roles + Profile + Favorites-Prefs + Config-Sets | 29 | users.ts |

PR #58's \`update_stack_env\` and \`update_stack_env_raw\` descriptions are **preserved character-for-character** except for wrapping sibling tool names in backticks (required by the new test). All other prose is original to this PR.

## Verification

- **41/41 audit tests GREEN** (4 generic + 38 cluster + initial discovery block) — \`npx vitest run tests/tool-descriptions.test.ts\`
- **228/228 total tests GREEN** — \`npm test\`
- **Typecheck clean** — \`npm run typecheck\`
- **Validator unchanged** — \`node scripts/validate-mcp-tools.mjs\` still reports 220 COVERED, 44 MISSING_TOOL, 0 ORPHANED, 0 PARAM_MISMATCH, 0 MISSING_ENCODE. Audit and coverage are orthogonal.
- **No \`Co-Authored-By: Claude\`** anywhere in history (20 audit-related commits, all clean)
- **All 20 commits reference \`Refs #62\`** in the body

## Why this matters

A Claude client given the question "lies die Env-Variablen vom Stack" can now correctly pick between \`get_stack_env\` (DB-backed structured list with secret flags) and \`get_stack_env_raw\` (the on-disk \`.env\` file content) — both descriptions name their axis, and the descriptions cross-reference each other in the form Claude can parse as code-style identifiers. The same pattern applies to all 38 cluster boundaries: container lifecycle (start/stop/restart/pause), prune family (4 typed + 1 aggregator), notification test variants (saved-id vs. config-blob vs. fire-default), test pairs (full-test vs. connection-probe), and so on.

The new test scaffolding prevents regression: a future tool added without a description (or without cross-references) will turn the audit test red on every CI run.

Closes #62.

Refs #58 (quality bar), #60 (coverage tracker — orthogonal to this PR).