### PR TITLE
feat(server): bound Streamable HTTP session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ DOCKHAND_URL=https://your-server.com DOCKHAND_USERNAME=admin DOCKHAND_PASSWORD=s
 | `DOCKHAND_USERNAME` | Yes | - | Dockhand username |
 | `DOCKHAND_PASSWORD` | Yes | - | Dockhand password |
 | `MCP_PORT` | No | `8080` | Port for the MCP server |
+| `MCP_SESSION_TTL_SECONDS` | No | `1800` | Inactivity timeout before a retained MCP session is expired |
+| `MCP_SESSION_CLEANUP_INTERVAL_SECONDS` | No | `300` | Interval for removing expired sessions (clamped to the session TTL) |
+| `MCP_MAX_SESSIONS` | No | `0` | Maximum retained sessions; `0` keeps the existing unlimited behavior |
 | `LOG_LEVEL` | No | `info` | Log level |
 
 ## MCP Client Configuration

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,13 @@ import express from 'express';
 import type { Request, Response } from 'express';
 import { DockhandClient } from './client/dockhand-client.js';
 import { registerAllTools } from './tools/index.js';
-import { getSessionLifecycleConfig, selectOldestIdleSession } from './session-lifecycle.js';
+import {
+  beginFoundingSession,
+  completeFoundingSession,
+  getSessionLifecycleConfig,
+  removeSessionEntry,
+  selectOldestIdleSession,
+} from './session-lifecycle.js';
 import type { DockhandConfig } from './types/dockhand.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
