### PR TITLE
fix(tools): route isSecret:false vars to .env in update_stack_env (#109)

### DIFF
--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -258,7 +258,12 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
             const raw = await client.get<string>(envRawPath, { env: environmentId });
             rawStr = typeof raw === 'string' ? raw : '';
             newContent = upsertDotEnv(rawStr, payloadNonSecrets.map((v) => ({ key: v.key, value: v.value })));
-            newContent = upsertDotEnv(newContent, toMigrate.map((v) => ({ key: v.key, value: v.value })));
+            // N1: the live .env is authoritative for non-secrets — only migrate
+            // orphaned DB rows whose key is NOT already in .env, so a stale DB
+            // value can never overwrite a live .env value.
+            const envKeys = new Set(parseDotEnvKeys(rawStr));
+            const migrateNew = toMigrate.filter((v) => !envKeys.has(v.key));
+            newContent = upsertDotEnv(newContent, migrateNew.map((v) => ({ key: v.key, value: v.value })));
             newContent = removeKeysFromDotEnv(newContent, promotedKeys);
           } else {
             // replace: rebuild the .env file from scratch — comments are lost

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -150,30 +150,45 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       })).describe('Environment variables — flag secrets with isSecret:true'),
       mode: z.enum(['merge', 'replace']).optional().describe('How to handle existing variables. "merge" (default): fetch existing vars, update/add the provided ones, preserve all others. "replace": overwrite the entire variable list with exactly the provided variables — all others are deleted.'),
     },
-    async ({ environmentId, name, variables, mode = 'merge' }) => {
+    async ({ environmentId, name, variables: rawVariables, mode = 'merge' }) => {
       const envPath = `/api/stacks/${encodePath(name)}/env`;
       const envRawPath = `/api/stacks/${encodePath(name)}/env/raw`;
 
+      // Minor 7: de-duplicate incoming keys before anything is derived from
+      // them (last occurrence wins) — a caller sending the same key twice
+      // must not produce two lines in .env or an ambiguous DB write.
+      const variables: EnvVariable[] = Array.from(
+        rawVariables.reduce((map, v) => map.set(v.key, v), new Map<string, EnvVariable>()).values(),
+      );
+
       let secrets: EnvVariable[];
       let payloadNonSecrets: EnvVariable[];
-      let diff: EnvDiff | undefined;
-      let summaryPromise: Promise<EnvDiff | undefined> | undefined;
+      let existingSecrets: EnvVariable[] = [];
+      let existingSecretsCount = 0;
+      let promotedKeys: string[] = [];
+      let toMigrate: EnvVariable[] = [];
 
       if (mode === 'merge') {
         // GET is load-bearing here: a failure must NOT issue any write (no data loss).
         const existing = await client.get<StackEnv>(envPath, { env: environmentId });
-        const existingVars = existing?.variables;
-        const mergedByKey = new Map<string, EnvVariable>();
-
+        const existingVarsRaw = existing?.variables;
         // Guard against a malformed API response (variables null / not an array).
-        if (Array.isArray(existingVars)) {
-          for (const v of existingVars) {
-            if (v && typeof v.key === 'string') {
-              mergedByKey.set(v.key, v);
-            }
-          }
-        }
+        const existingVars: EnvVariable[] = Array.isArray(existingVarsRaw)
+          ? existingVarsRaw.filter((v): v is EnvVariable => !!v && typeof v.key === 'string')
+          : [];
 
+        existingSecrets = existingVars.filter((v) => v.isSecret === true);
+        existingSecretsCount = existingSecrets.length;
+        // Orphaned DB rows: non-secret entries sitting in the DB-backed
+        // structured store. These should never exist going forward (non-secrets
+        // belong in .env) but may be left over from before this fix, or from a
+        // git-stack import. Critical 3: they must not be silently dropped.
+        const existingDbNonSecrets = existingVars.filter((v) => v.isSecret !== true);
+
+        const mergedByKey = new Map<string, EnvVariable>();
+        for (const v of existingVars) {
+          mergedByKey.set(v.key, v);
+        }
         for (const v of variables) {
           const existingVar = mergedByKey.get(v.key);
           // Preserve the existing isSecret flag when the caller omits it, so a
@@ -184,7 +199,6 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
           });
         }
         const finalVariables: EnvVariable[] = Array.from(mergedByKey.values());
-        diff = diffEnvVars(Array.isArray(existingVars) ? existingVars : [], variables, 'merge');
 
         secrets = finalVariables.filter((v) => v.isSecret);
         // Only the payload's own non-secret entries are upserted into .env —
@@ -192,59 +206,101 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
         payloadNonSecrets = variables
           .map((v) => mergedByKey.get(v.key))
           .filter((v): v is EnvVariable => !!v && !v.isSecret);
+
+        // Critical 2: a key the caller explicitly promotes to isSecret:true
+        // this call must be scrubbed from .env — otherwise the plaintext copy
+        // lingers alongside the new encrypted DB row.
+        promotedKeys = variables.filter((v) => v.isSecret === true).map((v) => v.key);
+
+        // Critical 1 + 3: the DB PUT below is DELETE-all+INSERT with only
+        // `secrets`. It must still fire when the last remaining secret is
+        // being degraded to isSecret:false (secrets.length would otherwise be
+        // 0 and the stale encrypted row would never be flushed). And when it
+        // fires, any orphaned non-secret DB row the caller did not touch this
+        // call would silently vanish — migrate its value into .env instead.
+        const willFireDbPut = secrets.length > 0 || existingSecretsCount > 0;
+        if (willFireDbPut) {
+          const payloadKeys = new Set(variables.map((v) => v.key));
+          toMigrate = existingDbNonSecrets.filter((v) => !payloadKeys.has(v.key));
+        }
       } else {
         // replace: wipe-and-set exactly the provided list, split by isSecret.
+        // No GET, no summary — Critical 4: matches the original #105 contract.
+        // replace is a deliberate full wipe of both stores, not a preview.
         secrets = variables.filter((v) => v.isSecret);
         payloadNonSecrets = variables.filter((v) => !v.isSecret);
-        // Best-effort GET purely to compute the summary — replace is a
-        // deliberate full wipe, so a GET failure must never block the write.
-        summaryPromise = client.get<StackEnv>(envPath, { env: environmentId })
-          .then((existing) => diffEnvVars(Array.isArray(existing?.variables) ? existing.variables : [], variables, 'replace'))
-          .catch(() => undefined);
       }
 
-      // DB store: only write when there is at least one secret to persist —
-      // in merge mode this also flushes any orphaned non-secret DB rows left
-      // over from before this fix, since the endpoint is DELETE-all+INSERT.
+      // DB store: fires when there is at least one secret to persist, or when
+      // secrets existed before this call and must be flushed (Critical 1).
       let dbSecretsWritten = 0;
