### PR TITLE
fix(tools): align stack, system and favorites API contracts

### DIFF
--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -25,6 +25,8 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
       compose: z.string().describe('Docker Compose file content as string'),
+      composePath: z.string().optional().describe('Explicit path for the compose file'),
+      envPath: z.string().optional().describe('Explicit path for the .env file'),
       start: z.boolean().optional().describe('Start/deploy the stack immediately (default: true)'),
       envVars: z.array(z.object({
         key: z.string(),
@@ -33,8 +35,10 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       })).optional().describe('Environment variables'),
       rawEnvContent: z.string().optional().describe('Raw .env file content'),
     },
-    async ({ environmentId, name, compose, start, envVars, rawEnvContent }) => {
+    async ({ environmentId, name, compose, composePath, envPath, start, envVars, rawEnvContent }) => {
       const body: Record<string, unknown> = { name, compose };
+      if (composePath !== undefined) body.composePath = composePath;
+      if (envPath !== undefined) body.envPath = envPath;
       if (start !== undefined) body.start = start;
       if (envVars) body.envVars = envVars;
       if (rawEnvContent) body.rawEnvContent = rawEnvContent;
@@ -450,12 +454,18 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name to adopt'),
-      path: z.string().optional().describe('Path to the stack on the filesystem'),
+      composePath: z.string().describe('Full path to the stack compose file'),
+      envPath: z.string().optional().describe('Optional full path to the stack .env file'),
+      sourceDir: z.string().optional().describe('Optional source directory for the stack'),
     },
-    async ({ environmentId, name, path }) => {
-      const body: Record<string, unknown> = { name };
-      if (path) body.path = path;
-      return jsonResponse(await client.post('/api/stacks/adopt', body, { env: environmentId }));
+    async ({ environmentId, name, composePath, envPath, sourceDir }) => {
+      const stack: Record<string, unknown> = { name, composePath };
+      if (envPath !== undefined) stack.envPath = envPath;
+      if (sourceDir !== undefined) stack.sourceDir = sourceDir;
+      return jsonResponse(await client.post('/api/stacks/adopt', {
+        environmentId,
+        stacks: [stack],
+      }));
     }
   );
 
@@ -463,10 +473,14 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
-      newPath: z.string().describe('New filesystem path'),
+      oldDir: z.string().describe('Current stack directory'),
+      newComposePath: z.string().describe('New full path to the compose file'),
+      newEnvPath: z.string().optional().describe('Optional new full path to the .env file'),
     },
-    async ({ environmentId, name, newPath }) => {
-      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/relocate`, { path: newPath }, { env: environmentId }));
+    async ({ environmentId, name, oldDir, newComposePath, newEnvPath }) => {
+      const body: Record<string, unknown> = { oldDir, newComposePath };
+      if (newEnvPath !== undefined) body.newEnvPath = newEnvPath;
+      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/relocate`, body, { env: environmentId }));
     }
   );
 