@@ -68,19 +74,7 @@ export async function createServer(config: ServerConfig): Promise<void> {
   async function removeSession(sessionId: string, reason: string): Promise<void> {
     const entry = sessions.get(sessionId);
     if (!entry) return;
-
-    sessions.delete(sessionId);
-    try {
-      await entry.server.close();
-    } catch (error) {
-      console.error(`[session] Error closing server for ${sessionId}:`, error);
-      try {
-        await entry.transport.close?.();
-      } catch {
-        // Best-effort fallback only.
-      }
-    }
-    console.error(`[session] Removed session ${sessionId} (${reason}; ${sessions.size} active)`);
+    await removeSessionEntry(sessions, sessionId, entry, reason);
   }
 
   async function handleExistingSession(
@@ -172,12 +166,12 @@ export async function createServer(config: ServerConfig): Promise<void> {
           sessionIdGenerator: () => crypto.randomUUID(),
           onsessioninitialized: (id) => {
             initializedSessionId = id;
-            sessions.set(id, {
-              server: server!,
-              transport: transport!,
-              lastActivity: Date.now(),
-              activeRequests: 0,
-            });
+            // Mark the session busy (activeRequests: 1) immediately: the
+            // founding transport.handleRequest(...) call below is still in
+            // flight for this very session, and until it resolves the
+            // session must not be a candidate for capacity eviction (see
+            // selectOldestIdleSession / reserveSessionSlot).
+            beginFoundingSession(sessions, id, { server: server!, transport: transport! });
             console.error(`[session] New session ${id} (${sessions.size} active)`);
           },
         });
@@ -193,6 +187,13 @@ export async function createServer(config: ServerConfig): Promise<void> {
         server = createMcpServer(client);
         await server.connect(transport);
         await transport.handleRequest(req, res, req.body);
+
+        // The founding request has now been fully served; release the busy
+        // marker so normal idle-eviction/inactivity-timeout accounting takes
+        // back over for this session.
+        if (initializedSessionId) {
+          completeFoundingSession(sessions, initializedSessionId);
+        }
       } catch (error) {
         if (initializedSessionId) {
           await removeSession(initializedSessionId, 'initialization failure');
@@ -242,7 +243,13 @@ export async function createServer(config: ServerConfig): Promise<void> {
     }
 
     await handleExistingSession(entry, req, res);
-    await removeSession(sessionId, 'client delete');
+    // Use the entry captured above rather than removeSession(sessionId, ...)
+    // (which would re-look-up via sessions.get(sessionId)): the SDK's own
+    // DELETE handling inside handleExistingSession() calls
+    // transport.close() internally, firing transport.onclose, which already
+    // deletes the map entry before we get here. A lookup-based removal would
+    // then silently no-op and skip server.close() + the removal log.
+    await removeSessionEntry(sessions, sessionId, entry, 'client delete');
   });
 
   const host = config.host || '0.0.0.0';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,9 @@
 /**
  * MCP Server setup with Streamable HTTP transport.
  *
- * Uses a factory pattern: each MCP session gets its own McpServer instance,
- * while all sessions share a single DockhandClient (and its auth cookie).
- * This fixes the multi-session bug where a second connection would fail with
- * "Already connected to a transport".
+ * Each stateful MCP session gets its own McpServer instance while all sessions
+ * share a single DockhandClient (and its auth cookie). Session resource usage is
+ * bounded through configurable inactivity cleanup and an optional LRU cap.
  */
 
 import { readFileSync } from 'node:fs';
@@ -14,15 +13,10 @@ import express from 'express';
 import type { Request, Response } from 'express';
 import { DockhandClient } from './client/dockhand-client.js';
 import { registerAllTools } from './tools/index.js';
+import { getSessionLifecycleConfig, selectOldestIdleSession } from './session-lifecycle.js';
 import type { DockhandConfig } from './types/dockhand.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
-
-/** Inactivity timeout before a session is cleaned up (30 minutes). */
-const SESSION_INACTIVITY_TIMEOUT_MS = 30 * 60 * 1000;
-
-/** Interval for checking expired sessions (5 minutes). */
-const SESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
 export interface ServerConfig {
   dockhand: DockhandConfig;
@@ -34,12 +28,9 @@ interface SessionEntry {
   server: McpServer;
   transport: StreamableHTTPServerTransport;
   lastActivity: number;
+  activeRequests: number;
 }
 
-/**
- * Create a new McpServer instance with all tools registered.
- * Each MCP session gets its own server instance, sharing the DockhandClient.
- */
 function createMcpServer(client: DockhandClient): McpServer {
   const server = new McpServer({
     name: 'mcp-dockhand',
@@ -50,82 +41,172 @@ function createMcpServer(client: DockhandClient): McpServer {
 }
 
 export async function createServer(config: ServerConfig): Promise<void> {
-  // Single shared Dockhand client — auth cookie is shared across all sessions
   const client = new DockhandClient(config.dockhand);
-
+  const lifecycle = getSessionLifecycleConfig();
   const app = express();
-
-  // Parse JSON request bodies (required for MCP Streamable HTTP)
   app.use(express.json());
 
-  // Health endpoint (no auth required)
+  const sessions = new Map<string, SessionEntry>();
+  let pendingSessions = 0;
+  let capacityGate: Promise<void> = Promise.resolve();
+
   app.get('/health', (_req: Request, res: Response) => {
-    res.json({ status: 'ok', server: 'mcp-dockhand', version: pkg.version });
+    res.json({
+      status: 'ok',
+      server: 'mcp-dockhand',
+      version: pkg.version,
+      sessions: {
+        active: sessions.size,
+        pending: pendingSessions,
+        max: lifecycle.maxSessions === 0 ? null : lifecycle.maxSessions,
+        ttlSeconds: lifecycle.inactivityTimeoutMs / 1000,
+        cleanupIntervalSeconds: lifecycle.cleanupIntervalMs / 1000,
+      },
+    });
   });
 
-  // Store sessions by session ID
-  const sessions = new Map<string, SessionEntry>();
-
-  /**
-   * Remove a session and close its transport.
-   */
-  function removeSession(sessionId: string): void {
+  async function removeSession(sessionId: string, reason: string): Promise<void> {
     const entry = sessions.get(sessionId);
-    if (entry) {
-      sessions.delete(sessionId);
-      // Close transport (async, fire-and-forget)
-      entry.transport.close?.().catch(() => {});
-      console.error(`[session] Removed session ${sessionId} (${sessions.size} active)`);
+    if (!entry) return;
+
+    sessions.delete(sessionId);
+    try {
+      await entry.server.close();
+    } catch (error) {
+      console.error(`[session] Error closing server for ${sessionId}:`, error);
+      try {
+        await entry.transport.close?.();
+      } catch {
+        // Best-effort fallback only.
+      }
+    }
+    console.error(`[session] Removed session ${sessionId} (${reason}; ${sessions.size} active)`);
+  }
+
+  async function handleExistingSession(
+    entry: SessionEntry,
+    req: Request,
+    res: Response,
+    body?: unknown,
+  ): Promise<void> {
+    entry.activeRequests += 1;
+    entry.lastActivity = Date.now();
+    try {
+      await entry.transport.handleRequest(req, res, body);
+    } finally {
+      entry.activeRequests = Math.max(0, entry.activeRequests - 1);
+      entry.lastActivity = Date.now();
     }
   }
 
-  /**
-   * Periodic cleanup of inactive sessions to prevent memory leaks.
-   */
-  const cleanupInterval = setInterval(() => {
-    const now = Date.now();
-    for (const [sessionId, entry] of sessions) {
-      if (now - entry.lastActivity > SESSION_INACTIVITY_TIMEOUT_MS) {
-        console.error(`[session] Session ${sessionId} timed out after inactivity`);
-        removeSession(sessionId);
-      }
-    }
-  }, SESSION_CLEANUP_INTERVAL_MS);
-  cleanupInterval.unref(); // Don't prevent process exit
+  async function reserveSessionSlot(): Promise<boolean> {
+    let releaseGate!: () => void;
+    const previousGate = capacityGate;
+    capacityGate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
 
-  // MCP Streamable HTTP endpoint
+    await previousGate;
+    try {
+      if (lifecycle.maxSessions !== 0 && sessions.size + pendingSessions >= lifecycle.maxSessions) {
+        const candidate = selectOldestIdleSession(sessions);
+        if (!candidate) return false;
+        console.error(`[session] Capacity ${lifecycle.maxSessions} reached; evicting idle session ${candidate}`);
+        await removeSession(candidate, 'capacity eviction');
+      }
+
+      if (lifecycle.maxSessions !== 0 && sessions.size + pendingSessions >= lifecycle.maxSessions) {
+        return false;
+      }
+
+      pendingSessions += 1;
+      return true;
+    } finally {
+      releaseGate();
+    }
+  }
+
+  function releasePendingSessionSlot(): void {
+    pendingSessions = Math.max(0, pendingSessions - 1);
+  }
+
+  const cleanupInterval = setInterval(() => {
+    void (async () => {
+      const now = Date.now();
+      for (const [sessionId, entry] of sessions) {
+        if (entry.activeRequests !== 0) continue;
+        if (now - entry.lastActivity > lifecycle.inactivityTimeoutMs) {
+          console.error(`[session] Session ${sessionId} timed out after inactivity`);
+          await removeSession(sessionId, 'inactivity timeout');
+        }
+      }
+    })();
+  }, lifecycle.cleanupIntervalMs);
+  cleanupInterval.unref();
+
   app.post('/mcp', async (req: Request, res: Response) => {
     try {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
-      // Existing session — reuse transport
-      if (sessionId && sessions.has(sessionId)) {
-        const entry = sessions.get(sessionId)!;
-        entry.lastActivity = Date.now();
-        await entry.transport.handleRequest(req, res, req.body);
+      if (sessionId) {
+        const entry = sessions.get(sessionId);
+        if (!entry) {
+          res.status(404).json({ error: 'Session not found or expired' });
+          return;
+        }
+        await handleExistingSession(entry, req, res, req.body);
         return;
       }
 
-      // New session — create dedicated McpServer + Transport
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => crypto.randomUUID(),
-        onsessioninitialized: (id) => {
-          sessions.set(id, { server, transport, lastActivity: Date.now() });
-          console.error(`[session] New session ${id} (${sessions.size} active)`);
-        },
-      });
+      if (!(await reserveSessionSlot())) {
+        res.setHeader('Retry-After', '1');
+        res.status(503).json({ error: 'MCP session capacity reached; retry shortly' });
+        return;
+      }
 
-      transport.onclose = () => {
-        const sid = [...sessions.entries()].find(([, e]) => e.transport === transport)?.[0];
-        if (sid) {
-          sessions.delete(sid);
-          console.error(`[session] Session ${sid} closed (${sessions.size} active)`);
+      let initializedSessionId: string | undefined;
+      let server: McpServer | undefined;
+      let transport: StreamableHTTPServerTransport | undefined;
+      try {
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => crypto.randomUUID(),
+          onsessioninitialized: (id) => {
+            initializedSessionId = id;
+            sessions.set(id, {
+              server: server!,
+              transport: transport!,
+              lastActivity: Date.now(),
+              activeRequests: 0,
+            });
+            console.error(`[session] New session ${id} (${sessions.size} active)`);
+          },
+        });
+
+        transport.onclose = () => {
+          const sid = [...sessions.entries()].find(([, entry]) => entry.transport === transport)?.[0];
+          if (sid) {
+            sessions.delete(sid);
+            console.error(`[session] Session ${sid} transport closed (${sessions.size} active)`);
+          }
+        };
+
+        server = createMcpServer(client);
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        if (initializedSessionId) {
+          await removeSession(initializedSessionId, 'initialization failure');
+        } else if (server) {
+          try {
+            await server.close();
+          } catch {
+            // Best-effort cleanup for a failed initialization.
+          }
         }
-      };
-
-      const server = createMcpServer(client);
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+        throw error;
+      } finally {
+        releasePendingSessionSlot();
+      }
     } catch (error) {
       console.error('[server] Error handling MCP request:', error);
       if (!res.headersSent) {
@@ -134,30 +215,34 @@ export async function createServer(config: ServerConfig): Promise<void> {
     }
   });
 
-  // Handle GET for SSE streams (session-based)
   app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    if (!sessionId || !sessions.has(sessionId)) {
-      res.status(400).json({ error: 'Invalid or missing session ID' });
+    if (!sessionId) {
+      res.status(400).json({ error: 'Missing session ID' });
       return;
     }
-
-    const entry = sessions.get(sessionId)!;
-    entry.lastActivity = Date.now();
-    await entry.transport.handleRequest(req, res);
+    const entry = sessions.get(sessionId);
+    if (!entry) {
+      res.status(404).json({ error: 'Session not found or expired' });
+      return;
+    }
+    await handleExistingSession(entry, req, res);
   });
 
-  // Handle DELETE for session cleanup
   app.delete('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
-    if (!sessionId || !sessions.has(sessionId)) {
-      res.status(400).json({ error: 'Invalid or missing session ID' });
+    if (!sessionId) {
+      res.status(400).json({ error: 'Missing session ID' });
+      return;
+    }
+    const entry = sessions.get(sessionId);
+    if (!entry) {
+      res.status(404).json({ error: 'Session not found or expired' });
       return;
     }
 
-    const entry = sessions.get(sessionId)!;
-    await entry.transport.handleRequest(req, res);
-    removeSession(sessionId);
+    await handleExistingSession(entry, req, res);
+    await removeSession(sessionId, 'client delete');
   });
 
   const host = config.host || '0.0.0.0';
@@ -166,5 +251,8 @@ export async function createServer(config: ServerConfig): Promise<void> {
     console.error(`[server] Dockhand URL: ${config.dockhand.url}`);
     console.error(`[server] Health: http://localhost:${config.port}/health`);
     console.error(`[server] MCP endpoint: http://localhost:${config.port}/mcp`);
+    console.error(
+      `[session] Lifecycle ttl=${lifecycle.inactivityTimeoutMs / 1000}s cleanup=${lifecycle.cleanupIntervalMs / 1000}s max=${lifecycle.maxSessions === 0 ? 'unlimited' : lifecycle.maxSessions}`,
+    );
   });
 }

--- a/src/session-lifecycle.ts
+++ b/src/session-lifecycle.ts
@@ -9,6 +9,23 @@ export interface SessionActivity {
   activeRequests: number;
 }
 
+/** Minimal shape a session's McpServer must expose for lifecycle bookkeeping. */
+export interface CloseableServer {
+  close(): Promise<void>;
+}
+
+/** Minimal shape a session's transport must expose for lifecycle bookkeeping. */
+export interface CloseableTransport {
+  close?: () => Promise<void>;
+}
+
+/** A session record as tracked by server.ts, generic enough to unit-test
+ * without any Express/HTTP/MCP-SDK involvement. */
+export interface ManagedSessionEntry extends SessionActivity {
+  server: CloseableServer;
+  transport: CloseableTransport;
+}
+
 const DEFAULT_INACTIVITY_TIMEOUT_SECONDS = 30 * 60;
 const DEFAULT_CLEANUP_INTERVAL_SECONDS = 5 * 60;
 const DEFAULT_MAX_SESSIONS = 0;
@@ -59,4 +76,84 @@ export function selectOldestIdleSession<T extends SessionActivity>(
   }
 
   return selectedId;
+}
+
+/**
+ * Registers a session record the moment the Streamable HTTP transport mints
+ * its session ID (the SDK's `onsessioninitialized` callback) -- while the
+ * *founding* `transport.handleRequest(...)` call that is processing the
+ * initialize handshake for that very session is still in flight.
+ *
+ * The entry starts busy (`activeRequests: 1`) rather than idle. Without this,
+ * a brand-new session sat in the map with `activeRequests: 0` for the entire
+ * duration of its own initialize handshake, making it eligible for capacity
+ * eviction via {@link selectOldestIdleSession} -- a concurrent session
+ * creation under `MCP_MAX_SESSIONS` could then evict a session that was still
+ * being initialized, aborting its handshake and leaving the client holding an
+ * already-invalidated session ID.
+ */
+export function beginFoundingSession<T extends ManagedSessionEntry>(
+  sessions: Map<string, T>,
+  id: string,
+  base: Omit<T, 'lastActivity' | 'activeRequests'>,
+  now: number = Date.now(),
+): void {
+  sessions.set(id, { ...base, lastActivity: now, activeRequests: 1 } as T);
+}
+
+/**
+ * Releases the busy marker set by {@link beginFoundingSession} once the
+ * founding `transport.handleRequest(...)` call has resolved (the initialize
+ * response/SSE stream has been fully handed off to the client). From this
+ * point on, normal idle-eviction and inactivity-timeout accounting applies.
+ *
+ * A no-op if the session is no longer present (e.g. it was already removed
+ * because initialization failed).
+ */
+export function completeFoundingSession<T extends SessionActivity>(
+  sessions: Map<string, T>,
+  id: string,
+  now: number = Date.now(),
+): void {
+  const entry = sessions.get(id);
+  if (!entry) return;
+  entry.activeRequests = Math.max(0, entry.activeRequests - 1);
+  entry.lastActivity = now;
+}
+
+/**
+ * Removes and closes a session using an already-known entry reference,
+ * independent of whether the session is still present in `sessions`.
+ *
+ * This matters specifically for the DELETE `/mcp` path: the MCP SDK's own
+ * DELETE handling calls `transport.close()` internally, which fires the
+ * transport's `onclose` handler and can already have deleted the map entry
+ * *before* the route handler gets a chance to run its own cleanup. A
+ * lookup-based removal (`sessions.get(id)` then bail if missing) silently
+ * no-ops in that case, so `server.close()` and the removal log never run.
+ * Passing the entry captured *before* the request was served sidesteps that
+ * race entirely.
+ *
+ * Safe to call even if `server.close()` throws because the session (and
+ * therefore its transport) was already closed by a racing `onclose` --
+ * the error is swallowed after a best-effort `transport.close()` fallback.
+ */
+export async function removeSessionEntry<T extends ManagedSessionEntry>(
+  sessions: Map<string, T>,
+  id: string,
+  entry: T,
+  reason: string,
+): Promise<void> {
+  sessions.delete(id);
+  try {
+    await entry.server.close();
+  } catch (error) {
+    console.error(`[session] Error closing server for ${id}:`, error);
+    try {
+      await entry.transport.close?.();
+    } catch {
+      // Best-effort fallback only.
+    }
+  }
+  console.error(`[session] Removed session ${id} (${reason}; ${sessions.size} active)`);
 }

--- a/src/session-lifecycle.ts
+++ b/src/session-lifecycle.ts
@@ -1,0 +1,62 @@
+export interface SessionLifecycleConfig {
+  inactivityTimeoutMs: number;
+  cleanupIntervalMs: number;
+  maxSessions: number;
+}
+
+export interface SessionActivity {
+  lastActivity: number;
+  activeRequests: number;
+}
+
+const DEFAULT_INACTIVITY_TIMEOUT_SECONDS = 30 * 60;
+const DEFAULT_CLEANUP_INTERVAL_SECONDS = 5 * 60;
+const DEFAULT_MAX_SESSIONS = 0;
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function getSessionLifecycleConfig(env: NodeJS.ProcessEnv = process.env): SessionLifecycleConfig {
+  const inactivitySeconds = parsePositiveInteger(
+    env.MCP_SESSION_TTL_SECONDS,
+    DEFAULT_INACTIVITY_TIMEOUT_SECONDS,
+  );
+  const requestedCleanupSeconds = parsePositiveInteger(
+    env.MCP_SESSION_CLEANUP_INTERVAL_SECONDS,
+    DEFAULT_CLEANUP_INTERVAL_SECONDS,
+  );
+  const cleanupSeconds = Math.min(requestedCleanupSeconds, inactivitySeconds);
+  const maxSessions = parseNonNegativeInteger(env.MCP_MAX_SESSIONS, DEFAULT_MAX_SESSIONS);
+
+  return {
+    inactivityTimeoutMs: inactivitySeconds * 1000,
+    cleanupIntervalMs: cleanupSeconds * 1000,
+    maxSessions,
+  };
+}
+
+export function selectOldestIdleSession<T extends SessionActivity>(
+  sessions: Map<string, T>,
+): string | undefined {
+  let selectedId: string | undefined;
+  let oldestActivity = Number.POSITIVE_INFINITY;
+
+  for (const [sessionId, entry] of sessions) {
+    if (entry.activeRequests !== 0) continue;
+    if (entry.lastActivity < oldestActivity) {
+      oldestActivity = entry.lastActivity;
+      selectedId = sessionId;
+    }
+  }
+
+  return selectedId;
+}

--- a/tests/session-lifecycle.test.ts
+++ b/tests/session-lifecycle.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { getSessionLifecycleConfig, selectOldestIdleSession } from '../src/session-lifecycle.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  beginFoundingSession,
+  completeFoundingSession,
+  getSessionLifecycleConfig,
+  removeSessionEntry,
+  selectOldestIdleSession,
+  type ManagedSessionEntry,
+} from '../src/session-lifecycle.js';
 
 describe('session lifecycle configuration', () => {
   it('keeps the existing timeout defaults when no overrides are set', () => {
@@ -47,5 +54,106 @@ describe('session capacity eviction', () => {
     ]);
     expect(selectOldestIdleSession(sessions)).toBe('idle-oldest');
     expect(selectOldestIdleSession(new Map([['active', { lastActivity: 1, activeRequests: 2 }]]))).toBeUndefined();
+  });
+});
+
+function fakeEntry(overrides: Partial<ManagedSessionEntry> = {}): ManagedSessionEntry {
+  return {
+    server: { close: vi.fn().mockResolvedValue(undefined) },
+    transport: {},
+    lastActivity: Date.now(),
+    activeRequests: 0,
+    ...overrides,
+  };
+}
+
+describe('beginFoundingSession / completeFoundingSession (bug: founding session evictable mid-initialize)', () => {
+  it('registers a brand-new session as busy (activeRequests: 1), not idle', () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    beginFoundingSession(sessions, 'founding', { server: { close: vi.fn() }, transport: {} });
+
+    expect(sessions.get('founding')?.activeRequests).toBe(1);
+  });
+
+  it('never lets selectOldestIdleSession pick a session whose founding request is still in flight, even if it is the only (and therefore oldest) session', () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    beginFoundingSession(sessions, 'founding', { server: { close: vi.fn() }, transport: {} }, 1 /* very old lastActivity */);
+
+    // Without the fix, onsessioninitialized stored activeRequests: 0 for the
+    // founding entry, so this session -- the only candidate -- would have
+    // been evicted by selectOldestIdleSession() while its own initialize
+    // handshake was still being served by transport.handleRequest(...).
+    expect(selectOldestIdleSession(sessions)).toBeUndefined();
+  });
+
+  it('releases the busy marker once the founding request has resolved, making the session evictable again under normal idle rules', () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    beginFoundingSession(sessions, 'founding', { server: { close: vi.fn() }, transport: {} }, 1);
+
+    completeFoundingSession(sessions, 'founding');
+
+    expect(sessions.get('founding')?.activeRequests).toBe(0);
+    expect(selectOldestIdleSession(sessions)).toBe('founding');
+  });
+
+  it('completeFoundingSession is a no-op when the session no longer exists (e.g. removed by an initialization failure)', () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    expect(() => completeFoundingSession(sessions, 'missing')).not.toThrow();
+  });
+});
+
+describe('removeSessionEntry (bug: DELETE-triggered cleanup never running)', () => {
+  it('closes the server and logs the removal using an already-captured entry, even when the session was already deleted from the map', async () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    const closeServer = vi.fn().mockResolvedValue(undefined);
+    const entry = fakeEntry({ server: { close: closeServer } });
+    sessions.set('deleted-by-client', entry);
+
+    // Simulate the MCP SDK's own DELETE handling: transport.handleRequest()
+    // calls transport.close() internally, which fires the transport's
+    // onclose handler and deletes the map entry -- BEFORE the DELETE route
+    // handler gets a chance to call removeSession(sessionId, 'client
+    // delete'). Without the fix, a subsequent sessions.get(sessionId) here
+    // returns undefined and the whole cleanup silently no-ops.
+    sessions.delete('deleted-by-client');
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await removeSessionEntry(sessions, 'deleted-by-client', entry, 'client delete');
+
+    // Assert before mockRestore(): restoring also clears the recorded call
+    // history (mockRestore implies mockReset/mockClear), so checking after
+    // restoring would always see zero calls regardless of behaviour.
+    expect(closeServer).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[session] Removed session deleted-by-client (client delete'),
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it('still removes/closes correctly on the normal path where the entry is still present in the map', async () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    const closeServer = vi.fn().mockResolvedValue(undefined);
+    const entry = fakeEntry({ server: { close: closeServer } });
+    sessions.set('still-present', entry);
+
+    await removeSessionEntry(sessions, 'still-present', entry, 'inactivity timeout');
+
+    expect(closeServer).toHaveBeenCalledTimes(1);
+    expect(sessions.has('still-present')).toBe(false);
+  });
+
+  it('falls back to transport.close() and stays idempotent-safe if server.close() throws (double-close from a racing onclose)', async () => {
+    const sessions = new Map<string, ManagedSessionEntry>();
+    const closeServer = vi.fn().mockRejectedValue(new Error('already closed'));
+    const closeTransport = vi.fn().mockResolvedValue(undefined);
+    const entry = fakeEntry({ server: { close: closeServer }, transport: { close: closeTransport } });
+    sessions.set('racing-close', entry);
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await expect(removeSessionEntry(sessions, 'racing-close', entry, 'client delete')).resolves.toBeUndefined();
+    errorSpy.mockRestore();
+
+    expect(closeTransport).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/session-lifecycle.test.ts
+++ b/tests/session-lifecycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { getSessionLifecycleConfig, selectOldestIdleSession } from '../src/session-lifecycle.js';
+
+describe('session lifecycle configuration', () => {
+  it('keeps the existing timeout defaults when no overrides are set', () => {
+    expect(getSessionLifecycleConfig({})).toEqual({
+      inactivityTimeoutMs: 30 * 60 * 1000,
+      cleanupIntervalMs: 5 * 60 * 1000,
+      maxSessions: 0,
+    });
+  });
+
+  it('parses explicit TTL, cleanup interval, and maximum session count', () => {
+    expect(getSessionLifecycleConfig({
+      MCP_SESSION_TTL_SECONDS: '600',
+      MCP_SESSION_CLEANUP_INTERVAL_SECONDS: '60',
+      MCP_MAX_SESSIONS: '32',
+    })).toEqual({ inactivityTimeoutMs: 600_000, cleanupIntervalMs: 60_000, maxSessions: 32 });
+  });
+
+  it('clamps cleanup interval to the inactivity TTL', () => {
+    expect(getSessionLifecycleConfig({
+      MCP_SESSION_TTL_SECONDS: '30',
+      MCP_SESSION_CLEANUP_INTERVAL_SECONDS: '120',
+    }).cleanupIntervalMs).toBe(30_000);
+  });
+
+  it('falls back safely for invalid values while allowing zero to mean unlimited sessions', () => {
+    expect(getSessionLifecycleConfig({
+      MCP_SESSION_TTL_SECONDS: 'invalid',
+      MCP_SESSION_CLEANUP_INTERVAL_SECONDS: '-1',
+      MCP_MAX_SESSIONS: '0',
+    })).toEqual({
+      inactivityTimeoutMs: 30 * 60 * 1000,
+      cleanupIntervalMs: 5 * 60 * 1000,
+      maxSessions: 0,
+    });
+  });
+});
+
+describe('session capacity eviction', () => {
+  it('selects the oldest idle session and never selects active sessions', () => {
+    const sessions = new Map([
+      ['active-oldest', { lastActivity: 1, activeRequests: 1 }],
+      ['idle-newer', { lastActivity: 30, activeRequests: 0 }],
+      ['idle-oldest', { lastActivity: 10, activeRequests: 0 }],
+    ]);
+    expect(selectOldestIdleSession(sessions)).toBe('idle-oldest');
+    expect(selectOldestIdleSession(new Map([['active', { lastActivity: 1, activeRequests: 2 }]]))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #132.

## Problem
The Streamable HTTP server retains a dedicated `McpServer` plus the complete registered tool catalog for every session. The existing fixed inactivity timeout eventually cleans stale sessions, but there is no upper bound on retained sessions, so transient-session churn can drive memory growth before cleanup catches up.

PR #65 previously explored configurable timeout/cleanup values but was closed without merge and did not add a maximum-session bound or inactive-session eviction.

## Changes
- add configurable `MCP_SESSION_TTL_SECONDS` (default 1800)
- add configurable `MCP_SESSION_CLEANUP_INTERVAL_SECONDS` (default 300)
- add configurable `MCP_MAX_SESSIONS` (default 0 = backward-compatible unlimited)
- track active requests per retained session
- when capped, evict only the least-recently-active idle session
- never evict an active session; return 503 + `Retry-After` when every slot is active
- close the session `McpServer` (and transport fallback) on timeout/eviction/delete
- return 404 for expired/unknown session IDs
- expose session lifecycle counters/config in `/health`
- document the new environment variables

## Verification
Freshly reconstructed against current `main` (`95d4d17a76db5c41e8a8005c39b6a15095978495`):
- build: pass
- typecheck: pass
- Vitest: 347/347 pass
- 5 focused lifecycle tests included

A longer isolated runtime validation of the same implementation created 256 sessions with `MCP_MAX_SESSIONS=32`; retained sessions never exceeded 32 and RSS plateaued around 490 MiB after initial V8 heap growth rather than continuing linearly with total sessions created. Short-TTL cleanup also reduced retained sessions to zero and accepted new sessions afterwards.

This is intentionally a general Streamable HTTP resource-control change, not a client-specific workaround.
