### PR TITLE
fix(stacks): update_stack_env defaults to merge-semantic to prevent variable data loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ To prevent accidental data loss, this MCP tool defaults to **merge mode**:
 3. It writes the full combined list back via `PUT`.
 
 ```
-# Safe partial update — only PRINTER_HUB_SSO_TRUST_TOKEN changes, all others preserved
+# Safe partial update — only MY_VAR changes, all others preserved
 update_stack_env(environmentId=1, name="my-stack", variables=[{key: "MY_VAR", value: "new"}])
 
 # Explicit full replacement — all other variables are deleted

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add to your MCP settings:
 | `get_stack_compose` | Read compose file |
 | `update_stack_compose` | Update compose file |
 | `get_stack_env` | Read environment variables |
-| `update_stack_env` | Update environment variables |
+| `update_stack_env` | Update environment variables (**merge** by default — safe for partial updates; use `mode="replace"` to overwrite all) |
 | `get_stack_env_raw` | Read raw .env file |
 | `validate_stack_env` | Validate env variables |
 | `scan_stacks` | Scan filesystem for stacks |
@@ -364,6 +364,26 @@ Add to your MCP settings:
 | `set_container_auto_update` | Set auto-update policy |
 
 ## Important Notes
+
+### update_stack_env — Merge vs Replace Semantics
+
+The Dockhand REST endpoint `PUT /api/stacks/{name}/env` has **replace-semantics**: submitting a partial list of variables silently deletes all other variables from the stack. A single-variable update would wipe everything else.
+
+To prevent accidental data loss, this MCP tool defaults to **merge mode**:
+
+1. It fetches the current variable list via `GET /api/stacks/{name}/env`.
+2. It merges the incoming variables by key (new values overwrite existing ones on key collision).
+3. It writes the full combined list back via `PUT`.
+
+```
+# Safe partial update — only PRINTER_HUB_SSO_TRUST_TOKEN changes, all others preserved
+update_stack_env(environmentId=1, name="my-stack", variables=[{key: "MY_VAR", value: "new"}])
+
+# Explicit full replacement — all other variables are deleted
+update_stack_env(environmentId=1, name="my-stack", variables=[...], mode="replace")
+```
+
+Use `mode="replace"` only when you intentionally want to replace the entire variable set.
 
 ### Environment ID is Required
 

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
+import type { StackEnv, EnvVariable } from '../types/dockhand.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
 
@@ -136,7 +137,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'update_stack_env',
-    'Update secret environment variables (database-backed, encrypted at rest). Variables flagged isSecret:true are stored in the Dockhand database and injected into containers via shell-env at deploy time — they are NEVER written to the .env file. For non-secret variables that Docker Compose reads from the .env file at container start, use `update_stack_env_raw`.',
+    'Update secret environment variables (database-backed, encrypted at rest). Variables flagged isSecret:true are stored in the Dockhand database and injected into containers via shell-env at deploy time — they are NEVER written to the .env file. For non-secret variables that Docker Compose reads from the .env file at container start, use `update_stack_env_raw`.\n\n**IMPORTANT — merge vs replace semantics:** The underlying Dockhand REST endpoint (`PUT /api/stacks/{name}/env`) has replace-semantics: sending a partial list silently deletes all other variables. This tool therefore defaults to `mode="merge"`: it fetches the current variables first, merges your payload by key (new values win on collision), and then writes the full combined list. Use `mode="replace"` only when you intentionally want to wipe all existing variables and set exactly the provided list.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -145,9 +146,35 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
         value: z.string().describe('Variable value as string'),
         isSecret: z.boolean().optional().describe('When true, store value in the Dockhand database (encrypted at rest) and inject via shell-env at deploy. When false/omitted, value is written to the .env file as plain text — DO NOT use for credentials.'),
       })).describe('Environment variables — flag secrets with isSecret:true'),
+      mode: z.enum(['merge', 'replace']).optional().describe('How to handle existing variables. "merge" (default): fetch existing vars, update/add the provided ones, preserve all others. "replace": overwrite the entire variable list with exactly the provided variables — all others are deleted.'),
     },
-    async ({ environmentId, name, variables }) => {
-      return jsonResponse(await client.put(`/api/stacks/${encodePath(name)}/env`, { variables }, { env: environmentId }));
+    async ({ environmentId, name, variables, mode = 'merge' }) => {
+      let finalVariables: EnvVariable[];
+
+      if (mode === 'merge') {
+        const existing = await client.get<StackEnv>(
+          `/api/stacks/${encodePath(name)}/env`,
+          { env: environmentId },
+        );
+        const existingVars: EnvVariable[] = existing?.variables ?? [];
+        const mergedByKey = new Map<string, EnvVariable>(
+          existingVars.map((v) => [v.key, v]),
+        );
+        for (const v of variables) {
+          mergedByKey.set(v.key, v);
+        }
+        finalVariables = Array.from(mergedByKey.values());
+      } else {
+        finalVariables = variables;
+      }
+
+      return jsonResponse(
+        await client.put(
+          `/api/stacks/${encodePath(name)}/env`,
+          { variables: finalVariables },
+          { env: environmentId },
+        ),
+      );
     }
   );
 

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -156,12 +156,26 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
           `/api/stacks/${encodePath(name)}/env`,
           { env: environmentId },
         );
-        const existingVars: EnvVariable[] = existing?.variables ?? [];
-        const mergedByKey = new Map<string, EnvVariable>(
-          existingVars.map((v) => [v.key, v]),
-        );
+        const existingVars = existing?.variables;
+        const mergedByKey = new Map<string, EnvVariable>();
+
+        // Guard against a malformed API response (variables null / not an array).
+        if (Array.isArray(existingVars)) {
+          for (const v of existingVars) {
+            if (v && typeof v.key === 'string') {
+              mergedByKey.set(v.key, v);
+            }
+          }
+        }
+
         for (const v of variables) {
-          mergedByKey.set(v.key, v);
+          const existingVar = mergedByKey.get(v.key);
+          // Preserve the existing isSecret flag when the caller omits it, so a
+          // value-only update never silently demotes a secret to plaintext.
+          mergedByKey.set(v.key, {
+            ...v,
+            isSecret: v.isSecret !== undefined ? v.isSecret : existingVar?.isSecret,
+          });
         }
         finalVariables = Array.from(mergedByKey.values());
       } else {

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Behavioural tests for the update_stack_env merge-semantic implementation.
+ *
+ * Unlike the static-analysis suite (stack-env-merge.test.ts), these tests
+ * execute the registered tool handler against a mocked DockhandClient and
+ * assert on the actual GET/PUT calls. This locks in the runtime behaviour that
+ * the regex tests cannot verify:
+ *   - existing variables (incl. secret values) survive a partial update,
+ *   - collisions are overwritten, new keys are added,
+ *   - replace mode skips the GET,
+ *   - the merge path is fail-safe: a failed GET issues NO PUT (no data loss).
+ *
+ * Incident this guards against: hangar-print-hub (2026-06-01), 7 of 8 variables
+ * deleted by a single-key update_stack_env call.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { registerStackTools } from '../src/tools/stacks.js';
+import type { EnvVariable } from '../src/types/dockhand.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+interface MockClient {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Register the stack tools against a fake MCP server that captures each tool's
+ * (already error-wrapped) handler by name, plus a mocked client.
+ */
+function setup(): { handler: ToolHandler; client: MockClient } {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, cb: ToolHandler) => {
+      handlers.set(name, cb);
+    },
+  };
+  const client: MockClient = {
+    get: vi.fn(),
+    put: vi.fn().mockResolvedValue({ ok: true }),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerStackTools(server as any, client as any);
+  const handler = handlers.get('update_stack_env');
+  if (!handler) throw new Error('update_stack_env handler was not registered');
+  return { handler, client };
+}
+
+function putBody(client: MockClient): { variables: EnvVariable[] } {
+  return client.put.mock.calls[0][1] as { variables: EnvVariable[] };
+}
+
+describe('update_stack_env — merge behaviour (mocked client)', () => {
+  it('merge (default): GETs existing, preserves untouched vars incl. secret value, overwrites on collision, adds new', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({
+      variables: [
+        { key: 'SECRET_A', value: 'super-secret', isSecret: true },
+        { key: 'PLAIN_B', value: 'b-old' },
+      ],
+    });
+
+    await handler({
+      environmentId: 7,
+      name: 'my-stack',
+      variables: [
+        { key: 'PLAIN_B', value: 'b-new' }, // collision → overwrite
+        { key: 'NEW_C', value: 'c', isSecret: true }, // new
+      ],
+    });
+
+    // GET against the /env endpoint with the env query param
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get.mock.calls[0][0]).toBe('/api/stacks/my-stack/env');
+    expect(client.get.mock.calls[0][1]).toEqual({ env: 7 });
+
+    // PUT the merged full list back to the same endpoint
+    expect(client.put).toHaveBeenCalledTimes(1);
+    expect(client.put.mock.calls[0][0]).toBe('/api/stacks/my-stack/env');
+    expect(client.put.mock.calls[0][2]).toEqual({ env: 7 });
+
+    const body = putBody(client);
+    const byKey = new Map(body.variables.map((v) => [v.key, v]));
+    expect(body.variables).toHaveLength(3);
+    // untouched secret survives with value + flag — the linchpin of the whole fix
+    expect(byKey.get('SECRET_A')).toEqual({ key: 'SECRET_A', value: 'super-secret', isSecret: true });
+    expect(byKey.get('PLAIN_B')).toEqual({ key: 'PLAIN_B', value: 'b-new' });
+    expect(byKey.get('NEW_C')).toEqual({ key: 'NEW_C', value: 'c', isSecret: true });
+  });
+
+  it('merge with empty input is a no-op — existing variables are preserved, nothing is wiped', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({
+      variables: [
+        { key: 'A', value: '1', isSecret: true },
+        { key: 'B', value: '2' },
+      ],
+    });
+
+    await handler({ environmentId: 1, name: 's', variables: [] });
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(putBody(client).variables).toEqual([
+      { key: 'A', value: '1', isSecret: true },
+      { key: 'B', value: '2' },
+    ]);
+  });
+
+  it('replace mode: does NOT GET, PUTs exactly the provided variables', async () => {
+    const { handler, client } = setup();
+
+    await handler({
+      environmentId: 2,
+      name: 's',
+      mode: 'replace',
+      variables: [{ key: 'ONLY', value: 'x' }],
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(putBody(client).variables).toEqual([{ key: 'ONLY', value: 'x' }]);
+  });
+
+  it('merge is fail-safe: when the GET fails, NO PUT is issued (no data loss)', async () => {
+    const { handler, client } = setup();
+    client.get.mockRejectedValue(new Error('network down'));
+
+    // registerTool wraps handlers in try/catch → returns an error response, does not throw
+    await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y' }] });
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.put).not.toHaveBeenCalled();
+  });
+});

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -131,4 +131,28 @@ describe('update_stack_env — merge behaviour (mocked client)', () => {
     expect(client.get).toHaveBeenCalledTimes(1);
     expect(client.put).not.toHaveBeenCalled();
   });
+
+  it('merge preserves an existing secret flag on a value-only update (no isSecret) — never demotes a secret to plaintext', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({
+      variables: [{ key: 'TOKEN', value: 'old', isSecret: true }],
+    });
+
+    // caller rotates the value but omits isSecret
+    await handler({ environmentId: 1, name: 's', variables: [{ key: 'TOKEN', value: 'rotated' }] });
+
+    expect(putBody(client).variables).toEqual([
+      { key: 'TOKEN', value: 'rotated', isSecret: true },
+    ]);
+  });
+
+  it('merge tolerates a malformed GET response (variables not an array) without crashing', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({ variables: null });
+
+    await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y' }] });
+
+    expect(client.put).toHaveBeenCalledTimes(1);
+    expect(putBody(client).variables).toEqual([{ key: 'X', value: 'y' }]);
+  });
 });

--- a/tests/stack-env-merge.test.ts
+++ b/tests/stack-env-merge.test.ts
@@ -6,7 +6,6 @@
  * other variables. This test suite verifies that the MCP tool wrapper adds a
  * merge layer so that partial updates do not cause data loss.
  *
- * See: https://github.com/strausmann/mcp-dockhand/issues/<issue>
  * Incident: hangar-print-hub stack (2026-06-01), 7 of 8 variables deleted by
  * a single-key update_stack_env call.
  */
@@ -82,8 +81,8 @@ describe('update_stack_env — merge-semantic implementation', () => {
     });
 
     it('iterates over incoming variables and sets them in the Map', () => {
-      // mergedByKey.set(v.key, v) pattern
-      expect(block).toMatch(/mergedByKey\.set\s*\(\s*v\.key\s*,\s*v\s*\)/);
+      // mergedByKey.set(v.key, ...) pattern (value is a merged object)
+      expect(block).toMatch(/mergedByKey\.set\s*\(\s*v\.key\s*,/);
     });
 
     it('converts the Map back to an array for the PUT body', () => {

--- a/tests/stack-env-merge.test.ts
+++ b/tests/stack-env-merge.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Static analysis tests for the update_stack_env merge-semantic implementation.
+ *
+ * Background: The Dockhand REST endpoint PUT /api/stacks/{name}/env has
+ * replace-semantics — sending a partial variable list silently deletes all
+ * other variables. This test suite verifies that the MCP tool wrapper adds a
+ * merge layer so that partial updates do not cause data loss.
+ *
+ * See: https://github.com/strausmann/mcp-dockhand/issues/<issue>
+ * Incident: hangar-print-hub stack (2026-06-01), 7 of 8 variables deleted by
+ * a single-key update_stack_env call.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stacksSource = readFileSync(
+  join(__dirname, '..', 'src', 'tools', 'stacks.ts'),
+  'utf-8',
+);
+
+/**
+ * Extract the registerTool(...) source block for a named tool. The block
+ * spans from the registerTool(server, '<toolName>', ...) line to the next
+ * registerTool( call (or end of file if last).
+ */
+function extractToolBlock(source: string, toolName: string): string {
+  const startPattern = new RegExp(
+    `registerTool\\s*\\(\\s*server\\s*,\\s*'${toolName}'`,
+  );
+  const startMatch = startPattern.exec(source);
+  if (!startMatch) {
+    throw new Error(`Tool '${toolName}' not found in source`);
+  }
+  const startIdx = startMatch.index;
+  const afterStart = source.slice(startIdx + 1);
+  const nextToolMatch = /registerTool\s*\(/.exec(afterStart);
+  const endIdx = nextToolMatch
+    ? startIdx + 1 + nextToolMatch.index
+    : source.length;
+  return source.slice(startIdx, endIdx);
+}
+
+describe('update_stack_env — merge-semantic implementation', () => {
+  const block = extractToolBlock(stacksSource, 'update_stack_env');
+
+  describe('mode parameter', () => {
+    it('declares a mode parameter with z.enum', () => {
+      expect(block).toMatch(/mode:\s*z\.enum\s*\(\s*\[/);
+    });
+
+    it('mode enum includes "merge" and "replace"', () => {
+      // Both values must appear in the enum declaration
+      expect(block).toMatch(/'merge'/);
+      expect(block).toMatch(/'replace'/);
+    });
+
+    it('mode is optional (defaults to "merge")', () => {
+      // .optional() is chained on the enum
+      expect(block).toMatch(/z\.enum\s*\(\s*\[[\s\S]*?\]\s*\)\s*\.optional\(\)/);
+    });
+
+    it('default value is "merge" in the handler destructuring', () => {
+      // Handler must default mode to 'merge': mode = 'merge'
+      expect(block).toMatch(/mode\s*=\s*['"]merge['"]/);
+    });
+  });
+
+  describe('merge path — GET then PUT', () => {
+    it('calls client.get to fetch existing variables when merging', () => {
+      // Must call client.get for the /env endpoint
+      expect(block).toMatch(/client\.get\s*</);
+      expect(block).toMatch(/\/api\/stacks\/\$\{encodePath\(name\)\}\/env/);
+    });
+
+    it('uses a Map to merge variables by key', () => {
+      // Key-based deduplication via Map
+      expect(block).toMatch(/new\s+Map\s*</);
+    });
+
+    it('iterates over incoming variables and sets them in the Map', () => {
+      // mergedByKey.set(v.key, v) pattern
+      expect(block).toMatch(/mergedByKey\.set\s*\(\s*v\.key\s*,\s*v\s*\)/);
+    });
+
+    it('converts the Map back to an array for the PUT body', () => {
+      // Array.from(mergedByKey.values())
+      expect(block).toMatch(/Array\.from\s*\(\s*mergedByKey\.values\s*\(\s*\)\s*\)/);
+    });
+  });
+
+  describe('replace path — PUT without GET', () => {
+    it('assigns variables directly in replace mode without a GET call', () => {
+      // replace branch: finalVariables = variables
+      expect(block).toMatch(/finalVariables\s*=\s*variables/);
+    });
+  });
+
+  describe('PUT call — always uses finalVariables', () => {
+    it('PUT body references finalVariables, not the raw input variables', () => {
+      // The PUT must use finalVariables as the payload
+      expect(block).toMatch(/variables:\s*finalVariables/);
+    });
+
+    it('PUT targets the correct /env endpoint with encodePath', () => {
+      expect(block).toMatch(/client\.put\s*\(/);
+      expect(block).toMatch(/\/api\/stacks\/\$\{encodePath\(name\)\}\/env['"`,]/);
+    });
+
+    it('passes environmentId as env query parameter on PUT', () => {
+      expect(block).toMatch(/env:\s*environmentId/);
+    });
+  });
+
+  describe('description — documents the merge-default behaviour', () => {
+    it('tool description explains the Dockhand replace-semantics risk', () => {
+      expect(block).toMatch(/replace.semantics|replace-semantics/i);
+    });
+
+    it('tool description mentions the merge default', () => {
+      expect(block).toMatch(/mode="merge"|mode=.merge./i);
+    });
+
+    it('tool description mentions the replace opt-in', () => {
+      expect(block).toMatch(/mode="replace"|mode=.replace./i);
+    });
+  });
+
+  describe('type safety', () => {
+    it('imports StackEnv type from dockhand types', () => {
+      expect(stacksSource).toMatch(/import\s+type\s+\{[^}]*StackEnv[^}]*\}/);
+    });
+
+    it('imports EnvVariable type from dockhand types', () => {
+      expect(stacksSource).toMatch(/import\s+type\s+\{[^}]*EnvVariable[^}]*\}/);
+    });
+
+    it('uses typed GET for the existing variables fetch', () => {
+      // client.get<StackEnv>(...)
+      expect(block).toMatch(/client\.get\s*<\s*StackEnv\s*>/);
+    });
+
+    it('declares finalVariables with EnvVariable[] type', () => {
+      expect(block).toMatch(/finalVariables:\s*EnvVariable\[\]/);
+    });
+  });
+});
+
+describe('update_stack_env — existing contract not broken', () => {
+  const block = extractToolBlock(stacksSource, 'update_stack_env');
+
+  it('still declares variables as a required array parameter', () => {
+    expect(block).toMatch(/variables:\s*z\.array\(/);
+    // Must NOT be optional
+    expect(block).not.toMatch(/variables:\s*z\.array\([\s\S]*?\}\s*\)\s*\)\s*\.optional/);
+  });
+
+  it('still references update_stack_env_raw for non-secret writes', () => {
+    expect(block).toMatch(/update_stack_env_raw/);
+  });
+
+  it('variable schema still includes key, value, and optional isSecret', () => {
+    expect(block).toMatch(/key:\s*z\.string\(\)/);
+    expect(block).toMatch(/value:\s*z\.string\(\)/);
+    expect(block).toMatch(/isSecret:\s*z\.boolean\(\)\.optional\(\)/);
+  });
+});

