### PR TITLE
fix(ci): event-agnostic timestamp for OCI image.created label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute build timestamp (event-agnostic)
+        id: ts
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v7
@@ -114,7 +118,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.created=${{ steps.ts.outputs.created }}
             org.opencontainers.image.licenses=MIT
 
       - name: Export digest


### PR DESCRIPTION
## Problem (follow-up to #97, caught by Copilot review)
#97 switched the Release workflow from `push` to `schedule`/`workflow_dispatch`. But the image label still used:
```yaml
org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
```
`github.event.head_commit` **only exists for `push` events**. On the now-only scheduled/manual runs it is empty → a blank `org.opencontainers.image.created` OCI label on every published image.

## Fix
Compute an ISO-8601 UTC timestamp in a step and reference it:
```yaml
- name: Compute build timestamp (event-agnostic)
  id: ts
  run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
...
org.opencontainers.image.created=${{ steps.ts.outputs.created }}
```
Event-agnostic (works on schedule/dispatch/push) and semantically correct — `image.created` per the OCI spec is the build time.

_(Copilot suggested `github.run_started_at`, which is not a documented `github`-context field; a computed step is the reliable choice.)_