### PR TITLE
fix(deps): sync package-lock so docker-build npm ci passes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -454,6 +454,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.0.tgz",
+      "integrity": "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",


### PR DESCRIPTION
## Problem
Releases v1.8.0 and v1.8.1 cut tags but pushed **no Docker image**. `docker-build` fails inside the Dockerfile at `npm ci`:
```
npm error Missing: conventional-commits-filter@6.0.1 from lock file
npm error Missing: conventional-commits-parser@7.1.0 from lock file
```
Transitive deps of semantic-release. The release job uses `npm install` (tolerant) so it stayed green; the image build uses `npm ci` (strict) and dies.

## Fix
`npm install --package-lock-only` to add the missing entries. No `package.json` change. `npm ci --dry-run` passes.

Refs #69