### PR TITLE
fix(ci): amd64-only docker smoke build to stop 6h QEMU hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,21 +38,23 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     needs: build
+    # amd64-only smoke build. arm64 is built and verified on release.yml via a
+    # native arm64 runner (build matrix), so emulating it here under QEMU is
+    # redundant — and it repeatedly hung for ~6h until GitHub auto-cancelled the
+    # job. timeout-minutes is a backstop against any future hang.
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker image (multi-arch smoke)
+      - name: Build Docker image (amd64 smoke)
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem
The CI `docker` job builds `linux/amd64,linux/arm64` with `push: false` as a smoke test, emulating **arm64 via QEMU** on an amd64 runner. That emulation repeatedly **hangs for ~6h** until GitHub auto-cancels the job, turning the `docker` check **red on otherwise-green PRs** (#82, #61, #76, #77, …) and blocking the merge signal. `build (22)` (build + tests) passes on all of them — only this smoke job hangs.

## Why arm64 here is redundant
`release.yml` already builds **and verifies** arm64 on a **native arm64 runner** (build matrix per arch → digest artifacts → `buildx imagetools` manifest combine, with an explicit `Missing linux/arm64` guard). Emulating arm64 in the PR smoke test adds nothing but flakiness.

## Change
- Smoke job builds **only `linux/amd64`** (native, ~3 min)
- Drop the now-unnecessary **QEMU setup** step
- Add **`timeout-minutes: 10`** as a backstop against any future hang

## Side effect
`docker/setup-qemu-action` is no longer referenced anywhere → the open Dependabot bump **#66** can be closed.

## Risk
Low. arm64 remains fully built + verified on release. No change to the published images.