-      if (mode === 'replace' || secrets.length > 0) {
-        await client.put(envPath, { variables: secrets }, { env: environmentId });
+      let dbPutResult: unknown;
+      if (mode === 'replace' || secrets.length > 0 || existingSecretsCount > 0) {
+        dbPutResult = await client.put(envPath, { variables: secrets }, { env: environmentId });
         dbSecretsWritten = secrets.length;
       }
 
-      // .env store: only touched when the payload actually contains
-      // non-secrets. GET-raw + upsert + PUT (merge) or a full rebuild
-      // (replace) are treated as one step — any failure inside it is
-      // reported as a partial success, it never undoes the DB write above.
+      // .env store: touched when the payload has non-secrets to upsert, when a
+      // key is being promoted to a secret and must be scrubbed from .env
+      // (Critical 2), or when an orphaned DB row needs migrating into .env
+      // before the DB PUT above would otherwise drop it (Critical 3).
+      // GET-raw + upsert + PUT (merge) or a full rebuild (replace) are treated
+      // as one step — any failure inside it is reported as a partial success,
+      // it never undoes the DB write above.
       let envNonSecretsWritten = 0;
       let envError: string | undefined;
-      if (mode === 'replace' || payloadNonSecrets.length > 0) {
+      let envPutResult: unknown;
+      let rawStr: string | undefined;
+      if (mode === 'replace' || payloadNonSecrets.length > 0 || promotedKeys.length > 0 || toMigrate.length > 0) {
         try {
           let newContent: string;
           if (mode === 'merge') {
             const raw = await client.get<string>(envRawPath, { env: environmentId });
-            const rawStr = typeof raw === 'string' ? raw : '';
+            rawStr = typeof raw === 'string' ? raw : '';
             newContent = upsertDotEnv(rawStr, payloadNonSecrets.map((v) => ({ key: v.key, value: v.value })));
+            newContent = upsertDotEnv(newContent, toMigrate.map((v) => ({ key: v.key, value: v.value })));
+            newContent = removeKeysFromDotEnv(newContent, promotedKeys);
           } else {
             // replace: rebuild the .env file from scratch — comments are lost
-            // (deliberate: replace is a full wipe-and-set).
+            // (deliberate: replace is a full wipe-and-set). Promoted secrets
+            // never land here since payloadNonSecrets already excludes them.
             newContent = payloadNonSecrets.map((v) => `${v.key}=${v.value}`).join('\n');
           }
-          await client.put(envRawPath, { content: newContent }, { env: environmentId });
+          envPutResult = await client.put(envRawPath, { content: newContent }, { env: environmentId });
           envNonSecretsWritten = payloadNonSecrets.length;
         } catch (e) {
           envError = `${dbSecretsWritten > 0 ? 'secrets written to database, but ' : ''}.env write failed: ${e instanceof Error ? e.message : String(e)}`;
         }
       }
 
-      diff = diff ?? (await summaryPromise);
+      // Summary: merge-only (Critical 4 — replace has no GET, no preview).
+      // Important 5: the baseline combines BOTH real stores — DB secrets and
+      // .env keys (parsed from the raw GET above, when it happened) — so a
+      // key already tracked in .env and changed this call is reported as
+      // `updated`, not `added`; a key left out is `preserved`. Critical 3:
+      // orphaned DB non-secret rows are deliberately excluded from the
+      // baseline — they are migrated into .env above, not "preserved" in DB.
+      let diff: EnvDiff | undefined;
+      if (mode === 'merge') {
+        const envBaselineKeys = rawStr !== undefined ? parseDotEnvKeys(rawStr) : [];
+        const baseline: EnvVariable[] = [
+          ...existingSecrets,
+          ...envBaselineKeys.map((key) => ({ key, value: '', isSecret: false })),
+        ];
+        diff = diffEnvVars(baseline, variables, 'merge');
+      }
 
       const hint =
         mode === 'merge' && diff && diff.added.length === 0 && diff.preserved.length > 0
           ? `merge mode preserved ${diff.preserved.length} variable(s) you did not include and removed nothing. To remove variables use remove_stack_env_vars, or update_stack_env with mode="replace".`
           : undefined;
 
+      // Important 6: spread through any extra fields the underlying PUT
+      // responses carried (e.g. API metadata), additively — our own fields
+      // (success/db/env/summary/hint/error) always take precedence.
       return jsonResponse({
+        ...(dbPutResult && typeof dbPutResult === 'object' ? dbPutResult : {}),
+        ...(envPutResult && typeof envPutResult === 'object' ? envPutResult : {}),
         success: !envError,
         db: { secretsWritten: dbSecretsWritten },
         env: { nonSecretsWritten: envNonSecretsWritten },

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -8,7 +8,7 @@ import type { DockhandClient } from '../client/dockhand-client.js';
 import type { StackEnv, EnvVariable } from '../types/dockhand.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
-import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv } from '../utils/env-helpers.js';
+import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv, upsertDotEnv } from '../utils/env-helpers.js';
 import type { EnvDiff } from '../utils/env-helpers.js';
 
 export function registerStackTools(server: McpServer, client: DockhandClient): void {
@@ -139,7 +139,7 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
   );
 
   registerTool(server, 'update_stack_env',
-    'Update secret environment variables (database-backed, encrypted at rest). Variables flagged isSecret:true are stored in the Dockhand database and injected into containers via shell-env at deploy time — they are NEVER written to the .env file. For non-secret variables that Docker Compose reads from the .env file at container start, use `update_stack_env_raw`.\n\n**IMPORTANT — merge vs replace semantics:** The underlying Dockhand REST endpoint (`PUT /api/stacks/{name}/env`) has replace-semantics: sending a partial list silently deletes all other variables. This tool therefore defaults to `mode="merge"`: it fetches the current variables first, merges your payload by key (new values win on collision), and then writes the full combined list. Use `mode="replace"` only when you intentionally want to wipe all existing variables and set exactly the provided list.',
+    'Set environment variables across both Dockhand stores in one call. Variables flagged isSecret:true are stored in the Dockhand database (encrypted at rest) and injected into containers via shell-env at deploy time. Variables with isSecret:false/omitted are written to the .env file on disk — the same file Docker Compose reads at container start — so they take effect without any extra step; equivalent in effect to `update_stack_env_raw` but merged in automatically. Never flag credentials isSecret:false.\n\n**IMPORTANT — merge vs replace semantics:** The underlying Dockhand REST endpoints (`PUT /api/stacks/{name}/env` and `PUT /api/stacks/{name}/env/raw`) both have replace-semantics for the store they touch. This tool therefore defaults to `mode="merge"`: it fetches the current DB-backed variables and the current .env content first, merges your payload in by key (new values win on collision), then writes each store only with what it now needs — the secrets to the database, the non-secrets upserted into .env. Use `mode="replace"` only when you intentionally want to wipe all existing variables and set exactly the provided list (the .env file is rebuilt from scratch; comments are lost).',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
@@ -151,15 +151,17 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       mode: z.enum(['merge', 'replace']).optional().describe('How to handle existing variables. "merge" (default): fetch existing vars, update/add the provided ones, preserve all others. "replace": overwrite the entire variable list with exactly the provided variables — all others are deleted.'),
     },
     async ({ environmentId, name, variables, mode = 'merge' }) => {
-      let finalVariables: EnvVariable[];
+      const envPath = `/api/stacks/${encodePath(name)}/env`;
+      const envRawPath = `/api/stacks/${encodePath(name)}/env/raw`;
+
+      let secrets: EnvVariable[];
+      let payloadNonSecrets: EnvVariable[];
       let diff: EnvDiff | undefined;
+      let summaryPromise: Promise<EnvDiff | undefined> | undefined;
 
       if (mode === 'merge') {
-        // GET is load-bearing here: a failure must NOT issue a PUT (no data loss).
-        const existing = await client.get<StackEnv>(
-          `/api/stacks/${encodePath(name)}/env`,
-          { env: environmentId },
-        );
+        // GET is load-bearing here: a failure must NOT issue any write (no data loss).
+        const existing = await client.get<StackEnv>(envPath, { env: environmentId });
         const existingVars = existing?.variables;
         const mergedByKey = new Map<string, EnvVariable>();
 
@@ -181,29 +183,76 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
             isSecret: v.isSecret !== undefined ? v.isSecret : existingVar?.isSecret,
           });
         }
-        finalVariables = Array.from(mergedByKey.values());
+        const finalVariables: EnvVariable[] = Array.from(mergedByKey.values());
         diff = diffEnvVars(Array.isArray(existingVars) ? existingVars : [], variables, 'merge');
+
+        secrets = finalVariables.filter((v) => v.isSecret);
+        // Only the payload's own non-secret entries are upserted into .env —
+        // pre-existing .env keys the caller did not touch stay untouched.
+        payloadNonSecrets = variables
+          .map((v) => mergedByKey.get(v.key))
+          .filter((v): v is EnvVariable => !!v && !v.isSecret);
       } else {
-        // replace: PUT the payload directly. No GET, no summary — the existing
-        // contract (replace does not GET) stays intact.
-        finalVariables = variables;
+        // replace: wipe-and-set exactly the provided list, split by isSecret.
+        secrets = variables.filter((v) => v.isSecret);
+        payloadNonSecrets = variables.filter((v) => !v.isSecret);
+        // Best-effort GET purely to compute the summary — replace is a
+        // deliberate full wipe, so a GET failure must never block the write.
+        summaryPromise = client.get<StackEnv>(envPath, { env: environmentId })
+          .then((existing) => diffEnvVars(Array.isArray(existing?.variables) ? existing.variables : [], variables, 'replace'))
+          .catch(() => undefined);
       }
 
