### PR TITLE
fix(tools): send pull/build/forceRecreate body from deploy_stack (#117)

### DIFF
--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -521,13 +521,30 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'deploy_stack', 'Explicit deploy operation for an existing stack (pulls latest images and recreates services from the current compose file); use `start_stack` if you just want to start without re-pulling, or `update_stack_compose` to change the compose file before deploying.',
+  registerTool(server, 'deploy_stack', 'Explicit deploy operation for an existing stack: pulls newer images (unless pull:false) and recreates services whose configuration changed, from the current compose file. Set forceRecreate to also recreate containers whose config is unchanged. Use `start_stack` if you just want to start without re-pulling, or `update_stack_compose` to change the compose file before deploying.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
+      pull: z.boolean().optional().describe('Pull newer images before recreating (default: true)'),
+      build: z.boolean().optional().describe('Build services that declare a `build:` section (default: false)'),
+      forceRecreate: z.boolean().optional().describe('Recreate containers even when their resolved configuration is unchanged (default: false)'),
     },
-    async ({ environmentId, name }) => {
-      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/deploy`, undefined, { env: environmentId }));
+    async ({ environmentId, name, pull, build, forceRecreate }) => {
+      // Dockhand's /deploy handler reads pull/build/forceRecreate out of the
+      // request body. Sending no body is not equivalent to sending defaults:
+      // before Dockhand 1.0.38 the handler called request.json() unguarded, so
+      // an empty body threw before the SSE stream opened and the endpoint
+      // answered with an HTML 500 while deploying nothing; and from 1.0.38 on
+      // (request.json().catch(() => ({}))) an absent body silently means
+      // pull:undefined, i.e. a deploy that never pulls — contradicting what
+      // this tool advertises. So always send all three, defaulting to the
+      // values the web UI's Deploy popover uses.
+      const body = {
+        pull: pull ?? true,
+        build: build ?? false,
+        forceRecreate: forceRecreate ?? false,
+      };
+      return jsonResponse(await client.postSSE(`/api/stacks/${encodePath(name)}/deploy`, body, { env: environmentId }));
     }
   );
 }

--- a/tests/deploy-stack.test.ts
+++ b/tests/deploy-stack.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stacksSource = readFileSync(
+  join(__dirname, '..', 'src', 'tools', 'stacks.ts'),
+  'utf-8',
+);
+
+/**
+ * Extract the registerTool(...) source block for a named tool. The block
+ * spans from the registerTool(server, '<toolName>', ...) line to the next
+ * registerTool( call (or end of file if last).
+ */
+function extractToolBlock(source: string, toolName: string): string {
+  const startPattern = new RegExp(
+    `registerTool\\s*\\(\\s*server\\s*,\\s*'${toolName}'`,
+  );
+  const startMatch = startPattern.exec(source);
+  if (!startMatch) {
+    throw new Error(`Tool '${toolName}' not found in source`);
+  }
+  const startIdx = startMatch.index;
+  const afterStart = source.slice(startIdx + 1);
+  const nextToolMatch = /registerTool\s*\(/.exec(afterStart);
+  const endIdx = nextToolMatch
+    ? startIdx + 1 + nextToolMatch.index
+    : source.length;
+  return source.slice(startIdx, endIdx);
+}
+
+/**
+ * Regression cover for #117: deploy_stack used to POST with no request body.
+ * Dockhand's handler destructures pull/build/forceRecreate out of that body —
+ * unguarded before 1.0.38 (HTML 500, nothing deployed) and defaulting to a
+ * pull-less deploy afterwards. The body is therefore mandatory, not cosmetic.
+ */
+describe('deploy_stack', () => {
+  const block = extractToolBlock(stacksSource, 'deploy_stack');
+
+  it('targets POST /api/stacks/{name}/deploy over SSE', () => {
+    expect(block).toMatch(/client\.postSSE\(/);
+    expect(block).toMatch(/\$\{encodePath\(name\)\}\/deploy/);
+  });
+
+  it('never sends an undefined body (the #117 regression)', () => {
+    expect(block).not.toMatch(/\/deploy`\s*,\s*undefined/);
+  });
+
+  it('sends pull, build and forceRecreate in the request body', () => {
+    expect(block).toMatch(/pull:\s*pull\s*\?\?/);
+    expect(block).toMatch(/build:\s*build\s*\?\?/);
+    expect(block).toMatch(/forceRecreate:\s*forceRecreate\s*\?\?/);
+    expect(block).toMatch(/\/deploy`\s*,\s*body\s*,/);
+  });
+
+  it('defaults to the web UI Deploy popover values (pull on, build and forceRecreate off)', () => {
+    expect(block).toMatch(/pull:\s*pull\s*\?\?\s*true/);
+    expect(block).toMatch(/build:\s*build\s*\?\?\s*false/);
+    expect(block).toMatch(/forceRecreate:\s*forceRecreate\s*\?\?\s*false/);
+  });
+
+  it('declares the three options as optional booleans', () => {
+    for (const opt of ['pull', 'build', 'forceRecreate']) {
+      expect(block).toMatch(
+        new RegExp(`${opt}:\\s*z\\.boolean\\(\\)\\.optional\\(\\)\\.describe`),
+      );
+    }
+  });
+
+  it('keeps passing the environment as the ?env= query param', () => {
+    expect(block).toMatch(/\{\s*env:\s*environmentId\s*\}/);
+  });
+});


### PR DESCRIPTION
Fixes #117.

## What's wrong

`deploy_stack` POSTs to `/api/stacks/{name}/deploy` with **no request body**, while Dockhand's handler destructures `pull` / `build` / `forceRecreate` out of that body. That misses in two different ways depending on the Dockhand version:

- **up to 1.0.37** the handler called `await request.json()` unguarded, so an empty body threw *before* the SSE stream opened and SvelteKit rendered its HTML error page. The tool always returned `HTTP 500: <!doctype html> … Unexpected end of JSON input` **and deployed nothing** — the failure mode reported in #117.
- **from 1.0.38** ([`request.json().catch(() => ({}))`](https://github.com/Finsys/dockhand/commit/64b6dcd7)) the call no longer throws, but an absent body still means `pull: undefined` → `pullPolicy: undefined`, i.e. a deploy that **never pulls**. That silently contradicts this tool's own description ("pulls latest images and recreates services").

So the body is load-bearing, not cosmetic: omitting it is not the same as sending defaults.

## The fix

Always send all three flags, defaulting to the values the web UI's Deploy popover uses ([`RedeployPopover.svelte`](https://github.com/Finsys/dockhand/blob/main/src/routes/stacks/RedeployPopover.svelte): `pull = true`, `build = false`, `forceRecreate = false`), and expose them as optional tool parameters. `forceRecreate` in particular had no MCP equivalent at all before — recreating containers whose config is unchanged (e.g. to re-exercise a rewritten compose file) previously required the web UI.

The tool description is updated to match the real semantics: it recreates services whose configuration changed, and force-recreate is opt-in.

## Scope

Only `deploy_stack`. Verified that the sibling tools are genuinely unaffected rather than assuming it: `start` / `stop` / `restart` handlers read no body, and `deploy_git_stack`'s handler (`/api/git/stacks/{id}/deploy`) reads none either.

## Verification

- `npm run typecheck`, `npm run build`, `node scripts/validate-mcp-tools.mjs` — clean (`ORPHANED_TOOL: 0`, `PARAM_MISMATCH: 0`, `MISSING_ENCODE: 0`).
- `vitest run` — **348 passed** (12 files), including 6 new tests in `tests/deploy-stack.test.ts` following the existing source-inspection pattern.
- The new tests were checked to actually catch the regression: against the previous implementation **4 of the 6 fail** (undefined body, missing flags, wrong defaults, missing params).
- Behaviour confirmed end to end on a live stack (Dockhand 1.0.37, MCP 1.9.x): before the change every `deploy_stack` call returned the HTML 500 with containers untouched; the web UI's Deploy button on the same stack worked, which is what pointed at the request body.

## Note for #109 while I'm here

`update_stack_env` with `isSecret:false` now persists correctly — that issue looks fixed by #110 (v1.9.1) but is still open; might be worth closing.