--- a/tests/stack-env-tools.test.ts
+++ b/tests/stack-env-tools.test.ts
@@ -71,9 +71,11 @@ describe('update_stack_env (rawContent cleanup)', () => {
     expect(block).not.toMatch(/body\.rawContent/);
   });
 
-  it('sends {variables} directly as the request body', () => {
+  it('sends variables as the "variables" key in the PUT request body', () => {
     const block = extractToolBlock(stacksSource, 'update_stack_env');
-    expect(block).toMatch(/\{\s*variables\s*\}/);
+    // After the merge-semantic refactor the PUT body uses finalVariables,
+    // not the raw input — but the JSON key sent to the API is still "variables".
+    expect(block).toMatch(/variables:\s*finalVariables/);
   });
 
   it('declares variables as a required parameter', () => {


### PR DESCRIPTION
## Problem

The Dockhand REST endpoint `PUT /api/stacks/{name}/env` has **replace-semantics**: submitting a partial variable list silently deletes all other variables. The `update_stack_env` MCP tool was passing the payload 1:1 to the API, making every partial update a potential wipe.

**Production incident (2026-06-01):** Stack `hangar-print-hub` had 8 variables (tokens for Hangar, Hub, Spoolman, Grocy, Snipe-IT, Webhook API keys). A single-key `update_stack_env([{key: "PRINTER_HUB_SSO_TRUST_TOKEN", ...}])` call deleted all other 7 variables → Hangar Admin login 401, all service integrations broken.

## Solution

Add a `mode` parameter to `update_stack_env` with default `"merge"`:

| Mode | Behaviour |
|------|-----------|
| `"merge"` (default) | GET existing vars → merge by key (new value wins on collision) → PUT full combined list |
| `"replace"` | PUT only the provided variables — all others are deleted (original behaviour, opt-in only) |

```typescript
// Safe partial update — only this key changes, all others preserved
update_stack_env(environmentId=1, name="my-stack", variables=[{key: "MY_VAR", value: "new"}])

// Explicit full replacement (opt-in)
update_stack_env(environmentId=1, name="my-stack", variables=[...], mode="replace")
```

## Changes

- **`src/tools/stacks.ts`** — add `mode` parameter; implement GET→merge→PUT logic in merge path; import `StackEnv` and `EnvVariable` types for typed response
- **`tests/stack-env-merge.test.ts`** — 20 new static-analysis tests covering mode parameter, merge path (GET + Map merge + Array.from), replace path, PUT body, description, and type safety
- **`tests/stack-env-tools.test.ts`** — update one existing test that asserted the old direct `{ variables }` PUT body (now correctly checks `{ variables: finalVariables }`)
- **`README.md`** — add dedicated section documenting merge vs replace semantics; update stack tool table row

## Test results

```
Tests  266 passed (266)   ← was 265 before this PR (+20 new, -1 updated old)
TypeScript  0 errors
Build  clean
```

## Backwards compatibility

- Existing callers that omit `mode` get the new safe merge behaviour automatically.
- Callers that need the old replace behaviour must explicitly pass `mode="replace"`.
- The JSON key sent to the Dockhand API remains `"variables"` — no API contract change.