-      const result = (await client.put(
-        `/api/stacks/${encodePath(name)}/env`, { variables: finalVariables },
-        { env: environmentId })) as Record<string, unknown>;
+      // DB store: only write when there is at least one secret to persist —
+      // in merge mode this also flushes any orphaned non-secret DB rows left
+      // over from before this fix, since the endpoint is DELETE-all+INSERT.
+      let dbSecretsWritten = 0;
+      if (mode === 'replace' || secrets.length > 0) {
+        await client.put(envPath, { variables: secrets }, { env: environmentId });
+        dbSecretsWritten = secrets.length;
+      }
+
+      // .env store: only touched when the payload actually contains
+      // non-secrets. GET-raw + upsert + PUT (merge) or a full rebuild
+      // (replace) are treated as one step — any failure inside it is
+      // reported as a partial success, it never undoes the DB write above.
+      let envNonSecretsWritten = 0;
+      let envError: string | undefined;
+      if (mode === 'replace' || payloadNonSecrets.length > 0) {
+        try {
+          let newContent: string;
+          if (mode === 'merge') {
+            const raw = await client.get<string>(envRawPath, { env: environmentId });
+            const rawStr = typeof raw === 'string' ? raw : '';
+            newContent = upsertDotEnv(rawStr, payloadNonSecrets.map((v) => ({ key: v.key, value: v.value })));
+          } else {
+            // replace: rebuild the .env file from scratch — comments are lost
+            // (deliberate: replace is a full wipe-and-set).
+            newContent = payloadNonSecrets.map((v) => `${v.key}=${v.value}`).join('\n');
+          }
+          await client.put(envRawPath, { content: newContent }, { env: environmentId });
+          envNonSecretsWritten = payloadNonSecrets.length;
+        } catch (e) {
+          envError = `${dbSecretsWritten > 0 ? 'secrets written to database, but ' : ''}.env write failed: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      }
+
+      diff = diff ?? (await summaryPromise);
 
       const hint =
-        diff && diff.added.length === 0 && diff.preserved.length > 0
+        mode === 'merge' && diff && diff.added.length === 0 && diff.preserved.length > 0
           ? `merge mode preserved ${diff.preserved.length} variable(s) you did not include and removed nothing. To remove variables use remove_stack_env_vars, or update_stack_env with mode="replace".`
           : undefined;
 
       return jsonResponse({
-        ...result,
+        success: !envError,
+        db: { secretsWritten: dbSecretsWritten },
+        env: { nonSecretsWritten: envNonSecretsWritten },
         ...(diff ? { summary: {
           added: diff.added.length, updated: diff.updated.length,
           preserved: diff.preserved.length, removed: diff.removed.length,
         } } : {}),
+        ...(envError ? { error: envError } : {}),
         ...(hint ? { hint } : {}),
       });
     }

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -113,5 +113,11 @@ export function upsertDotEnv(content: string, vars: { key: string; value: string
     return appended.join('\n');
   }
 
-  return [...updated, ...appended].join('\n');
+  // A trailing newline in the source leaves an empty last element after split.
+  // Drop it before appending (so we don't insert a spurious blank line), then
+  // restore the trailing newline so the file's original shape is preserved.
+  const hasTrailingNewline = lines[lines.length - 1] === '';
+  const cleanUpdated = hasTrailingNewline ? updated.slice(0, -1) : updated;
+  const result = [...cleanUpdated, ...appended].join('\n');
+  return hasTrailingNewline ? result + '\n' : result;
 }

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -69,3 +69,49 @@ export function removeKeysFromDotEnv(content: string, keys: string[]): string {
   });
   return kept.join('\n');
 }
+
+/**
+ * Upsert KEY=value pairs into raw .env content: replace the value on an
+ * existing `KEY=` line (preserving an optional leading `export ` prefix,
+ * comments, blank lines and overall order), or append a new `KEY=value`
+ * line at the end when the key is not present. A pure function — does not
+ * touch the network or filesystem.
+ */
+export function upsertDotEnv(content: string, vars: { key: string; value: string }[]): string {
+  if (vars.length === 0) return content;
+
+  const byKey = new Map(vars.map((v) => [v.key, v.value]));
+  const seen = new Set<string>();
+  const lines = content.length > 0 ? content.split(/\r?\n/) : [];
+
+  const updated = lines.map((rawLine) => {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) return rawLine;
+
+    let rest = line;
+    let prefix = '';
+    if (rest.startsWith('export ')) {
+      prefix = 'export ';
+      rest = rest.slice(7).trim();
+    }
+    const eq = rest.indexOf('=');
+    if (eq <= 0) return rawLine;
+
+    const key = rest.slice(0, eq).trim();
+    if (!byKey.has(key)) return rawLine;
+
+    seen.add(key);
+    return `${prefix}${key}=${byKey.get(key)}`;
+  });
+
+  const appended = vars.filter((v) => !seen.has(v.key)).map((v) => `${v.key}=${v.value}`);
+  if (appended.length === 0) return updated.join('\n');
+
+  // Empty (or whitespace-only single-line) starting content: append without a
+  // spurious leading blank line.
+  if (updated.length === 0 || (updated.length === 1 && updated[0].trim() === '')) {
+    return appended.join('\n');
+  }
+
+  return [...updated, ...appended].join('\n');
+}

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv } from '../src/utils/env-helpers.js';
+import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv, upsertDotEnv } from '../src/utils/env-helpers.js';
 
 describe('diffEnvVars', () => {
   const existing = [
@@ -66,5 +66,50 @@ describe('diffEnvVars — defensive against malformed API entries', () => {
     expect(d.updated).toEqual(['A']);
     expect(d.preserved).toEqual([]);
     expect(d.removed).toEqual([]);
+  });
+});
+
+describe('upsertDotEnv', () => {
+  it('replaces an existing KEY= line in place, preserving surrounding lines and order', () => {
+    const content = 'A=1\nB=2\nC=3';
+    expect(upsertDotEnv(content, [{ key: 'B', value: 'two' }])).toBe('A=1\nB=two\nC=3');
+  });
+
+  it('appends a new key at the end when it is not present', () => {
+    const content = 'A=1\nB=2';
+    expect(upsertDotEnv(content, [{ key: 'C', value: '3' }])).toBe('A=1\nB=2\nC=3');
+  });
+
+  it('preserves an "export " prefix when replacing the value', () => {
+    const content = 'export A=1\nB=2';
+    expect(upsertDotEnv(content, [{ key: 'A', value: 'rotated' }])).toBe('export A=rotated\nB=2');
+  });
+
+  it('preserves comments and blank lines untouched', () => {
+    const content = '# keep me\nA=1\n\nB=2';
+    expect(upsertDotEnv(content, [{ key: 'A', value: '9' }])).toBe('# keep me\nA=9\n\nB=2');
+  });
+
+  it('handles a value containing "=" by only splitting on the first "="', () => {
+    const content = 'A=old';
+    expect(upsertDotEnv(content, [{ key: 'A', value: 'x=y=z' }])).toBe('A=x=y=z');
+  });
+
+  it('appends to empty content without introducing a leading blank line', () => {
+    expect(upsertDotEnv('', [{ key: 'A', value: '1' }])).toBe('A=1');
+  });
+
+  it('handles a mix of replace and append across multiple vars in one call', () => {
+    const content = '# header\nA=1\nB=2';
+    const result = upsertDotEnv(content, [
+      { key: 'B', value: 'two' },
+      { key: 'D', value: '4' },
+    ]);
+    expect(result).toBe('# header\nA=1\nB=two\nD=4');
+  });
+
+  it('is a no-op when given an empty vars array', () => {
+    const content = 'A=1\nB=2';
+    expect(upsertDotEnv(content, [])).toBe('A=1\nB=2');
   });
 });

--- a/tests/env-helpers.test.ts
+++ b/tests/env-helpers.test.ts
@@ -112,4 +112,8 @@ describe('upsertDotEnv', () => {
     const content = 'A=1\nB=2';
     expect(upsertDotEnv(content, [])).toBe('A=1\nB=2');
   });
+
+  it('preserves a trailing newline when appending, without a spurious blank line', () => {
+    expect(upsertDotEnv('A=1\nB=2\n', [{ key: 'C', value: '3' }])).toBe('A=1\nB=2\nC=3\n');
+  });
 });

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -1,22 +1,23 @@
 /**
- * Behavioural tests for the update_stack_env merge-semantic implementation.
+ * Behavioural tests for update_stack_env's auto-routing between the DB
+ * secrets store (PUT /env) and the .env file (PUT /env/raw).
  *
- * Unlike the static-analysis suite (stack-env-merge.test.ts), these tests
- * execute the registered tool handler against a mocked DockhandClient and
- * assert on the actual GET/PUT calls. This locks in the runtime behaviour that
- * the regex tests cannot verify:
- *   - existing variables (incl. secret values) survive a partial update,
- *   - collisions are overwritten, new keys are added,
- *   - replace mode skips the GET,
- *   - the merge path is fail-safe: a failed GET issues NO PUT (no data loss).
+ * Follow-up to #105 (merge/replace semantics against the DB-only /env
+ * endpoint). This suite locks in the routing added in #109:
+ *   - isSecret:true  vars -> DB (PUT /env), as before,
+ *   - isSecret:false vars -> .env file (PUT /env/raw), auto-upserted,
+ *   - the merge-mode structured GET stays load-bearing: on failure, NO
+ *     write happens at all (no data loss) — the original #105 fail-safe,
+ *   - replace mode rebuilds .env from exactly the non-secret payload.
  *
- * Incident this guards against: hangar-print-hub (2026-06-01), 7 of 8 variables
- * deleted by a single-key update_stack_env call.
+ * Incident this guards against (root cause of #109): isSecret:false vars
+ * sent through update_stack_env were PUT to the DB-only /env endpoint and
+ * silently orphaned there — get_stack_env always reads non-secrets from
+ * the .env file, so the value written to the DB was never actually applied.
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { registerStackTools } from '../src/tools/stacks.js';
-import type { EnvVariable } from '../src/types/dockhand.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
 
@@ -47,81 +48,154 @@ function setup(): { handler: ToolHandler; client: MockClient } {
   return { handler, client };
 }
 
-function putBody(client: MockClient): { variables: EnvVariable[] } {
-  return client.put.mock.calls[0][1] as { variables: EnvVariable[] };
+/** Wires client.get so `/env/raw` and the structured `/env` return different mocked payloads. */
+function wireGet(client: MockClient, structured: unknown, raw: string) {
+  client.get.mockImplementation((path: string) =>
+    path.endsWith('/env/raw') ? Promise.resolve(raw) : Promise.resolve(structured));
 }
 
-describe('update_stack_env — merge behaviour (mocked client)', () => {
-  it('merge (default): GETs existing, preserves untouched vars incl. secret value, overwrites on collision, adds new', async () => {
-    const { handler, client } = setup();
-    client.get.mockResolvedValue({
-      variables: [
-        { key: 'SECRET_A', value: 'super-secret', isSecret: true },
-        { key: 'PLAIN_B', value: 'b-old' },
-      ],
-    });
+function envPut(client: MockClient) {
+  return client.put.mock.calls.find((c) => String(c[0]).endsWith('/env'));
+}
+function rawPut(client: MockClient) {
+  return client.put.mock.calls.find((c) => String(c[0]).endsWith('/env/raw'));
+}
 
-    await handler({
+function jsonOut(res: unknown): Record<string, unknown> {
+  const text = (res as { content: { text: string }[] }).content[0].text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('update_stack_env — merge auto-routing (mocked client)', () => {
+  it('mixed payload (1 secret + 1 non-secret): secret -> /env PUT, non-secret -> /env/raw upsert PUT', async () => {
+    const { handler, client } = setup();
+    wireGet(
+      client,
+      { variables: [{ key: 'SECRET_A', value: 'super-secret', isSecret: true }] },
+      'PLAIN_B=old\n',
+    );
+
+    const res = await handler({
       environmentId: 7,
       name: 'my-stack',
       variables: [
-        { key: 'PLAIN_B', value: 'b-new' }, // collision → overwrite
-        { key: 'NEW_C', value: 'c', isSecret: true }, // new
+        { key: 'SECRET_A', value: 'super-secret', isSecret: true }, // resend, unchanged
+        { key: 'PLAIN_B', value: 'new', isSecret: false },
       ],
     });
 
-    // GET against the /env endpoint with the env query param
-    expect(client.get).toHaveBeenCalledTimes(1);
-    expect(client.get.mock.calls[0][0]).toBe('/api/stacks/my-stack/env');
-    expect(client.get.mock.calls[0][1]).toEqual({ env: 7 });
+    // structured GET always happens (load-bearing merge fetch)
+    expect(client.get).toHaveBeenCalledWith('/api/stacks/my-stack/env', { env: 7 });
+    // raw GET happens because the payload has a non-secret to upsert
+    expect(client.get).toHaveBeenCalledWith('/api/stacks/my-stack/env/raw', { env: 7 });
 
-    // PUT the merged full list back to the same endpoint
-    expect(client.put).toHaveBeenCalledTimes(1);
-    expect(client.put.mock.calls[0][0]).toBe('/api/stacks/my-stack/env');
-    expect(client.put.mock.calls[0][2]).toEqual({ env: 7 });
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'SECRET_A', value: 'super-secret', isSecret: true }] });
+    expect(rawPut(client)?.[1]).toEqual({ content: 'PLAIN_B=new\n' });
 
-    const body = putBody(client);
-    const byKey = new Map(body.variables.map((v) => [v.key, v]));
-    expect(body.variables).toHaveLength(3);
-    // untouched secret survives with value + flag — the linchpin of the whole fix
-    expect(byKey.get('SECRET_A')).toEqual({ key: 'SECRET_A', value: 'super-secret', isSecret: true });
-    expect(byKey.get('PLAIN_B')).toEqual({ key: 'PLAIN_B', value: 'b-new' });
-    expect(byKey.get('NEW_C')).toEqual({ key: 'NEW_C', value: 'c', isSecret: true });
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+    expect(out.env).toEqual({ nonSecretsWritten: 1 });
+    expect(out.summary).toBeDefined();
+    expect(out.success).toBe(true);
   });
 
-  it('merge with empty input is a no-op — existing variables are preserved, nothing is wiped', async () => {
+  it('pure secret payload: only /env PUT — no /env/raw GET or PUT', async () => {
     const { handler, client } = setup();
-    client.get.mockResolvedValue({
-      variables: [
-        { key: 'A', value: '1', isSecret: true },
-        { key: 'B', value: '2' },
-      ],
+    wireGet(client, { variables: [] }, '');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'TOKEN', value: 'x', isSecret: true }],
     });
 
-    await handler({ environmentId: 1, name: 's', variables: [] });
+    expect(client.get).toHaveBeenCalledTimes(1); // only the structured GET
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'TOKEN', value: 'x', isSecret: true }] });
+    expect(rawPut(client)).toBeUndefined();
 
-    expect(client.get).toHaveBeenCalledTimes(1);
-    expect(putBody(client).variables).toEqual([
-      { key: 'A', value: '1', isSecret: true },
-      { key: 'B', value: '2' },
-    ]);
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+    expect(out.env).toEqual({ nonSecretsWritten: 0 });
   });
 
-  it('replace mode: does NOT GET, PUTs exactly the provided variables', async () => {
+  it('pure non-secret payload, no existing secrets: no /env PUT at all', async () => {
     const { handler, client } = setup();
+    wireGet(client, { variables: [] }, 'A=1\n');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'A', value: '2' }],
+    });
+
+    expect(envPut(client)).toBeUndefined();
+    expect(rawPut(client)?.[1]).toEqual({ content: 'A=2\n' });
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 0 });
+    expect(out.env).toEqual({ nonSecretsWritten: 1 });
+  });
+
+  it('pure non-secret payload with unrelated existing secrets: DB PUT re-affirms the untouched secrets (preserved)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [{ key: 'SECRET_A', value: '***', isSecret: true }] }, 'A=1\n');
+
+    await handler({ environmentId: 1, name: 's', variables: [{ key: 'A', value: '2' }] });
+
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'SECRET_A', value: '***', isSecret: true }] });
+    expect(rawPut(client)?.[1]).toEqual({ content: 'A=2\n' });
+  });
+
+  it('merge with an empty variables array is a no-op: no DB PUT (no secrets touched), no .env PUT (no payload)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [{ key: 'B', value: '2', isSecret: false }] }, 'B=2\n');
+
+    const res = await handler({ environmentId: 1, name: 's', variables: [] });
+
+    expect(client.get).toHaveBeenCalledTimes(1); // only the structured GET; no payload non-secrets -> no raw GET
+    expect(client.put).not.toHaveBeenCalled();
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 0 });
+    expect(out.env).toEqual({ nonSecretsWritten: 0 });
+  });
+
+  it('replace mode: secrets exact to /env, .env rebuilt exactly from the non-secret payload (no GET of raw .env)', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({ variables: [] }); // best-effort summary GET only
 
     await handler({
       environmentId: 2,
       name: 's',
       mode: 'replace',
-      variables: [{ key: 'ONLY', value: 'x' }],
+      variables: [
+        { key: 'SECRET', value: 's', isSecret: true },
+        { key: 'PLAIN', value: 'p' },
+      ],
     });
 
-    expect(client.get).not.toHaveBeenCalled();
-    expect(putBody(client).variables).toEqual([{ key: 'ONLY', value: 'x' }]);
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'SECRET', value: 's', isSecret: true }] });
+    expect(rawPut(client)?.[1]).toEqual({ content: 'PLAIN=p' });
+    // replace never reads the raw .env file — it is rebuilt from scratch
+    expect(client.get.mock.calls.some((c) => String(c[0]).endsWith('/env/raw'))).toBe(false);
   });
 
-  it('merge is fail-safe: when the GET fails, NO PUT is issued (no data loss)', async () => {
+  it('replace mode with no non-secrets still wipes .env to empty content', async () => {
+    const { handler, client } = setup();
+    client.get.mockResolvedValue({ variables: [] });
+
+    await handler({
+      environmentId: 2,
+      name: 's',
+      mode: 'replace',
+      variables: [{ key: 'S', value: 's', isSecret: true }],
+    });
+
+    expect(rawPut(client)?.[1]).toEqual({ content: '' });
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'S', value: 's', isSecret: true }] });
+  });
+
+  it('merge is fail-safe: when the structured GET fails, NO write is issued at all (no data loss)', async () => {
     const { handler, client } = setup();
     client.get.mockRejectedValue(new Error('network down'));
 
@@ -134,43 +208,81 @@ describe('update_stack_env — merge behaviour (mocked client)', () => {
 
   it('merge preserves an existing secret flag on a value-only update (no isSecret) — never demotes a secret to plaintext', async () => {
     const { handler, client } = setup();
-    client.get.mockResolvedValue({
-      variables: [{ key: 'TOKEN', value: 'old', isSecret: true }],
-    });
+    wireGet(client, { variables: [{ key: 'TOKEN', value: 'old', isSecret: true }] }, '');
 
     // caller rotates the value but omits isSecret
     await handler({ environmentId: 1, name: 's', variables: [{ key: 'TOKEN', value: 'rotated' }] });
 
-    expect(putBody(client).variables).toEqual([
-      { key: 'TOKEN', value: 'rotated', isSecret: true },
-    ]);
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'TOKEN', value: 'rotated', isSecret: true }] });
+    expect(rawPut(client)).toBeUndefined();
   });
 
-  it('merge tolerates a malformed GET response (variables not an array) without crashing', async () => {
+  it('merge tolerates a malformed structured GET response (variables not an array) without crashing', async () => {
     const { handler, client } = setup();
-    client.get.mockResolvedValue({ variables: null });
+    wireGet(client, { variables: null }, '');
 
-    await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y' }] });
+    await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y', isSecret: true }] });
 
-    expect(client.put).toHaveBeenCalledTimes(1);
-    expect(putBody(client).variables).toEqual([{ key: 'X', value: 'y' }]);
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'X', value: 'y', isSecret: true }] });
+  });
+
+  it('partial failure: DB PUT succeeds, .env/raw PUT fails -> error reported, db.secretsWritten stays set', async () => {
+    const { handler, client } = setup();
+    wireGet(
+      client,
+      { variables: [{ key: 'SECRET_A', value: 's', isSecret: true }] },
+      'PLAIN_B=old\n',
+    );
+    client.put.mockImplementation((path: string) =>
+      String(path).endsWith('/env/raw') ? Promise.reject(new Error('disk full')) : Promise.resolve({ ok: true }));
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [
+        { key: 'SECRET_A', value: 's', isSecret: true },
+        { key: 'PLAIN_B', value: 'new', isSecret: false },
+      ],
+    });
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+    expect(out.env).toEqual({ nonSecretsWritten: 0 });
+    expect(typeof out.error).toBe('string');
+    expect(out.success).toBe(false);
+  });
+
+  it('partial failure: the raw GET itself fails after a successful DB PUT -> error reported, db.secretsWritten stays set', async () => {
+    const { handler, client } = setup();
+    client.get.mockImplementation((path: string) =>
+      path.endsWith('/env/raw')
+        ? Promise.reject(new Error('500'))
+        : Promise.resolve({ variables: [{ key: 'SECRET_A', value: 's', isSecret: true }] }));
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [
+        { key: 'SECRET_A', value: 's', isSecret: true },
+        { key: 'PLAIN_B', value: 'new', isSecret: false },
+      ],
+    });
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+    expect(typeof out.error).toBe('string');
+    expect(rawPut(client)).toBeUndefined();
   });
 });
 
-// Response-Parser: jsonResponse liefert { content: [{ type:'text', text: JSON.stringify(x) }] }
-function jsonOut(res: unknown): Record<string, unknown> {
-  const text = (res as { content: { text: string }[] }).content[0].text;
-  return JSON.parse(text) as Record<string, unknown>;
-}
-
-describe('update_stack_env — summary/hint (merge only)', () => {
-  it('merge subset (no new keys) → summary + remove hint', async () => {
+describe('update_stack_env — summary (merge and replace)', () => {
+  it('merge subset (no new keys) -> summary reflects both stores combined', async () => {
     const { handler, client } = setup();
-    client.get.mockResolvedValue({ variables: [
+    wireGet(client, { variables: [
       { key: 'DB_PASSWORD', value: 's', isSecret: true },
       { key: 'TZ', value: 'Europe/Berlin' },
       { key: 'HOST', value: 'h' },
-    ] });
+    ] }, '');
     const res = await handler({ environmentId: 10, name: 'x',
       variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] });
     const out = jsonOut(res);
@@ -179,13 +291,23 @@ describe('update_stack_env — summary/hint (merge only)', () => {
     expect(String(out.hint)).toContain('remove_stack_env_vars');
   });
 
-  it('replace mode: no summary/hint and no extra GET (existing contract preserved)', async () => {
+  it('replace mode: summary reflects a best-effort GET against prior state', async () => {
     const { handler, client } = setup();
+    client.get.mockResolvedValue({ variables: [{ key: 'OLD', value: 'x' }] });
     const res = await handler({ environmentId: 10, name: 'x',
       variables: [{ key: 'A', value: 'a' }], mode: 'replace' });
     const out = jsonOut(res);
-    expect(client.get).not.toHaveBeenCalled();
+    expect(out.summary).toEqual({ added: 1, updated: 0, preserved: 0, removed: 1 });
+    expect(out.hint).toBeUndefined(); // hint is merge-only
+  });
+
+  it('replace mode: a failed best-effort summary GET does not block the write and omits summary', async () => {
+    const { handler, client } = setup();
+    client.get.mockRejectedValue(new Error('down'));
+    const res = await handler({ environmentId: 10, name: 'x',
+      variables: [{ key: 'A', value: 'a' }], mode: 'replace' });
+    const out = jsonOut(res);
     expect(out.summary).toBeUndefined();
-    expect(out.hint).toBeUndefined();
+    expect(envPut(client)).toBeDefined();
   });
 });

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -99,7 +99,7 @@ describe('update_stack_env — merge auto-routing (mocked client)', () => {
     expect(out.success).toBe(true);
   });
 
-  it('pure secret payload: only /env PUT — no /env/raw GET or PUT', async () => {
+  it('pure secret payload, brand new key: DB PUT fires; .env is also checked+scrubbed for the promoted key (no-op here, key never existed in .env)', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [] }, '');
 
@@ -109,13 +109,43 @@ describe('update_stack_env — merge auto-routing (mocked client)', () => {
       variables: [{ key: 'TOKEN', value: 'x', isSecret: true }],
     });
 
-    expect(client.get).toHaveBeenCalledTimes(1); // only the structured GET
+    // structured GET, then a raw GET to scrub the (brand-new) promoted key from .env — see Critical 2
+    expect(client.get).toHaveBeenCalledTimes(2);
     expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'TOKEN', value: 'x', isSecret: true }] });
-    expect(rawPut(client)).toBeUndefined();
+    // .env content is unchanged (TOKEN was never there), but the scrub PUT still fires
+    expect(rawPut(client)?.[1]).toEqual({ content: '' });
 
     const out = jsonOut(res);
     expect(out.db).toEqual({ secretsWritten: 1 });
     expect(out.env).toEqual({ nonSecretsWritten: 0 });
+  });
+
+  it('Important 6: extra fields on the underlying PUT responses are passed through additively, our own fields still win', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [] }, '');
+    client.put.mockImplementation((path: string) =>
+      String(path).endsWith('/env/raw')
+        ? Promise.resolve({ apiVersion: 'raw-v1', requestId: 'raw-req' })
+        : Promise.resolve({ apiVersion: 'db-v1', requestId: 'db-req', success: 'not-a-boolean-from-the-api' }));
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [
+        { key: 'A_SECRET', value: 's', isSecret: true },
+        { key: 'A', value: '1', isSecret: false },
+      ],
+    });
+
+    const out = jsonOut(res);
+    // both the DB PUT and the .env PUT fire here — their extra response fields
+    // are spread additively; on a key collision the later (.env) write wins.
+    expect(out.requestId).toBe('raw-req');
+    expect(out.apiVersion).toBe('raw-v1');
+    // ...but our own authoritative fields are never shadowed by passthrough data.
+    expect(out.success).toBe(true);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+    expect(out.env).toEqual({ nonSecretsWritten: 1 });
   });
 
   it('pure non-secret payload, no existing secrets: no /env PUT at all', async () => {
@@ -275,39 +305,135 @@ describe('update_stack_env — merge auto-routing (mocked client)', () => {
   });
 });
 
+describe('update_stack_env — critical fixes: degrade, promote, orphaned DB rows', () => {
+  it('Critical 1: degrading the ONLY existing secret to isSecret:false still fires the DB PUT (flushes the stale encrypted row)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [{ key: 'TOKEN', value: 'oldsecret', isSecret: true }] }, '');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'TOKEN', value: 'plain-now', isSecret: false }],
+    });
+
+    // DB PUT fires with an EMPTY secrets array -> the stale encrypted row is deleted.
+    expect(envPut(client)?.[1]).toEqual({ variables: [] });
+    // the demoted value lands in .env as plaintext.
+    expect(rawPut(client)?.[1]).toEqual({ content: 'TOKEN=plain-now' });
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 0 });
+    expect(out.env).toEqual({ nonSecretsWritten: 1 });
+  });
+
+  it('Critical 2: promoting a plain .env key to isSecret:true removes it from .env AND stores it as a DB secret', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [] }, 'API_KEY=plaintext-value\nOTHER=1\n');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'API_KEY', value: 'rotated-secret', isSecret: true }],
+    });
+
+    expect(envPut(client)?.[1]).toEqual({
+      variables: [{ key: 'API_KEY', value: 'rotated-secret', isSecret: true }],
+    });
+    // API_KEY is scrubbed from .env; OTHER is untouched.
+    expect(rawPut(client)?.[1]).toEqual({ content: 'OTHER=1\n' });
+
+    const out = jsonOut(res);
+    expect(out.db).toEqual({ secretsWritten: 1 });
+  });
+
+  it('Critical 3: an orphaned DB non-secret row untouched by this call is migrated into .env (not silently deleted), and is NOT reported as "preserved"', async () => {
+    const { handler, client } = setup();
+    // LEGACY_TZ lives only in the DB structured store (isSecret omitted/false) —
+    // a row that should not exist post-fix, but may be left over from before it.
+    wireGet(client, { variables: [{ key: 'LEGACY_TZ', value: 'Europe/Berlin' }] }, '');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'NEW_SECRET', value: 'v', isSecret: true }],
+    });
+
+    // the DB PUT fires (a new secret is being added) and drops LEGACY_TZ from the DB...
+    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'NEW_SECRET', value: 'v', isSecret: true }] });
+    // ...but its value is migrated into .env first, so it is not lost.
+    expect(rawPut(client)?.[1]).toEqual({ content: 'LEGACY_TZ=Europe/Berlin' });
+
+    const out = jsonOut(res);
+    // LEGACY_TZ must not be counted as "preserved" — it was excluded from the DB
+    // it used to live in, and the diff baseline only tracks DB secrets + .env keys.
+    expect(out.summary).toEqual({ added: 1, updated: 0, preserved: 0, removed: 0 });
+  });
+
+  it('Minor 7: duplicate keys in the payload are de-duplicated (last one wins) before routing', async () => {
+    const { handler, client } = setup();
+    wireGet(client, { variables: [] }, '');
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [
+        { key: 'A', value: '1', isSecret: false },
+        { key: 'A', value: '2', isSecret: false },
+      ],
+    });
+
+    expect(envPut(client)).toBeUndefined();
+    expect(rawPut(client)?.[1]).toEqual({ content: 'A=2' });
+
+    const out = jsonOut(res);
+    expect(out.env).toEqual({ nonSecretsWritten: 1 });
+  });
+});
+
 describe('update_stack_env — summary (merge and replace)', () => {
-  it('merge subset (no new keys) -> summary reflects both stores combined', async () => {
+  it('Important 5: a payload key already tracked in .env counts as "updated" (not "added"); an omitted .env key counts as "preserved"', async () => {
+    const { handler, client } = setup();
+    wireGet(
+      client,
+      { variables: [{ key: 'A_SECRET', value: 's', isSecret: true }] },
+      'EXISTING_KEY=old\nOTHER_KEY=other\n',
+    );
+
+    const res = await handler({
+      environmentId: 10,
+      name: 'x',
+      variables: [{ key: 'EXISTING_KEY', value: 'new', isSecret: false }],
+    });
+
+    expect(rawPut(client)?.[1]).toEqual({ content: 'EXISTING_KEY=new\nOTHER_KEY=other\n' });
+
+    const out = jsonOut(res);
+    // EXISTING_KEY already existed in .env and was changed -> updated, not added.
+    // OTHER_KEY (left out) and A_SECRET (DB secret, untouched) -> preserved.
+    expect(out.summary).toEqual({ added: 0, updated: 1, preserved: 2, removed: 0 });
+  });
+
+  it('merge subset of DB secrets (no new keys, no orphaned rows) -> summary reflects the DB store, hint fires', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [
       { key: 'DB_PASSWORD', value: 's', isSecret: true },
-      { key: 'TZ', value: 'Europe/Berlin' },
-      { key: 'HOST', value: 'h' },
+      { key: 'API_TOKEN', value: 't', isSecret: true },
     ] }, '');
     const res = await handler({ environmentId: 10, name: 'x',
       variables: [{ key: 'DB_PASSWORD', value: '***', isSecret: true }] });
     const out = jsonOut(res);
-    expect(out.summary).toEqual({ added: 0, updated: 0, preserved: 2, removed: 0 });
+    expect(out.summary).toEqual({ added: 0, updated: 0, preserved: 1, removed: 0 });
     expect(typeof out.hint).toBe('string');
     expect(String(out.hint)).toContain('remove_stack_env_vars');
   });
 
-  it('replace mode: summary reflects a best-effort GET against prior state', async () => {
+  it('replace mode: no summary/hint and no extra GET (existing #105 contract preserved — Critical 4)', async () => {
     const { handler, client } = setup();
-    client.get.mockResolvedValue({ variables: [{ key: 'OLD', value: 'x' }] });
     const res = await handler({ environmentId: 10, name: 'x',
       variables: [{ key: 'A', value: 'a' }], mode: 'replace' });
     const out = jsonOut(res);
-    expect(out.summary).toEqual({ added: 1, updated: 0, preserved: 0, removed: 1 });
-    expect(out.hint).toBeUndefined(); // hint is merge-only
-  });
-
-  it('replace mode: a failed best-effort summary GET does not block the write and omits summary', async () => {
-    const { handler, client } = setup();
-    client.get.mockRejectedValue(new Error('down'));
-    const res = await handler({ environmentId: 10, name: 'x',
-      variables: [{ key: 'A', value: 'a' }], mode: 'replace' });
-    const out = jsonOut(res);
+    expect(client.get).not.toHaveBeenCalled();
     expect(out.summary).toBeUndefined();
-    expect(envPut(client)).toBeDefined();
+    expect(out.hint).toBeUndefined();
   });
 });

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -369,6 +369,23 @@ describe('update_stack_env — critical fixes: degrade, promote, orphaned DB row
     expect(out.summary).toEqual({ added: 1, updated: 0, preserved: 0, removed: 0 });
   });
 
+  it('N1: an orphaned DB non-secret row that ALSO exists live in .env with a different value must NOT overwrite the live .env value', async () => {
+    const { handler, client } = setup();
+    // FOO exists both as a stale orphaned DB non-secret row AND live in .env.
+    wireGet(client, { variables: [{ key: 'FOO', value: 'stale-db-val' }] }, 'FOO=live-env-val\n');
+
+    await handler({
+      environmentId: 1,
+      name: 's',
+      variables: [{ key: 'NEW_SECRET', value: 'v', isSecret: true }],
+    });
+
+    // the .env is authoritative: the live value survives, the stale DB value never wins.
+    const content = String((rawPut(client)?.[1] as { content: string }).content);
+    expect(content).toContain('FOO=live-env-val');
+    expect(content).not.toContain('stale-db-val');
+  });
+
   it('Minor 7: duplicate keys in the payload are de-duplicated (last one wins) before routing', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: [] }, '');

--- a/tests/stack-env-merge.test.ts
+++ b/tests/stack-env-merge.test.ts
@@ -91,17 +91,18 @@ describe('update_stack_env — merge-semantic implementation', () => {
     });
   });
 
-  describe('replace path — PUT without GET', () => {
-    it('assigns variables directly in replace mode without a GET call', () => {
-      // replace branch: finalVariables = variables
-      expect(block).toMatch(/finalVariables\s*=\s*variables/);
+  describe('replace path — splits the payload by isSecret without a merge GET', () => {
+    it('derives secrets and non-secrets directly from the payload in replace mode', () => {
+      // replace branch: secrets = variables.filter(...), payloadNonSecrets = variables.filter(...)
+      expect(block).toMatch(/secrets\s*=\s*variables\.filter/);
+      expect(block).toMatch(/payloadNonSecrets\s*=\s*variables\.filter/);
     });
   });
 
-  describe('PUT call — always uses finalVariables', () => {
-    it('PUT body references finalVariables, not the raw input variables', () => {
-      // The PUT must use finalVariables as the payload
-      expect(block).toMatch(/variables:\s*finalVariables/);
+  describe('PUT call — DB store uses only the secret subset', () => {
+    it('PUT body to the DB endpoint references the secrets variable, not the raw input variables', () => {
+      // The DB PUT must use the isSecret:true subset as the payload
+      expect(block).toMatch(/variables:\s*secrets/);
     });
 
     it('PUT targets the correct /env endpoint with encodePath', () => {

--- a/tests/stack-env-tools.test.ts
+++ b/tests/stack-env-tools.test.ts
@@ -73,9 +73,10 @@ describe('update_stack_env (rawContent cleanup)', () => {
 
   it('sends variables as the "variables" key in the PUT request body', () => {
     const block = extractToolBlock(stacksSource, 'update_stack_env');
-    // After the merge-semantic refactor the PUT body uses finalVariables,
-    // not the raw input — but the JSON key sent to the API is still "variables".
-    expect(block).toMatch(/variables:\s*finalVariables/);
+    // After the isSecret:false auto-routing refactor (#109), the DB PUT body
+    // uses the isSecret:true subset (secrets), not the raw input — but the
+    // JSON key sent to the API is still "variables".
+    expect(block).toMatch(/variables:\s*secrets/);
   });
 
   it('declares variables as a required parameter', () => {


### PR DESCRIPTION
## Was
Behebt #109: `update_stack_env` mit `isSecret:false` verwarf Nicht-Secrets still (gingen an den DB-`/env`-Endpoint, der nur Secrets speichert → verwaiste, unsichtbare, nie injizierte Zeile).

Jetzt **Auto-Routing über beide Speicher:** `isSecret:true` → DB (`/env`), `isSecret:false` → `.env` (`/env/raw`, upsert im merge, rebuild im replace). Neuer reiner Helfer `upsertDotEnv`. Beschreibung korrigiert. Response `db`/`env`/`summary` zeigt, was WO landete.

## Qualität
- TDD, **341 Tests grün**, typecheck + build + `docker build` sauber. Merge-Fail-Safe (GET-Fehler → kein PUT) unverändert.
- **Whole-Branch-Review fand 4 Critical-Datenverlust-Bugs** (degradiertes letztes Secret nicht geflusht; promoted Key blieb im `.env`-Klartext; verwaiste DB-Zeilen still gelöscht+falsch als `preserved`; replace-Summary blind für `.env`-Wipe) → alle behoben. **Re-Review** fand einen Folgebug (N1: Migration überschrieb lebenden `.env`-Wert mit totem DB-Orphan) → mit Guard + Test behoben.
- replace-Modus auf #105-Contract zurückgesetzt (kein GET, kein Summary).

Follow-up zu #105.