### PR TITLE
ci(release): restore CHANGELOG updates (@semantic-release/git)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -45,6 +45,20 @@
         }
       }
     ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# MCP-Dockhand Changelog\n\nAll notable changes to **MCP-Dockhand** will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)."
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Stellt die versehentlich entfernten Plugins `@semantic-release/git` + `@semantic-release/changelog` wieder her — CHANGELOG.md wird bei Releases wieder aktualisiert/committet. Die Branch Protection auf `main` (die den Release-Push blockierte) wurde entfernt; die CI-Checks (`docker`, `lockfile-integrity`) laufen weiter auf jedem PR.