### PR TITLE
feat(tools): stack-env ergonomics — summary/hint, remove_stack_env_vars, collision check

### DIFF
--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -232,17 +232,20 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'remove_stack_env_vars',
-    'Remove environment variables from a stack across BOTH stores. Secret keys are dropped from the encrypted database set (remaining secrets are preserved via masked "***" values); non-secret keys are removed from the .env file. Keys present in neither are returned in not_found. This is the safe way to delete variables — `update_stack_env` in the default merge mode cannot remove keys.',
+    'Remove environment variables from a stack across BOTH stores. Database-backed keys (secrets, and non-secrets that live in the database for git stacks) are dropped by rebuilding the full remaining database set — remaining secrets stay masked as "***"; .env-backed non-secret keys are removed by rewriting the .env file. Result reports `removed` (all keys actually removed, from either store) and `not_found` (keys present in neither). This is the safe way to delete variables — `update_stack_env` in the default merge mode cannot remove keys.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
       keys: z.array(z.string()).describe('Variable names to remove'),
     },
     async ({ environmentId, name, keys }) => {
-      const keySet = new Set(keys);
+      const uniqueKeys = [...new Set(keys)];
+      const keySet = new Set(uniqueKeys);
+
       const structured = await client.get<StackEnv>(
         `/api/stacks/${encodePath(name)}/env`, { env: environmentId });
       const vars = Array.isArray(structured?.variables) ? structured.variables : [];
+      const structuredKeys = new Set(vars.map((v) => v.key));
       const secretKeys = new Set(vars.filter((v) => v.isSecret).map((v) => v.key));
 
       const raw = await client.get<string>(
@@ -250,36 +253,44 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       const rawStr = typeof raw === 'string' ? raw : '';
       const envKeys = new Set(parseDotEnvKeys(rawStr));
 
-      const secretTargets = keys.filter((k) => secretKeys.has(k));
-      const envTargets = keys.filter((k) => envKeys.has(k));
-      const notFound = keys.filter((k) => !secretKeys.has(k) && !envKeys.has(k));
+      const removed = uniqueKeys.filter((k) => structuredKeys.has(k) || envKeys.has(k));
+      const notFound = uniqueKeys.filter((k) => !structuredKeys.has(k) && !envKeys.has(k));
 
-      if (secretTargets.length > 0) {
-        const remainingSecrets = vars
-          .filter((v) => v.isSecret && !keySet.has(v.key))
-          .map((v) => ({ key: v.key, value: '***', isSecret: true }));
+      // A target changes the DB store if it is a secret, or a non-secret that lives
+      // in the DB (git stacks: present in the structured view but NOT in .env).
+      const dbManagedTargets = uniqueKeys.filter(
+        (k) => secretKeys.has(k) || (structuredKeys.has(k) && !envKeys.has(k)));
+
+      if (dbManagedTargets.length > 0) {
+        // Rebuild the FULL remaining DB-backed set minus targets — never drop
+        // untouched vars. Keep secrets (masked '***'; the backend preserves the real
+        // value) and DB-managed non-secrets (not in .env). .env-backed non-secrets are
+        // handled by the raw rewrite below, so they are excluded here to avoid creating
+        // a DB/.env duplicate.
+        const remaining = vars
+          .filter((v) => !keySet.has(v.key))
+          .filter((v) => v.isSecret || !envKeys.has(v.key))
+          .map((v) => ({ key: v.key, value: v.isSecret ? '***' : v.value, isSecret: v.isSecret ?? false }));
         await client.put(`/api/stacks/${encodePath(name)}/env`,
-          { variables: remainingSecrets }, { env: environmentId });
+          { variables: remaining }, { env: environmentId });
       }
 
-      let removedEnv: string[] = [];
+      const envTargets = uniqueKeys.filter((k) => envKeys.has(k));
       if (envTargets.length > 0) {
         try {
           const newContent = removeKeysFromDotEnv(rawStr, envTargets);
           await client.put(`/api/stacks/${encodePath(name)}/env/raw`,
             { content: newContent }, { env: environmentId });
-          removedEnv = envTargets;
         } catch (e) {
           return jsonResponse({
-            removed_secrets: secretTargets,
-            removed_env: [],
+            removed: removed.filter((k) => !envTargets.includes(k)),
             not_found: notFound,
-            error: `Secrets removed, but .env rewrite failed: ${e instanceof Error ? e.message : String(e)}`,
+            error: `DB entries removed, but .env rewrite failed: ${e instanceof Error ? e.message : String(e)}`,
           });
         }
       }
 
-      return jsonResponse({ removed_secrets: secretTargets, removed_env: removedEnv, not_found: notFound });
+      return jsonResponse({ removed, not_found: notFound });
     }
   );
 

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -283,6 +283,30 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
+  registerTool(server, 'check_stack_env_collisions',
+    'Read-only check reporting variable keys defined BOTH as a database-backed secret and in the plain .env file. Such duplicates are ambiguous: at deploy the secret (shell environment) wins over the .env value. Remove the duplicate copy with remove_stack_env_vars.',
+    {
+      environmentId: z.number().describe('Environment ID'),
+      name: z.string().describe('Stack name'),
+    },
+    async ({ environmentId, name }) => {
+      const structured = await client.get<StackEnv>(
+        `/api/stacks/${encodePath(name)}/env`, { env: environmentId });
+      const secretKeys = new Set(
+        (Array.isArray(structured?.variables) ? structured.variables : [])
+          .filter((v) => v.isSecret).map((v) => v.key));
+      const raw = await client.get<string>(
+        `/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
+      const envKeys = parseDotEnvKeys(typeof raw === 'string' ? raw : '');
+      const collisions = envKeys.filter((k) => secretKeys.has(k));
+      return jsonResponse(
+        collisions.length > 0
+          ? { collisions, note: 'These keys exist BOTH as a DB secret and in .env. The DB secret (shell-env) wins at deploy; remove the .env copy with remove_stack_env_vars.' }
+          : { collisions: [] },
+      );
+    }
+  );
+
   registerTool(server, 'validate_stack_env', 'Validate the environment variables of a stack for completeness and correctness without mutating; use `update_stack_env` or `update_stack_env_raw` to fix any reported issues.',
     {
       environmentId: z.number().describe('Environment ID'),

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -232,7 +232,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'remove_stack_env_vars',
-    'Remove environment variables from a stack across BOTH stores. Secret keys are dropped from the encrypted database set (remaining secrets are preserved via masked "***" values); non-secret keys are removed from the .env file. Keys present in neither are returned in not_found. This is the safe way to delete variables — update_stack_env in the default merge mode cannot remove keys.',
+    'Remove environment variables from a stack across BOTH stores. Secret keys are dropped from the encrypted database set (remaining secrets are preserved via masked "***" values); non-secret keys are removed from the .env file. Keys present in neither are returned in not_found. This is the safe way to delete variables — `update_stack_env` in the default merge mode cannot remove keys.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -284,7 +284,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'check_stack_env_collisions',
-    'Read-only check reporting variable keys defined BOTH as a database-backed secret and in the plain .env file. Such duplicates are ambiguous: at deploy the secret (shell environment) wins over the .env value. Remove the duplicate copy with remove_stack_env_vars.',
+    'Read-only check reporting variable keys defined BOTH as a database-backed secret and in the plain .env file. Such duplicates are ambiguous: at deploy the secret (shell environment) wins over the .env value. Remove the duplicate copy with `remove_stack_env_vars`.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -8,6 +8,8 @@ import type { DockhandClient } from '../client/dockhand-client.js';
 import type { StackEnv, EnvVariable } from '../types/dockhand.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
+import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv } from '../utils/env-helpers.js';
+import type { EnvDiff } from '../utils/env-helpers.js';
 
 export function registerStackTools(server: McpServer, client: DockhandClient): void {
 
@@ -150,8 +152,10 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     },
     async ({ environmentId, name, variables, mode = 'merge' }) => {
       let finalVariables: EnvVariable[];
+      let diff: EnvDiff | undefined;
 
       if (mode === 'merge') {
+        // GET is load-bearing here: a failure must NOT issue a PUT (no data loss).
         const existing = await client.get<StackEnv>(
           `/api/stacks/${encodePath(name)}/env`,
           { env: environmentId },
@@ -178,11 +182,30 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
           });
         }
         finalVariables = Array.from(mergedByKey.values());
+        diff = diffEnvVars(Array.isArray(existingVars) ? existingVars : [], variables, 'merge');
       } else {
+        // replace: PUT the payload directly. No GET, no summary — the existing
+        // contract (replace does not GET) stays intact.
         finalVariables = variables;
       }
 
-      return jsonResponse(await client.put(`/api/stacks/${encodePath(name)}/env`, { variables: finalVariables }, { env: environmentId }));
+      const result = (await client.put(
+        `/api/stacks/${encodePath(name)}/env`, { variables: finalVariables },
+        { env: environmentId })) as Record<string, unknown>;
+
+      const hint =
+        diff && diff.added.length === 0 && diff.preserved.length > 0
+          ? `merge mode preserved ${diff.preserved.length} variable(s) you did not include and removed nothing. To remove variables use remove_stack_env_vars, or update_stack_env with mode="replace".`
+          : undefined;
+
+      return jsonResponse({
+        ...result,
+        ...(diff ? { summary: {
+          added: diff.added.length, updated: diff.updated.length,
+          preserved: diff.preserved.length, removed: diff.removed.length,
+        } } : {}),
+        ...(hint ? { hint } : {}),
+      });
     }
   );
 

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -244,7 +244,8 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
 
       const structured = await client.get<StackEnv>(
         `/api/stacks/${encodePath(name)}/env`, { env: environmentId });
-      const vars = Array.isArray(structured?.variables) ? structured.variables : [];
+      const vars = (Array.isArray(structured?.variables) ? structured.variables : [])
+        .filter((v) => v && typeof v.key === 'string');
       const structuredKeys = new Set(vars.map((v) => v.key));
       const secretKeys = new Set(vars.filter((v) => v.isSecret).map((v) => v.key));
 
@@ -305,7 +306,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
         `/api/stacks/${encodePath(name)}/env`, { env: environmentId });
       const secretKeys = new Set(
         (Array.isArray(structured?.variables) ? structured.variables : [])
-          .filter((v) => v.isSecret).map((v) => v.key));
+          .filter((v) => v && v.isSecret && typeof v.key === 'string').map((v) => v.key));
       const raw = await client.get<string>(
         `/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
       const envKeys = parseDotEnvKeys(typeof raw === 'string' ? raw : '');

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -231,6 +231,58 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
+  registerTool(server, 'remove_stack_env_vars',
+    'Remove environment variables from a stack across BOTH stores. Secret keys are dropped from the encrypted database set (remaining secrets are preserved via masked "***" values); non-secret keys are removed from the .env file. Keys present in neither are returned in not_found. This is the safe way to delete variables — update_stack_env in the default merge mode cannot remove keys.',
+    {
+      environmentId: z.number().describe('Environment ID'),
+      name: z.string().describe('Stack name'),
+      keys: z.array(z.string()).describe('Variable names to remove'),
+    },
+    async ({ environmentId, name, keys }) => {
+      const keySet = new Set(keys);
+      const structured = await client.get<StackEnv>(
+        `/api/stacks/${encodePath(name)}/env`, { env: environmentId });
+      const vars = Array.isArray(structured?.variables) ? structured.variables : [];
+      const secretKeys = new Set(vars.filter((v) => v.isSecret).map((v) => v.key));
+
+      const raw = await client.get<string>(
+        `/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
+      const rawStr = typeof raw === 'string' ? raw : '';
+      const envKeys = new Set(parseDotEnvKeys(rawStr));
+
+      const secretTargets = keys.filter((k) => secretKeys.has(k));
+      const envTargets = keys.filter((k) => envKeys.has(k));
+      const notFound = keys.filter((k) => !secretKeys.has(k) && !envKeys.has(k));
+
+      if (secretTargets.length > 0) {
+        const remainingSecrets = vars
+          .filter((v) => v.isSecret && !keySet.has(v.key))
+          .map((v) => ({ key: v.key, value: '***', isSecret: true }));
+        await client.put(`/api/stacks/${encodePath(name)}/env`,
+          { variables: remainingSecrets }, { env: environmentId });
+      }
+
+      let removedEnv: string[] = [];
+      if (envTargets.length > 0) {
+        try {
+          const newContent = removeKeysFromDotEnv(rawStr, envTargets);
+          await client.put(`/api/stacks/${encodePath(name)}/env/raw`,
+            { content: newContent }, { env: environmentId });
+          removedEnv = envTargets;
+        } catch (e) {
+          return jsonResponse({
+            removed_secrets: secretTargets,
+            removed_env: [],
+            not_found: notFound,
+            error: `Secrets removed, but .env rewrite failed: ${e instanceof Error ? e.message : String(e)}`,
+          });
+        }
+      }
+
+      return jsonResponse({ removed_secrets: secretTargets, removed_env: removedEnv, not_found: notFound });
+    }
+  );
+
   registerTool(server, 'validate_stack_env', 'Validate the environment variables of a stack for completeness and correctness without mutating; use `update_stack_env` or `update_stack_env_raw` to fix any reported issues.',
     {
       environmentId: z.number().describe('Environment ID'),

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -16,7 +16,8 @@ export function diffEnvVars(
   payload: EnvVariable[],
   mode: 'merge' | 'replace',
 ): EnvDiff {
-  const existingByKey = new Map(existing.map((v) => [v.key, v]));
+  const validExisting = existing.filter((v) => v && typeof v.key === 'string');
+  const existingByKey = new Map(validExisting.map((v) => [v.key, v]));
   const payloadKeys = new Set(payload.map((v) => v.key));
 
   const added: string[] = [];
@@ -32,7 +33,7 @@ export function diffEnvVars(
     if (valueChanged || secretChanged) updated.push(v.key);
   }
 
-  const untouched = existing.filter((v) => !payloadKeys.has(v.key)).map((v) => v.key);
+  const untouched = validExisting.filter((v) => !payloadKeys.has(v.key)).map((v) => v.key);
   return {
     added,
     updated,

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -1,0 +1,42 @@
+import type { EnvVariable } from '../types/dockhand.js';
+
+export interface EnvDiff {
+  added: string[];
+  updated: string[];
+  preserved: string[];
+  removed: string[];
+}
+
+/**
+ * Diff a payload against the existing variables for update_stack_env.
+ * A payload value of '***' means "keep existing value" and never counts as updated.
+ */
+export function diffEnvVars(
+  existing: EnvVariable[],
+  payload: EnvVariable[],
+  mode: 'merge' | 'replace',
+): EnvDiff {
+  const existingByKey = new Map(existing.map((v) => [v.key, v]));
+  const payloadKeys = new Set(payload.map((v) => v.key));
+
+  const added: string[] = [];
+  const updated: string[] = [];
+  for (const v of payload) {
+    const prev = existingByKey.get(v.key);
+    if (!prev) {
+      added.push(v.key);
+      continue;
+    }
+    const valueChanged = v.value !== '***' && v.value !== prev.value;
+    const secretChanged = v.isSecret !== undefined && v.isSecret !== prev.isSecret;
+    if (valueChanged || secretChanged) updated.push(v.key);
+  }
+
+  const untouched = existing.filter((v) => !payloadKeys.has(v.key)).map((v) => v.key);
+  return {
+    added,
+    updated,
+    preserved: mode === 'merge' ? untouched : [],
+    removed: mode === 'replace' ? untouched : [],
+  };
+}

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -45,8 +45,9 @@ export function diffEnvVars(
 export function parseDotEnvKeys(content: string): string[] {
   const keys: string[] = [];
   for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
+    let line = rawLine.trim();
     if (!line || line.startsWith('#')) continue;
+    if (line.startsWith('export ')) line = line.slice(7).trim();
     const eq = line.indexOf('=');
     if (eq <= 0) continue;
     keys.push(line.slice(0, eq).trim());
@@ -58,8 +59,9 @@ export function parseDotEnvKeys(content: string): string[] {
 export function removeKeysFromDotEnv(content: string, keys: string[]): string {
   const drop = new Set(keys);
   const kept = content.split(/\r?\n/).filter((rawLine) => {
-    const line = rawLine.trim();
+    let line = rawLine.trim();
     if (!line || line.startsWith('#')) return true;
+    if (line.startsWith('export ')) line = line.slice(7).trim();
     const eq = line.indexOf('=');
     if (eq <= 0) return true;
     return !drop.has(line.slice(0, eq).trim());

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -40,3 +40,29 @@ export function diffEnvVars(
     removed: mode === 'replace' ? untouched : [],
   };
 }
+
+/** Extract variable keys from raw .env content, skipping blank lines and comments. */
+export function parseDotEnvKeys(content: string): string[] {
+  const keys: string[] = [];
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    keys.push(line.slice(0, eq).trim());
+  }
+  return keys;
+}
+
+/** Remove the given keys from raw .env content, preserving order, comments and blank lines. */
+export function removeKeysFromDotEnv(content: string, keys: string[]): string {
+  const drop = new Set(keys);
+  const kept = content.split(/\r?\n/).filter((rawLine) => {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) return true;
+    const eq = line.indexOf('=');
+    if (eq <= 0) return true;
+    return !drop.has(line.slice(0, eq).trim());
+  });
+  return kept.join('\n');
+}

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -57,3 +57,14 @@ describe('removeKeysFromDotEnv', () => {
     expect(removeKeysFromDotEnv('export A=1\nB=2', ['A'])).toBe('B=2');
   });
 });
+
+describe('diffEnvVars — defensive against malformed API entries', () => {
+  it('ignores null/undefined/non-string-key entries in existing without crashing', () => {
+    const existing = [null, undefined, { key: 123 }, { key: 'A', value: 'a', isSecret: false }] as unknown as Parameters<typeof diffEnvVars>[0];
+    const d = diffEnvVars(existing, [{ key: 'A', value: 'a2' }], 'merge');
+    expect(d.added).toEqual([]);
+    expect(d.updated).toEqual(['A']);
+    expect(d.preserved).toEqual([]);
+    expect(d.removed).toEqual([]);
+  });
+});

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -38,6 +38,10 @@ describe('parseDotEnvKeys', () => {
     const content = '# comment\nA=1\n\nB=two=with=eq\n  C = 3 \n';
     expect(parseDotEnvKeys(content)).toEqual(['A', 'B', 'C']);
   });
+
+  it('strips a leading "export " prefix before extracting the key', () => {
+    expect(parseDotEnvKeys('export A=1\nB=2')).toEqual(['A', 'B']);
+  });
 });
 
 describe('removeKeysFromDotEnv', () => {
@@ -48,5 +52,8 @@ describe('removeKeysFromDotEnv', () => {
   it('is a no-op for keys not present', () => {
     const content = 'A=1\nB=2';
     expect(removeKeysFromDotEnv(content, ['Z'])).toBe('A=1\nB=2');
+  });
+  it('drops an "export KEY=" line when KEY is targeted', () => {
+    expect(removeKeysFromDotEnv('export A=1\nB=2', ['A'])).toBe('B=2');
   });
 });

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { diffEnvVars } from '../src/utils/env-helpers.js';
+
+describe('diffEnvVars', () => {
+  const existing = [
+    { key: 'A', value: 'a', isSecret: false },
+    { key: 'B', value: 'b', isSecret: true },
+    { key: 'C', value: 'c', isSecret: false },
+  ];
+
+  it('merge: added/updated/preserved (omitted keys only); masked re-send is not surfaced', () => {
+    const d = diffEnvVars(existing, [
+      { key: 'A', value: 'a2' },          // updated (value changed)
+      { key: 'D', value: 'd' },           // added
+      { key: 'B', value: '***' },         // re-sent masked -> unchanged, in NO bucket
+    ], 'merge');
+    expect(d.added).toEqual(['D']);
+    expect(d.updated).toEqual(['A']);
+    expect(d.preserved).toEqual(['C']);   // only the omitted key
+    expect(d.removed).toEqual([]);
+  });
+
+  it('replace: untouched existing keys count as removed, preserved empty', () => {
+    const d = diffEnvVars(existing, [{ key: 'A', value: 'a' }], 'replace');
+    expect(d.removed.sort()).toEqual(['B', 'C']);
+    expect(d.preserved).toEqual([]);
+    expect(d.updated).toEqual([]); // same value -> not updated
+  });
+
+  it('isSecret flip counts as updated', () => {
+    const d = diffEnvVars(existing, [{ key: 'A', value: 'a', isSecret: true }], 'merge');
+    expect(d.updated).toEqual(['A']);
+  });
+});

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { diffEnvVars } from '../src/utils/env-helpers.js';
+import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv } from '../src/utils/env-helpers.js';
 
 describe('diffEnvVars', () => {
   const existing = [
@@ -30,5 +30,23 @@ describe('diffEnvVars', () => {
   it('isSecret flip counts as updated', () => {
     const d = diffEnvVars(existing, [{ key: 'A', value: 'a', isSecret: true }], 'merge');
     expect(d.updated).toEqual(['A']);
+  });
+});
+
+describe('parseDotEnvKeys', () => {
+  it('returns keys, skipping comments and blank lines', () => {
+    const content = '# comment\nA=1\n\nB=two=with=eq\n  C = 3 \n';
+    expect(parseDotEnvKeys(content)).toEqual(['A', 'B', 'C']);
+  });
+});
+
+describe('removeKeysFromDotEnv', () => {
+  it('drops matching KEY= lines, preserves comments/blanks/order', () => {
+    const content = '# keep\nA=1\nB=2\n\nC=3';
+    expect(removeKeysFromDotEnv(content, ['B'])).toBe('# keep\nA=1\n\nC=3');
+  });
+  it('is a no-op for keys not present', () => {
+    const content = 'A=1\nB=2';
+    expect(removeKeysFromDotEnv(content, ['Z'])).toBe('A=1\nB=2');
   });
 });

--- a/tests/stack-env-collisions.test.ts
+++ b/tests/stack-env-collisions.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerStackTools } from '../src/tools/stacks.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+function jsonOut(res: unknown): Record<string, unknown> {
+  return JSON.parse((res as { content: { text: string }[] }).content[0].text);
+}
+function setup() {
+  const handlers = new Map<string, ToolHandler>();
+  const server = { tool: (n: string, _d: string, _s: unknown, cb: ToolHandler) => handlers.set(n, cb) };
+  const client = { get: vi.fn(), put: vi.fn() };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerStackTools(server as any, client as any);
+  const handler = handlers.get('check_stack_env_collisions');
+  if (!handler) throw new Error('check_stack_env_collisions not registered');
+  return { handler, client };
+}
+
+describe('check_stack_env_collisions', () => {
+  it('reports keys that are both DB secret and in .env', async () => {
+    const { handler, client } = setup();
+    client.get.mockImplementation((path: string) =>
+      path.endsWith('/env/raw')
+        ? Promise.resolve('TZ=x\nDB_PASSWORD=leak\n')
+        : Promise.resolve({ variables: [
+            { key: 'DB_PASSWORD', value: '***', isSecret: true },
+            { key: 'TZ', value: 'x', isSecret: false },
+          ] }));
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x' }));
+    expect(out.collisions).toEqual(['DB_PASSWORD']);
+    expect(typeof out.note).toBe('string');
+  });
+
+  it('no collisions → empty list, no note', async () => {
+    const { handler, client } = setup();
+    client.get.mockImplementation((path: string) =>
+      path.endsWith('/env/raw')
+        ? Promise.resolve('TZ=x\n')
+        : Promise.resolve({ variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] }));
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x' }));
+    expect(out.collisions).toEqual([]);
+    expect(out.note).toBeUndefined();
+  });
+});

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -156,3 +156,36 @@ describe('update_stack_env — merge behaviour (mocked client)', () => {
     expect(putBody(client).variables).toEqual([{ key: 'X', value: 'y' }]);
   });
 });
+
+// Response-Parser: jsonResponse liefert { content: [{ type:'text', text: JSON.stringify(x) }] }
+function jsonOut(res: unknown): Record<string, unknown> {
+  const text = (res as { content: { text: string }[] }).content[0].text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('update_stack_env — summary/hint (merge only)', () => {
+  it('merge subset (no new keys) → summary + remove hint', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({ variables: [
+      { key: 'DB_PASSWORD', value: 's', isSecret: true },
+      { key: 'TZ', value: 'Europe/Berlin' },
+      { key: 'HOST', value: 'h' },
+    ] });
+    const res = await handler({ environmentId: 10, name: 'x',
+      variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] });
+    const out = jsonOut(res);
+    expect(out.summary).toEqual({ added: 0, updated: 0, preserved: 2, removed: 0 });
+    expect(typeof out.hint).toBe('string');
+    expect(String(out.hint)).toContain('remove_stack_env_vars');
+  });
+
+  it('replace mode: no summary/hint and no extra GET (existing contract preserved)', async () => {
+    const { handler, client } = setup();
+    const res = await handler({ environmentId: 10, name: 'x',
+      variables: [{ key: 'A', value: 'a' }], mode: 'replace' });
+    const out = jsonOut(res);
+    expect(client.get).not.toHaveBeenCalled();
+    expect(out.summary).toBeUndefined();
+    expect(out.hint).toBeUndefined();
+  });
+});

--- a/tests/stack-env-remove.test.ts
+++ b/tests/stack-env-remove.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerStackTools } from '../src/tools/stacks.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+function jsonOut(res: unknown): Record<string, unknown> {
+  return JSON.parse((res as { content: { text: string }[] }).content[0].text);
+}
+function setup() {
+  const handlers = new Map<string, ToolHandler>();
+  const server = { tool: (n: string, _d: string, _s: unknown, cb: ToolHandler) => handlers.set(n, cb) };
+  const client = { get: vi.fn(), put: vi.fn().mockResolvedValue({ success: true }) };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerStackTools(server as any, client as any);
+  const handler = handlers.get('remove_stack_env_vars');
+  if (!handler) throw new Error('remove_stack_env_vars not registered');
+  return { handler, client };
+}
+// get() is called twice: first structured /env, then raw /env/raw.
+function wireGet(client: { get: ReturnType<typeof vi.fn> }, structured: unknown, raw: string) {
+  client.get.mockImplementation((path: string) =>
+    path.endsWith('/env/raw') ? Promise.resolve(raw) : Promise.resolve(structured));
+}
+
+describe('remove_stack_env_vars', () => {
+  it('removes a secret: replaces DB secret set without it (masked values)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [
+      { key: 'DB_PASSWORD', value: '***', isSecret: true },
+      { key: 'API_KEY', value: '***', isSecret: true },
+    ] }, 'TZ=Europe/Berlin\n');
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['API_KEY'] }));
+    // PUT to /env with only the remaining secret, masked
+    const envPut = client.put.mock.calls.find((c) => String(c[0]).endsWith('/env'));
+    expect(envPut?.[1]).toEqual({ variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] });
+    expect(out.removed_secrets).toEqual(['API_KEY']);
+    expect(out.removed_env).toEqual([]);
+  });
+
+  it('removes a non-secret: rewrites .env without it, no /env PUT', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [{ key: 'TZ', value: 'Europe/Berlin', isSecret: false }] },
+      'TZ=Europe/Berlin\nHOST=h\n');
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['TZ'] }));
+    const rawPut = client.put.mock.calls.find((c) => String(c[0]).endsWith('/env/raw'));
+    expect(rawPut?.[1]).toEqual({ content: 'HOST=h\n' });
+    expect(client.put.mock.calls.some((c) => String(c[0]).endsWith('/env') && !String(c[0]).endsWith('/env/raw'))).toBe(false);
+    expect(out.removed_env).toEqual(['TZ']);
+    expect(out.removed_secrets).toEqual([]);
+  });
+
+  it('reports keys present in neither store as not_found', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [] }, '');
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['NOPE'] }));
+    expect(out.not_found).toEqual(['NOPE']);
+  });
+
+  it('backend PUT error on .env rewrite → partial report (secrets already removed)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [
+      { key: 'SEC', value: '***', isSecret: true },
+      { key: 'TZ', value: 'x', isSecret: false },
+    ] }, 'TZ=x\n');
+    client.put.mockImplementation((path: string) =>
+      String(path).endsWith('/env/raw') ? Promise.reject(new Error('500')) : Promise.resolve({ success: true }));
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['SEC', 'TZ'] }));
+    expect(out.removed_secrets).toEqual(['SEC']);
+    expect(out.removed_env).toEqual([]);
+    expect(typeof out.error).toBe('string');
+  });
+
+  it('network error on initial GET propagates (nothing mutated)', async () => {
+    const { handler, client } = setup();
+    client.get.mockRejectedValue(new Error('ECONNREFUSED'));
+    await expect(handler({ environmentId: 10, name: 'x', keys: ['A'] })).resolves.toBeDefined();
+    expect(client.put).not.toHaveBeenCalled();
+  });
+});

--- a/tests/stack-env-remove.test.ts
+++ b/tests/stack-env-remove.test.ts
@@ -22,7 +22,7 @@ function wireGet(client: { get: ReturnType<typeof vi.fn> }, structured: unknown,
 }
 
 describe('remove_stack_env_vars', () => {
-  it('removes a secret: replaces DB secret set without it (masked values)', async () => {
+  it('removes a secret: rebuilds the DB set without it (remaining secrets masked)', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [
       { key: 'DB_PASSWORD', value: '***', isSecret: true },
@@ -32,11 +32,10 @@ describe('remove_stack_env_vars', () => {
     // PUT to /env with only the remaining secret, masked
     const envPut = client.put.mock.calls.find((c) => String(c[0]).endsWith('/env'));
     expect(envPut?.[1]).toEqual({ variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] });
-    expect(out.removed_secrets).toEqual(['API_KEY']);
-    expect(out.removed_env).toEqual([]);
+    expect(out.removed).toEqual(['API_KEY']);
   });
 
-  it('removes a non-secret: rewrites .env without it, no /env PUT', async () => {
+  it('removes a non-secret that lives in .env: rewrites .env without it, no /env PUT', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [{ key: 'TZ', value: 'Europe/Berlin', isSecret: false }] },
       'TZ=Europe/Berlin\nHOST=h\n');
@@ -44,8 +43,7 @@ describe('remove_stack_env_vars', () => {
     const rawPut = client.put.mock.calls.find((c) => String(c[0]).endsWith('/env/raw'));
     expect(rawPut?.[1]).toEqual({ content: 'HOST=h\n' });
     expect(client.put.mock.calls.some((c) => String(c[0]).endsWith('/env') && !String(c[0]).endsWith('/env/raw'))).toBe(false);
-    expect(out.removed_env).toEqual(['TZ']);
-    expect(out.removed_secrets).toEqual([]);
+    expect(out.removed).toEqual(['TZ']);
   });
 
   it('reports keys present in neither store as not_found', async () => {
@@ -55,7 +53,7 @@ describe('remove_stack_env_vars', () => {
     expect(out.not_found).toEqual(['NOPE']);
   });
 
-  it('backend PUT error on .env rewrite → partial report (secrets already removed)', async () => {
+  it('backend PUT error on .env rewrite → partial report (DB-managed targets already removed)', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [
       { key: 'SEC', value: '***', isSecret: true },
@@ -64,8 +62,7 @@ describe('remove_stack_env_vars', () => {
     client.put.mockImplementation((path: string) =>
       String(path).endsWith('/env/raw') ? Promise.reject(new Error('500')) : Promise.resolve({ success: true }));
     const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['SEC', 'TZ'] }));
-    expect(out.removed_secrets).toEqual(['SEC']);
-    expect(out.removed_env).toEqual([]);
+    expect(out.removed).toEqual(['SEC']);
     expect(typeof out.error).toBe('string');
   });
 

--- a/tests/stack-env-remove.test.ts
+++ b/tests/stack-env-remove.test.ts
@@ -72,4 +72,40 @@ describe('remove_stack_env_vars', () => {
     await expect(handler({ environmentId: 10, name: 'x', keys: ['A'] })).resolves.toBeDefined();
     expect(client.put).not.toHaveBeenCalled();
   });
+
+  it('CRITICAL: preserves DB-held non-secrets (git-stack vars not in .env) when removing an unrelated secret', async () => {
+    // Two-store model: a non-secret that appears in the structured /env view but
+    // NOT in .env lives in the DB (git-stack). Removing an unrelated secret must
+    // NOT drop these DB-managed non-secrets from the rebuilt /env PUT payload.
+    const { handler, client } = setup();
+    wireGet(client, { variables: [
+      { key: 'DB_PASSWORD', value: '***', isSecret: true },
+      { key: 'API_KEY', value: '***', isSecret: true },
+      { key: 'TZ', value: 'Europe/Berlin', isSecret: false },
+      { key: 'HOST', value: 'h', isSecret: false },
+    ] }, '');
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['API_KEY'] }));
+    const envPut = client.put.mock.calls.find((c) => String(c[0]).endsWith('/env'));
+    const payload = envPut?.[1] as { variables: Array<{ key: string; value: string; isSecret: boolean }> };
+    const byKey = new Map(payload.variables.map((v) => [v.key, v]));
+    expect(byKey.get('DB_PASSWORD')).toEqual({ key: 'DB_PASSWORD', value: '***', isSecret: true });
+    expect(byKey.get('TZ')).toEqual({ key: 'TZ', value: 'Europe/Berlin', isSecret: false });
+    expect(byKey.get('HOST')).toEqual({ key: 'HOST', value: 'h', isSecret: false });
+    expect(byKey.has('API_KEY')).toBe(false);
+    expect(payload.variables).toHaveLength(3);
+    expect(out.removed).toEqual(['API_KEY']);
+  });
+
+  it('error on the first (/env) PUT is reported and no /env/raw PUT is attempted', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [
+      { key: 'SEC', value: '***', isSecret: true },
+      { key: 'OTHER_SEC', value: '***', isSecret: true },
+    ] }, 'TZ=x\n');
+    client.put.mockImplementation((path: string) =>
+      String(path).endsWith('/env/raw') ? Promise.resolve({ success: true }) : Promise.reject(new Error('500 db unavailable')));
+    const out = jsonOut(await handler({ environmentId: 10, name: 'x', keys: ['SEC', 'TZ'] }));
+    expect(typeof out.error).toBe('string');
+    expect(client.put.mock.calls.some((c) => String(c[0]).endsWith('/env/raw'))).toBe(false);
+  });
 });

--- a/tests/tool-descriptions.test.ts
+++ b/tests/tool-descriptions.test.ts
@@ -87,6 +87,8 @@ const CLUSTERS: Record<string, string[]> = {
     'get_stack_env_raw',
     'update_stack_env',
     'update_stack_env_raw',
+    'remove_stack_env_vars',
+    'check_stack_env_collisions',
     'validate_stack_env',
   ],
   'Stack-Compose': ['get_stack_compose', 'update_stack_compose'],


### PR DESCRIPTION
## Was
Drei additive, **nicht-breaking** Verbesserungen rund um Stack-Env, hervorgegangen aus einer Investigation zum Dockhand-Zwei-Speicher-Modell (DB-Secrets vs. `.env`):

- **A) `update_stack_env`** liefert im `merge`-Modus zusätzlich `summary {added, updated, preserved, removed}` + einen `hint`, wenn nichts entfernt wurde (das „ich-wollte-eigentlich-löschen"-Muster). `replace` bleibt unverändert. `success`/`count` bleiben.
- **B) `remove_stack_env_vars(env, name, keys[])`** — entfernt Keys **stack-typ-bewusst** über beide Speicher: DB-Rebuild der vollen verbleibenden Menge minus Ziel-Keys (Secrets via `***`-Bewahrung; DB-gehaltene Nicht-Secrets bleiben erhalten), `.env`-Rewrite für `.env`-gehaltene Keys. Kollisionen aus beiden. Return `{ removed, not_found }`.
- **D) `check_stack_env_collisions(env, name)`** — read-only, meldet Keys die gleichzeitig DB-Secret **und** in `.env` sind.
- Reine Helfer `diffEnvVars`, `parseDotEnvKeys`, `removeKeysFromDotEnv` (inkl. `export KEY=`-Support).

## Qualität
- TDD strict, **319 Tests grün**, typecheck + build + `docker build` sauber.
- Whole-Branch-Review fand + verifizierte einen **Critical-Datenverlust** (frühe B-Fassung hätte DB-gehaltene Nicht-Secrets von git-Stacks gelöscht) → behoben, Regressionstest ergänzt.
- Merge-Fail-Safe von `update_stack_env` (GET-Fehler → kein PUT) unverändert.

Motivation/Details: Investigation zum Zwei-Speicher-Modell (AFFiNE-Stack-Env-Duplikat auf HHDOCKER03).