@@ -484,10 +498,13 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'get_stack_path_hints', 'Retrieve a list of suggested filesystem paths for placing a new stack; complements `get_stack_default_path` (single default) and `get_stack_base_path` (root base dir).',
-    { environmentId: z.number().describe('Environment ID') },
-    async ({ environmentId }) => {
-      return jsonResponse(await client.get('/api/stacks/path-hints', { env: environmentId }));
+  registerTool(server, 'get_stack_path_hints', 'Retrieve a list of suggested filesystem paths for placing a stack; complements `get_stack_default_path` (single default) and `get_stack_base_path` (root base dir).',
+    {
+      environmentId: z.number().describe('Environment ID'),
+      name: z.string().describe('Stack name'),
+    },
+    async ({ environmentId, name }) => {
+      return jsonResponse(await client.get('/api/stacks/path-hints', { env: environmentId, name }));
     }
   );
 
@@ -503,21 +520,24 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
 
   // --- Missing endpoints ---
 
-  registerTool(server, 'get_stack_default_path', 'Retrieve the default suggested path for a new stack on this environment; use `get_stack_path_hints` for multiple alternatives, or `validate_stack_path` to confirm a chosen path.',
-    { environmentId: z.number().describe('Environment ID') },
-    async ({ environmentId }) => {
-      return jsonResponse(await client.get('/api/stacks/default-path', { env: environmentId }));
-    }
-  );
-
-  registerTool(server, 'check_stack_path_change', 'Check whether moving a stack to a new filesystem path is safe (e.g. no conflicts, writable); call before `relocate_stack` to avoid data issues, or use `validate_stack_path` for a new-stack path check.',
+  registerTool(server, 'get_stack_default_path', 'Retrieve the default suggested path for a stack on this environment; use `get_stack_path_hints` for multiple alternatives, or `validate_stack_path` to confirm a chosen path.',
     {
       environmentId: z.number().describe('Environment ID'),
       name: z.string().describe('Stack name'),
-      newPath: z.string().describe('New filesystem path to check'),
     },
-    async ({ environmentId, name, newPath }) => {
-      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/check-path-change`, { path: newPath }, { env: environmentId }));
+    async ({ environmentId, name }) => {
+      return jsonResponse(await client.get('/api/stacks/default-path', { env: environmentId, name }));
+    }
+  );
+
+  registerTool(server, 'check_stack_path_change', 'Check whether moving a stack to a new compose path is safe (e.g. no conflicts, writable); call before `relocate_stack` to avoid data issues, or use `validate_stack_path` for a new-stack path check.',
+    {
+      environmentId: z.number().describe('Environment ID'),
+      name: z.string().describe('Stack name'),
+      newComposePath: z.string().describe('New full path to the compose file to check'),
+    },
+    async ({ environmentId, name, newComposePath }) => {
+      return jsonResponse(await client.post(`/api/stacks/${encodePath(name)}/check-path-change`, { newComposePath }, { env: environmentId }));
     }
   );
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -41,10 +41,10 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'get_system_disk', 'Retrieve disk usage statistics for the Dockhand server host; use `get_host_info` for OS-level details or `get_general_settings` to read application-level configuration.',
-    {},
-    async () => {
-      return jsonResponse(await client.get('/api/system/disk'));
+  registerTool(server, 'get_system_disk', 'Retrieve disk usage statistics for a Dockhand environment; use `get_host_info` for OS-level details or `get_general_settings` to read application-level configuration.',
+    { environmentId: z.number().describe('Environment ID') },
+    async ({ environmentId }) => {
+      return jsonResponse(await client.get('/api/system/disk', { env: environmentId }));
     }
   );
 

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -170,35 +170,45 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
 
   // --- UI Preferences ---
 
-  registerTool(server, 'get_favorites', 'Retrieve the UI favorite containers and stacks; use `set_favorites` to update the list.',
-    {},
-    async () => {
-      return jsonResponse(await client.get('/api/preferences/favorites'));
+  registerTool(server, 'get_favorites', 'Retrieve the UI favorite containers and stacks for an environment; use `set_favorites` to update the list.',
+    { environmentId: z.number().describe('Environment ID') },
+    async ({ environmentId }) => {
+      return jsonResponse(await client.get('/api/preferences/favorites', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'set_favorites', 'Replace the UI favorites list with the provided containers/stacks; see `get_favorites` to read current entries before overwriting.',
+  registerTool(server, 'set_favorites', 'Replace the UI favorites list for an environment with the provided containers/stacks; see `get_favorites` to read current entries before overwriting.',
     {
+      environmentId: z.number().describe('Environment ID'),
       favorites: z.array(z.unknown()).describe('Favorites list'),
     },
-    async ({ favorites }) => {
-      return jsonResponse(await client.post('/api/preferences/favorites', favorites));
+    async ({ environmentId, favorites }) => {
+      return jsonResponse(await client.post('/api/preferences/favorites', {
+        environmentId,
+        action: 'reorder',
+        favorites,
+      }));
     }
   );
 
-  registerTool(server, 'get_favorite_groups', 'Retrieve the named groups used to organise UI favorites; use `set_favorite_groups` to save changes.',
-    {},
-    async () => {
-      return jsonResponse(await client.get('/api/preferences/favorite-groups'));
+  registerTool(server, 'get_favorite_groups', 'Retrieve the named groups used to organise UI favorites for an environment; use `set_favorite_groups` to save changes.',
+    { environmentId: z.number().describe('Environment ID') },
+    async ({ environmentId }) => {
+      return jsonResponse(await client.get('/api/preferences/favorite-groups', { env: environmentId }));
     }
   );
 
-  registerTool(server, 'set_favorite_groups', 'Replace the UI favorite groups definition; see `get_favorite_groups` to read the existing groups before overwriting.',
+  registerTool(server, 'set_favorite_groups', 'Replace the UI favorite groups definition for an environment; see `get_favorite_groups` to read the existing groups before overwriting.',
     {
+      environmentId: z.number().describe('Environment ID'),
       groups: z.array(z.unknown()).describe('Favorite groups'),
     },
-    async ({ groups }) => {
-      return jsonResponse(await client.post('/api/preferences/favorite-groups', groups));
+    async ({ environmentId, groups }) => {
+      return jsonResponse(await client.post('/api/preferences/favorite-groups', {
+        environmentId,
+        action: 'reorder',
+        groups,
+      }));
     }
   );
 

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const stacksSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'stacks.ts'), 'utf-8');
+const systemSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'system.ts'), 'utf-8');
+const usersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'users.ts'), 'utf-8');
+
+function extractToolBlock(source: string, toolName: string): string {
+  const startPattern = new RegExp(
+    `registerTool\\s*\\(\\s*server\\s*,\\s*'${toolName}'`,
+  );
+  const startMatch = startPattern.exec(source);
+  if (!startMatch) {
+    throw new Error(`Tool '${toolName}' not found in source`);
+  }
+  const startIdx = startMatch.index;
+  const afterStart = source.slice(startIdx + 1);
+  const nextToolMatch = /registerTool\s*\(/.exec(afterStart);
+  const endIdx = nextToolMatch
+    ? startIdx + 1 + nextToolMatch.index
+    : source.length;
+  return source.slice(startIdx, endIdx);
+}
+
+describe('Dockhand API contract alignment', () => {
+  it('create_stack exposes and forwards composePath and envPath', () => {
+    const block = extractToolBlock(stacksSource, 'create_stack');
+    expect(block).toMatch(/composePath:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/envPath:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/body\.composePath\s*=\s*composePath/);
+    expect(block).toMatch(/body\.envPath\s*=\s*envPath/);
+  });
+
+  it('adopt_stack sends environmentId and stacks[] with composePath in the body', () => {
+    const block = extractToolBlock(stacksSource, 'adopt_stack');
+    expect(block).toMatch(/composePath:\s*z\.string\(\)/);
+    expect(block).toMatch(/envPath:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/sourceDir:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/environmentId,\s*\n\s*stacks:\s*\[stack\]/);
+    expect(block).toMatch(/client\.post\('\/api\/stacks\/adopt'/);
+    expect(block).not.toMatch(/\{\s*env:\s*environmentId\s*\}/);
+  });
+
+  it('relocate_stack sends oldDir, newComposePath and optional newEnvPath', () => {
+    const block = extractToolBlock(stacksSource, 'relocate_stack');
+    expect(block).toMatch(/oldDir:\s*z\.string\(\)/);
+    expect(block).toMatch(/newComposePath:\s*z\.string\(\)/);
+    expect(block).toMatch(/newEnvPath:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/\{\s*oldDir,\s*newComposePath\s*\}/);
+    expect(block).toMatch(/body\.newEnvPath\s*=\s*newEnvPath/);
+    expect(block).not.toMatch(/\{\s*path:\s*newPath\s*\}/);
+  });
+
+  it('stack path helpers include name and use newComposePath for path-change checks', () => {
+    const hints = extractToolBlock(stacksSource, 'get_stack_path_hints');
+    const defaultPath = extractToolBlock(stacksSource, 'get_stack_default_path');
+    const check = extractToolBlock(stacksSource, 'check_stack_path_change');
+    for (const block of [hints, defaultPath]) {
+      expect(block).toMatch(/name:\s*z\.string\(\)/);
+      expect(block).toMatch(/\{\s*env:\s*environmentId,\s*name\s*\}/);
+    }
+    expect(check).toMatch(/newComposePath:\s*z\.string\(\)/);
+    expect(check).toMatch(/\{\s*newComposePath\s*\}/);
+    expect(check).not.toMatch(/\{\s*path:\s*newPath\s*\}/);
+  });
+
+  it('get_system_disk is scoped to an environment', () => {
+    const block = extractToolBlock(systemSource, 'get_system_disk');
+    expect(block).toMatch(/environmentId:\s*z\.number\(\)/);
+    expect(block).toMatch(/client\.get\('\/api\/system\/disk',\s*\{\s*env:\s*environmentId\s*\}\)/);
+  });
+
+  it('favorites and favorite groups are environment-scoped reorder operations', () => {
+    const getFavorites = extractToolBlock(usersSource, 'get_favorites');
+    const setFavorites = extractToolBlock(usersSource, 'set_favorites');
+    const getGroups = extractToolBlock(usersSource, 'get_favorite_groups');
+    const setGroups = extractToolBlock(usersSource, 'set_favorite_groups');
+
+    for (const block of [getFavorites, getGroups]) {
+      expect(block).toMatch(/environmentId:\s*z\.number\(\)/);
+      expect(block).toMatch(/\{\s*env:\s*environmentId\s*\}/);
+    }
+    expect(setFavorites).toMatch(/environmentId,\s*\n\s*action:\s*'reorder',\s*\n\s*favorites/);
+    expect(setGroups).toMatch(/environmentId,\s*\n\s*action:\s*'reorder',\s*\n\s*groups/);
+  });
+});


### PR DESCRIPTION
Fixes #130.

## Problem
Several MCP tools currently use request bodies or query parameters that do not match the Dockhand REST API contract. These mismatches are independent of the `deploy_stack` issue already tracked in #117 / #119.

## What this fixes
- `create_stack`: expose and forward optional `composePath` and `envPath`
- `adopt_stack`: send `{ environmentId, stacks: [...] }` with `composePath` and optional `envPath` / `sourceDir`, instead of a single `{ name, path }` body plus `?env=...`
- `relocate_stack`: send `{ oldDir, newComposePath, newEnvPath? }`
- `check_stack_path_change`: send `{ newComposePath }`
- `get_stack_default_path`: include both `env` and `name`
- `get_stack_path_hints`: include both `env` and `name`
- `get_system_disk`: scope the request with `env=<environmentId>`
- favorites: scope reads by environment and send the replacement body as `{ environmentId, action: "reorder", favorites }`
- favorite groups: analogous environment scope and reorder body

## Verification
The corrected contracts were verified end-to-end against Dockhand 1.0.40 before upstreaming.

The prepared upstream-safe variant (without the `deploy_stack` change) passed:
- build
- typecheck
- 353/353 Vitest tests

This PR adds six focused API-contract regression tests covering the corrected request shapes.

## Scope
`deploy_stack` is intentionally excluded because #117 / #119 already covers the `{ pull, build, forceRecreate }` request body and should remain the single upstream path for that fix.

Also intentionally excluded from this PR:
- Streamable HTTP session lifecycle / memory bounds
- `exec_container`
- packaging/version metadata
- Dockhand file permissions / umask
