### PR TITLE
fix(ci): pin artifact actions to v7 (upload-artifact has no v8)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest artifact
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Download digest artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: digest-*
           path: /tmp/digests


### PR DESCRIPTION
## Problem
The manual v1.8.0 release published the tag + GitHub release, but both `docker-build` legs failed at *Set up job* with `Unable to resolve action actions/upload-artifact@v8, unable to find version v8` → no Docker image was pushed for v1.8.0.

## Cause
`actions/upload-artifact` only exists up to **v7** (download-artifact goes to v8). #100 wrongly bumped upload to a non-existent v8; they can only match at **v7**.

## Fix
Pin both artifact actions to **v7** (matched, both exist — verified: upload v4–v7, download v3–v8). The next release (v1.8.1) will then build + push the image with the new tools.