### PR TITLE
fix(tools): align exec_container with the real Docker-exec-instance contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Add to your MCP settings:
 | `update_container` | Update container settings |
 | `create_container` | Create a new container |
 | `get_container_shells` | List available shells |
+| `exec_container` | Create a terminal exec session (execId + WS connectionInfo); does NOT run a one-shot command or return output — no such endpoint exists in the Dockhand API |
 | `list_container_files` | Browse files inside container |
 | `get_container_file_content` | Read file from container |
 | `create_container_file` | Create file in container |

--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -356,20 +356,17 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'exec_container', 'Execute a one-shot command inside a running container and return its output (similar to `docker exec`); pair with `get_container_shells` to discover available shells, or `get_container_logs` if you only need to inspect already-emitted output rather than run something new.',
+  registerTool(server, 'exec_container', 'Create a Docker exec instance for terminal attachment inside a running container (like opening a `docker exec -it` session) and return an execId plus WebSocket connectionInfo for a terminal client to attach to. This does NOT run a one-shot command and does NOT return output — the Dockhand REST API has no endpoint for arbitrary command execution with captured output; only the `shell` to attach and the `user` to run as are honored. Use `get_container_shells` to discover available shells first, or `get_container_logs`/`get_container_top` if you need output or process info without an interactive session.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
-      command: z.array(z.string()).describe('Command as argv array (e.g. ["sh", "-c", "ls /app"])'),
-      workingDir: z.string().optional().describe('Working directory inside the container'),
+      shell: z.string().optional().describe('Shell executable to exec into (default: /bin/sh); see `get_container_shells` for what is available'),
       user: z.string().optional().describe('User to exec as (e.g. "root" or "1000:1000")'),
-      tty: z.boolean().optional().describe('Allocate a TTY'),
     },
-    async ({ environmentId, containerId, command, workingDir, user, tty }) => {
-      const body: Record<string, unknown> = { command };
-      if (workingDir) body.workingDir = workingDir;
+    async ({ environmentId, containerId, shell, user }) => {
+      const body: Record<string, unknown> = {};
+      if (shell) body.shell = shell;
       if (user) body.user = user;
-      if (tty !== undefined) body.tty = tty;
       return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/exec`, body, { envId: environmentId }));
     }
   );

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const stacksSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'stacks.ts'), 'utf-8');
 const systemSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'system.ts'), 'utf-8');
 const usersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'users.ts'), 'utf-8');
+const containersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'containers.ts'), 'utf-8');
 
 function extractToolBlock(source: string, toolName: string): string {
   const startPattern = new RegExp(
@@ -85,5 +86,34 @@ describe('Dockhand API contract alignment', () => {
     }
     expect(setFavorites).toMatch(/environmentId,\s*\n\s*action:\s*'reorder',\s*\n\s*favorites/);
     expect(setGroups).toMatch(/environmentId,\s*\n\s*action:\s*'reorder',\s*\n\s*groups/);
+  });
+
+  it('exec_container matches the real /api/containers/{id}/exec contract: envId query param, shell+user body only', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/containers/[id]/exec/+server.ts, unchanged
+    // since the route's initial commit through v1.0.41): the handler reads `envId` from the
+    // query string (not `env`, unlike every sibling containers endpoint), and only reads
+    // `body.shell` (default '/bin/sh') and `body.user` (default 'root') — it creates a Docker
+    // exec instance for WebSocket terminal attachment and returns { execId, connectionInfo }.
+    // It never reads body.command/workingDir/tty and never executes or captures output for an
+    // arbitrary command — there is no REST endpoint upstream that does that (see issue #81).
+    const block = extractToolBlock(containersSource, 'exec_container');
+
+    // Query param must be envId, not env (the one endpoint in the cluster that differs).
+    expect(block).toMatch(/\{\s*envId:\s*environmentId\s*\}/);
+    expect(block).not.toMatch(/\{\s*env:\s*environmentId\s*\}/);
+
+    // Only fields the real handler reads may be sent.
+    expect(block).toMatch(/shell:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/user:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).not.toMatch(/command:\s*z\.array/);
+    expect(block).not.toMatch(/workingDir:\s*z\.string/);
+    expect(block).not.toMatch(/tty:\s*z\.boolean/);
+    expect(block).not.toMatch(/body\.command/);
+    expect(block).not.toMatch(/body\.workingDir/);
+    expect(block).not.toMatch(/body\.tty/);
+
+    // Description must not promise one-shot command execution/output the API cannot deliver.
+    expect(block).not.toMatch(/Execute a one-shot command/i);
+    expect(block).toMatch(/does not run|cannot run|no.*output|terminal attach/i);
   });
 });


### PR DESCRIPTION
## Summary

Closes #81. Thanks @sugarfunk for the detailed report and reproduction steps.

The issue's specific claim — that `exec_container` sends `env` instead of `envId` on
`POST /api/containers/{id}/exec` — does **not** reproduce against current `main`: that
param was already corrected to `envId` in PR #64's review pass (commit `e3589ad`,
squashed into `e0e7057`), well before this issue was filed. I verified this against the
real upstream handler (`Finsys/dockhand` `src/routes/api/containers/[id]/exec/+server.ts`),
which has read `envId` from the query string since the route's very first commit, all the
way through `v1.0.41`/`main` — the file has never changed.

The **real** root cause is bigger than a param-name typo. The handler only ever reads:

```ts
const shell = body.shell || '/bin/sh';
const user = body.user || 'root';
// ...
const exec = await createExec({ containerId, cmd: [shell], user, envId });
```

It creates a Docker exec instance for **WebSocket terminal attachment** and returns
`{ execId, connectionInfo }` — it never reads `body.command`, `workingDir`, or `tty`, and
it never runs a command or captures output synchronously. Dockhand does have an internal
one-shot "exec and capture output" helper (`execInContainer` in `src/lib/server/docker.ts`,
used by the `shells` and `top` routes with hardcoded commands), but it is **not exposed via
any public REST route**. There is currently no Dockhand API endpoint that runs an arbitrary
command and returns its output — so `command`/`workingDir`/`tty` were being silently
discarded server-side regardless of the query-param name, which matches the "succeeds but
nothing happens" symptom you reported.

## Changes

- `src/tools/containers.ts`: `exec_container` now only sends the fields the real handler
  honors (`shell`, `user` in the body; `envId` in the query), and its description is
  rewritten to state plainly that it creates a terminal-attach session and does **not** run
  a one-shot command or return output — so callers aren't misled the way this issue
  describes.
- `tests/api-contracts.test.ts`: new contract test asserting the `envId` query param, the
  `shell`/`user`-only body shape, and the corrected description — red against the old
  implementation, green after the fix.
- `README.md`: added the previously-missing `exec_container` row to the tool table (also
  flagged in #81).

## Test plan

- [x] `npm run build` (tsc) — clean
- [x] `npx vitest run` — 372/372 passing (was 371 before the new test)
- [x] New contract test fails against the pre-fix code, passes after the fix (TDD)
- [x] Verified the `envId` vs `env` query param and the `shell`/`user`-only body shape
      directly against the upstream handler source, not just our schema/docs

## Notes for follow-up (out of scope here)

`exec_container` is now honest about its real capability, but that capability (create an
exec instance for a browser-side terminal to attach to) isn't very useful from an MCP
client. If one-shot "run this command and give me the output" is wanted for agent
workflows, that would need a new endpoint upstream in `Finsys/dockhand` wrapping
`execInContainer` — happy to open that as a separate feature request if there's interest.