### PR TITLE
fix(ci): run releases nightly + on demand, not on every push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  # Releases run once nightly (batching the day's commits into a single release)
+  # or on demand — NOT on every push to main. semantic-release evaluates all
+  # commits since the last tag, so a nightly cadence still releases everything.
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC nightly
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem
`release.yml` triggers on `push: branches: [main]`, so **every merged PR** starts a Release run and every `feat`/`fix` commit cuts a release. With the current batch of merges (and Dependabot), that means a release per merge.

## Change
```yaml
on:
  schedule:
    - cron: '0 3 * * *'   # 03:00 UTC nightly
  workflow_dispatch:
```
- **Nightly** cron batches the day's commits into a single release.
- **workflow_dispatch** allows a manual release any time.
- **push: main** trigger removed → no more per-commit releases.

## Why this still releases everything
semantic-release evaluates all commits since the last tag, so the nightly run releases everything accumulated that day — just as **one** release instead of one per merge.

## Notes
- Cron time (03:00 UTC) is easily adjustable to your preferred night window (CET ≈ +1/+2h).
- No change to what gets released or how (same job, same semantic-release config) — only the trigger cadence.