### PR TITLE
fix(tools): correct image-prune settings and trigger methods

### DIFF
--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -216,7 +216,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       settings: z.record(z.string(), z.unknown()).describe('Image prune settings'),
     },
     async ({ environmentId, settings }) => {
-      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/image-prune`, settings));
+      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/image-prune`, settings));
     }
   );
 
@@ -268,12 +268,12 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     }
   );
 
-  registerTool(server, 'trigger_environment_image_prune', 'Trigger an immediate image-prune sweep for an environment using the configured retention policy (separate from the GET/PUT pair `get_environment_image_prune` and `set_environment_image_prune` which read and modify the schedule/retention settings).',
+  registerTool(server, 'trigger_environment_image_prune', 'Trigger an immediate image-prune sweep for an environment using the configured retention policy (separate from the GET/POST pair `get_environment_image_prune` and `set_environment_image_prune` which read and modify the schedule/retention settings).',
     {
       environmentId: z.number().describe('Environment ID'),
     },
     async ({ environmentId }) => {
-      return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/image-prune`, undefined));
+      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/image-prune`, undefined));
     }
   );
 }

--- a/tests/image-prune-contract.test.ts
+++ b/tests/image-prune-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, '..', 'src', 'tools', 'environments.ts'), 'utf-8');
+
+function extractToolBlock(toolName: string): string {
+  const startPattern = new RegExp(
+    `registerTool\\s*\\(\\s*server\\s*,\\s*'${toolName}'`,
+  );
+  const startMatch = startPattern.exec(source);
+  if (!startMatch) {
+    throw new Error(`Tool '${toolName}' not found in source`);
+  }
+  const startIdx = startMatch.index;
+  const afterStart = source.slice(startIdx + 1);
+  const nextToolMatch = /registerTool\s*\(/.exec(afterStart);
+  const endIdx = nextToolMatch
+    ? startIdx + 1 + nextToolMatch.index
+    : source.length;
+  return source.slice(startIdx, endIdx);
+}
+
+describe('image prune API contract', () => {
+  it('set_environment_image_prune uses POST for settings and not PUT', () => {
+    const block = extractToolBlock('set_environment_image_prune');
+    expect(block).toContain('return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/image-prune`, settings));');
+    expect(block).not.toContain('return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/image-prune`, settings));');
+  });
+
+  it('trigger_environment_image_prune uses PUT for immediate prune and not POST', () => {
+    const block = extractToolBlock('trigger_environment_image_prune');
+    expect(block).toContain('return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}/image-prune`, undefined));');
+    expect(block).not.toContain('return jsonResponse(await client.post(`/api/environments/${encodePath(environmentId)}/image-prune`, undefined));');
+  });
+});


### PR DESCRIPTION
## Summary

Correct the HTTP methods used by the image-prune MCP tools to match Dockhand's API contract:

- `get_environment_image_prune` → `GET` settings (unchanged)
- `set_environment_image_prune` → `POST` settings
- `trigger_environment_image_prune` → `PUT` immediate prune

Also updates the trigger tool description and adds focused regression coverage asserting that the setter uses POST (not PUT) and the trigger uses PUT (not POST).

## Validation

- full existing test suite passes
- typecheck passes
- build passes
- locally validated the setter against Dockhand with the existing settings: `lastPruned` remained unchanged and the Docker image inventory was unchanged
- the trigger tool was not invoked during the live regression check

Fixes #138