### PR TITLE
ci(release): drop @semantic-release/git so releases work under branch protection

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,20 +45,6 @@
         }
       }
     ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# MCP-Dockhand Changelog\n\nAll notable changes to **MCP-Dockhand** will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Problem
After enabling branch protection (required status checks) on `main`, the nightly/dispatch release fails: `@semantic-release/git` commits CHANGELOG.md/package.json back to `main` and **pushes directly** — which protection now rejects. Result: tags/images stop being produced (v1.9.0 release job failed).

## Fix
Remove `@semantic-release/git` (and the now-orphaned `@semantic-release/changelog`). semantic-release still: analyses commits, generates release notes, creates the git **tag** + **GitHub Release**, and the workflow builds/pushes the Docker image. No direct push to the protected branch → protection stays fully intact for Dependabot/PRs.

**Tradeoff:** CHANGELOG.md is no longer committed into the repo; release notes live in the GitHub Releases. Alternative (not chosen): a bypass PAT to keep the changelog commit.