### PR TITLE
fix(ci): align upload-artifact to v8 to match download-artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/*


### PR DESCRIPTION
## Problem
#68 bumped `actions/download-artifact` 4 → 8 in `release.yml` but left `actions/upload-artifact` at **v7**. The release's `docker-build` leg **uploads** per-arch digest artifacts (v7) and the `docker-merge` leg **downloads** them (v8) — a major-version mismatch between the two artifact actions. Since releases now run **nightly**, a break here would only surface on the next scheduled run.

## Fix
Bump `actions/upload-artifact` v7 → **v8** so both legs use the same major version.

## Risk
Minimal — both are already v4+ generation; this just removes the version skew introduced by #68.