### PR TITLE
feat(tools): extend validate-mcp-tools.mjs with query-param diff

### DIFF
--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -10,11 +10,13 @@
  * - COVERED: Endpunkt hat ein MCP-Tool
  * - MISSING_TOOL: Endpunkt existiert in API aber kein MCP-Tool
  * - ORPHANED_TOOL: MCP-Tool referenziert Endpunkt der nicht (mehr) existiert
- * - PARAM_MISMATCH: Parameter stimmen nicht überein
+ * - PARAM_MISMATCH: Path-Parameter stimmen nicht überein (Anzahl + Namens-Suffix)
  * - MISSING_ENCODE: Path-Parameter wird nicht mit encodePath() encoded
+ * - QUERY_PARAM_MISSING: Endpunkt erwartet einen Query-Parameter, das Tool sendet ihn nicht
+ * - QUERY_PARAM_UNKNOWN: Tool sendet einen Query-Parameter, den der Endpunkt nicht kennt
  *
- * Exit-Code 1 bei Mismatches (ORPHANED_TOOL oder PARAM_MISMATCH)
- * Exit-Code 0 wenn nur MISSING_TOOL (neue Endpunkte sind normal)
+ * Exit-Code 1 bei Mismatches (ORPHANED_TOOL, PARAM_MISMATCH, MISSING_ENCODE oder QUERY_PARAM_UNKNOWN)
+ * Exit-Code 0 wenn nur MISSING_TOOL oder QUERY_PARAM_MISSING (siehe Begründung unten)
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
@@ -42,6 +44,24 @@ const CLIENT_METHOD_MAP = {
   patch: 'PATCH',
 };
 
+// DockhandClient-Methoden bei denen der Query-Params-Record das 2. Argument ist:
+// get(path, params?), getRaw(path, params?), delete(path, params?)
+const GET_LIKE_METHODS = new Set(['get', 'getRaw', 'delete']);
+
+// DockhandClient-Methoden bei denen der Query-Params-Record das 3. Argument ist
+// (nach dem Body): post(path, body?, params?), put(path, body?, params?), ...
+const BODY_LIKE_METHODS = new Set(['post', 'postSSE', 'postMultipart', 'put', 'putSSE', 'patch']);
+
+/**
+ * `env` ist der universelle Environment-Scoping-Query-Param, den fast jeder Tool-Call
+ * mitschickt. extract-dockhand-api.mjs filtert ihn beim Schema-Bau bewusst heraus
+ * (`if (!['env'].includes(param))`), taucht also NIE in ep.queryParams auf — er darf
+ * deshalb nie als QUERY_PARAM_UNKNOWN markiert werden. `envId` und alle anderen
+ * Query-Params werden normal geprüft (siehe Issue #95 / #81: dort erwartete das Schema
+ * `envId`, das Tool sendete nur `env` — envId fehlte tatsächlich).
+ */
+const WHITELISTED_QUERY_PARAMS = new Set(['env']);
+
 /**
  * Lädt das API-Schema
  * @returns {object}
@@ -55,65 +75,367 @@ function loadSchema() {
   return JSON.parse(readFileSync(SCHEMA_FILE, 'utf8'));
 }
 
+// --- Balancierter Mini-Parser für Aufruf-Argumente & Objekt-Keys ---
+//
+// Die MCP-Tools rufen `client.<method>(path, body?, params?)` teils einzeilig, teils
+// über mehrere Zeilen auf (siehe z.B. containers.ts get_container_logs). Um die
+// tatsächlich gesendeten Query-Param-Keys zu extrahieren, muss der komplette
+// Argument-Ausdruck geparst werden — nicht nur die eine Zeile mit dem Funktionsnamen.
+// Die folgenden Helfer sind ein absichtlich einfacher, aber string/template/comment
+// bewusster Klammer-Scanner (kein vollständiger JS-Parser, reicht aber für die in
+// diesem Repo verwendeten einfachen Objekt-Literale).
+
+/**
+ * Überspringt einen String-Literal-Body ab dem öffnenden Quote-Zeichen.
+ * @param {string} text
+ * @param {number} i Index des öffnenden Quote-Zeichens
+ * @param {string} quote `'` oder `"`
+ * @returns {number} Index direkt nach dem schließenden Quote
+ */
+function skipString(text, i, quote) {
+  i++;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === quote) {
+      return i + 1;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Überspringt ein Template-Literal (Backtick-String) inkl. verschachtelter `${...}`
+ * Ausdrücke ab dem öffnenden Backtick.
+ * @param {string} text
+ * @param {number} i Index des öffnenden Backtick
+ * @returns {number} Index direkt nach dem schließenden Backtick
+ */
+function skipTemplate(text, i) {
+  i++;
+  while (i < text.length) {
+    if (text[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (text[i] === '`') {
+      return i + 1;
+    }
+    if (text[i] === '$' && text[i + 1] === '{') {
+      i += 2;
+      let depth = 1;
+      while (i < text.length && depth > 0) {
+        const c = text[i];
+        if (c === "'" || c === '"') {
+          i = skipString(text, i, c);
+          continue;
+        }
+        if (c === '`') {
+          i = skipTemplate(text, i);
+          continue;
+        }
+        if (c === '{') {
+          depth++;
+          i++;
+          continue;
+        }
+        if (c === '}') {
+          depth--;
+          i++;
+          continue;
+        }
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Findet den Index der zu `content[openIndex]` passenden schließenden Klammer
+ * (respektiert Strings, Template-Literale und Kommentare).
+ * @param {string} content
+ * @param {number} openIndex Index von `(`, `{` oder `[`
+ * @returns {number} Index der passenden schließenden Klammer, oder -1 bei unbalanciertem Input
+ */
+function findMatchingClose(content, openIndex) {
+  const pairs = { '(': ')', '{': '}', '[': ']' };
+  const openChar = content[openIndex];
+  const closeChar = pairs[openChar];
+  if (!closeChar) return -1;
+
+  let depth = 1;
+  let i = openIndex + 1;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "'" || ch === '"') {
+      i = skipString(content, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(content, i);
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '/') {
+      const nl = content.indexOf('\n', i);
+      i = nl === -1 ? content.length : nl;
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '*') {
+      const end = content.indexOf('*/', i);
+      i = end === -1 ? content.length : end + 2;
+      continue;
+    }
+    if (ch === openChar) {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === closeChar) {
+      depth--;
+      if (depth === 0) return i;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Splittet einen Ausdruck an Top-Level-Kommas (Tiefe 0), respektiert dabei
+ * verschachtelte Klammern/Objekte/Arrays, Strings, Template-Literale und Kommentare.
+ * @param {string} text
+ * @returns {string[]} getrimmte Teil-Ausdrücke
+ */
+function splitTopLevel(text) {
+  const parts = [];
+  let depth = 0;
+  let start = 0;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === "'" || ch === '"') {
+      i = skipString(text, i, ch);
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(text, i);
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '/') {
+      const nl = text.indexOf('\n', i);
+      i = nl === -1 ? text.length : nl;
+      continue;
+    }
+    if (ch === '/' && text[i + 1] === '*') {
+      const end = text.indexOf('*/', i);
+      i = end === -1 ? text.length : end + 2;
+      continue;
+    }
+    if ('([{'.includes(ch)) {
+      depth++;
+      i++;
+      continue;
+    }
+    if (')]}'.includes(ch)) {
+      depth--;
+      i++;
+      continue;
+    }
+    if (ch === ',' && depth === 0) {
+      parts.push(text.slice(start, i));
+      start = i + 1;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  const last = text.slice(start);
+  if (last.trim().length > 0) parts.push(last);
+  return parts.map((p) => p.trim());
+}
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Ermittelt den Property-Key eines Objekt-Literal-Segments (`key: value` oder
+ * Shorthand `key`). Gibt `null` zurück wenn kein statisch bestimmbarer Key vorliegt
+ * (Spread `...x`, computed key `[expr]: ...`).
+ * @param {string} segment Ein Top-Level-Segment aus splitTopLevel() über den Objekt-Inhalt
+ * @returns {string|null}
+ */
+function extractObjectKey(segment) {
+  const seg = segment.trim();
+  if (!seg || seg.startsWith('...')) return null;
+  if (seg.startsWith('[')) return null; // computed key, statisch nicht auflösbar
+
+  const quotedMatch = seg.match(/^(['"])((?:\\.|(?!\1).)*)\1\s*:/);
+  if (quotedMatch) return quotedMatch[2];
+
+  let depth = 0;
+  for (let i = 0; i < seg.length; i++) {
+    const ch = seg[i];
+    if (ch === "'" || ch === '"') {
+      i = skipString(seg, i, ch) - 1;
+      continue;
+    }
+    if (ch === '`') {
+      i = skipTemplate(seg, i) - 1;
+      continue;
+    }
+    if ('([{'.includes(ch)) {
+      depth++;
+      continue;
+    }
+    if (')]}'.includes(ch)) {
+      depth--;
+      continue;
+    }
+    if (ch === ':' && depth === 0) {
+      const key = seg.slice(0, i).trim();
+      return IDENTIFIER_RE.test(key) ? key : null;
+    }
+  }
+
+  // Kein Top-Level-Doppelpunkt → Shorthand-Property `{ foo }`
+  return IDENTIFIER_RE.test(seg) ? seg : null;
+}
+
+/**
+ * Extrahiert die statisch bestimmbaren Query-Param-Keys eines `client.<method>(...)`
+ * Aufrufs.
+ * @param {string} content Gesamter Datei-Inhalt
+ * @param {number} openParenIndex Index der öffnenden Klammer des Aufrufs
+ * @param {string} clientMethod z.B. 'get', 'post', ...
+ * @returns {string[]|null} Keys, oder `null` wenn nicht statisch analysierbar
+ *   (z.B. Params als Variable übergeben statt als Objekt-Literal)
+ */
+function extractCallQueryParamKeys(content, openParenIndex, clientMethod) {
+  let paramsIdx;
+  if (GET_LIKE_METHODS.has(clientMethod)) {
+    paramsIdx = 1;
+  } else if (BODY_LIKE_METHODS.has(clientMethod)) {
+    paramsIdx = 2;
+  } else {
+    return null;
+  }
+
+  const closeParenIndex = findMatchingClose(content, openParenIndex);
+  if (closeParenIndex === -1) return null;
+
+  const argsText = content.slice(openParenIndex + 1, closeParenIndex);
+  const args = splitTopLevel(argsText);
+  const paramsArgText = args[paramsIdx];
+  if (!paramsArgText) return null;
+
+  const trimmed = paramsArgText.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null; // nicht statisch analysierbar
+
+  const inner = trimmed.slice(1, -1);
+  const keys = [];
+  for (const segment of splitTopLevel(inner)) {
+    const key = extractObjectKey(segment);
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * Extrahiert alle API-Aufrufe aus dem Inhalt EINER Tool-Datei.
+ * @param {string} file Dateiname (nur für Reporting)
+ * @param {string} content Datei-Inhalt
+ * @returns {Array<{file: string, toolName: string, httpMethod: string, path: string, usesEncode: boolean, hasPathParams: boolean, queryParamKeys: string[]|null, line: number}>}
+ */
+function extractToolCallsFromSource(file, content) {
+  const calls = [];
+  const lines = content.split('\n');
+
+  // Zeilen-Start-Offsets für die Umrechnung Zeile+Spalte → absoluter Index in `content`.
+  const lineOffsets = [];
+  {
+    let offset = 0;
+    for (const l of lines) {
+      lineOffsets.push(offset);
+      offset += l.length + 1; // +1 für das durch split('\n') entfernte '\n'
+    }
+  }
+
+  let currentTool = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Erkenne Tool-Registrierungen
+    const toolMatch = line.match(/registerTool\s*\(\s*server\s*,\s*['"]([^'"]+)['"]/);
+    if (toolMatch) {
+      currentTool = toolMatch[1];
+    }
+
+    // Erkenne API-Aufrufe: client.get('/api/...'), client.post(`/api/...`)
+    const callMatch = line.match(
+      /client\.(\w+)\s*\(\s*[`'"]([^`'"]*(?:\$\{[^}]+\}[^`'"]*)*)[`'"]/
+    );
+    if (callMatch && currentTool) {
+      const [, clientMethod, rawPath] = callMatch;
+      const httpMethod = CLIENT_METHOD_MAP[clientMethod];
+
+      if (!httpMethod) continue; // Kein bekannter HTTP-Method-Aufruf
+
+      // Konvertiere Template-Literale zu Schema-Pfad-Format
+      // `/api/containers/${encodePath(id)}` → `/api/containers/{id}`
+      let normalizedPath = rawPath
+        .replace(/\$\{encodePath\((\w+)\)\}/g, '{$1}')
+        .replace(/\$\{(\w+)\}/g, '{$1}');
+
+      // Fix #30 (HIGH): Per-interpolation encodePath check (PR #25).
+      // Each ${...} interpolation must use encodePath, not just any occurrence in the string.
+      const interpolations = [...rawPath.matchAll(/\$\{([^}]+)\}/g)].map((m) => m[1]);
+      const hasPathParams = normalizedPath.includes('{');
+      const usesEncode = hasPathParams
+        ? interpolations.every((expr) => expr.includes('encodePath'))
+        : true;
+
+      // Query-Param-Keys: der komplette Aufruf kann über mehrere Zeilen gehen
+      // (z.B. containers.ts get_container_logs), deshalb ab hier im Volltext weiterscannen.
+      const absoluteMatchStart = lineOffsets[i] + callMatch.index;
+      const openParenIndex = content.indexOf('(', absoluteMatchStart);
+      const queryParamKeys =
+        openParenIndex === -1 ? null : extractCallQueryParamKeys(content, openParenIndex, clientMethod);
+
+      calls.push({
+        file,
+        toolName: currentTool,
+        httpMethod,
+        path: normalizedPath,
+        usesEncode,
+        hasPathParams,
+        queryParamKeys,
+        line: i + 1,
+      });
+    }
+  }
+
+  return calls;
+}
+
 /**
  * Extrahiert alle API-Aufrufe aus den MCP-Tool-Dateien
- * @returns {Array<{file: string, toolName: string, httpMethod: string, path: string, usesEncode: boolean, line: number}>}
+ * @returns {Array<{file: string, toolName: string, httpMethod: string, path: string, usesEncode: boolean, queryParamKeys: string[]|null, line: number}>}
  */
 function extractToolCalls() {
   const calls = [];
-  const files = readdirSync(TOOLS_DIR).filter(f => f.endsWith('.ts') && f !== 'index.ts');
+  const files = readdirSync(TOOLS_DIR).filter((f) => f.endsWith('.ts') && f !== 'index.ts');
 
   for (const file of files) {
     const filePath = join(TOOLS_DIR, file);
     const content = readFileSync(filePath, 'utf8');
-    const lines = content.split('\n');
-
-    let currentTool = null;
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-
-      // Erkenne Tool-Registrierungen
-      const toolMatch = line.match(/registerTool\s*\(\s*server\s*,\s*['"]([^'"]+)['"]/);
-      if (toolMatch) {
-        currentTool = toolMatch[1];
-      }
-
-      // Erkenne API-Aufrufe: client.get('/api/...'), client.post(`/api/...`)
-      const callMatch = line.match(
-        /client\.(\w+)\s*\(\s*[`'"]([^`'"]*(?:\$\{[^}]+\}[^`'"]*)*)[`'"]/
-      );
-      if (callMatch && currentTool) {
-        const [, clientMethod, rawPath] = callMatch;
-        const httpMethod = CLIENT_METHOD_MAP[clientMethod];
-
-        if (!httpMethod) continue; // Kein bekannter HTTP-Method-Aufruf
-
-        // Konvertiere Template-Literale zu Schema-Pfad-Format
-        // `/api/containers/${encodePath(id)}` → `/api/containers/{id}`
-        let normalizedPath = rawPath
-          .replace(/\$\{encodePath\((\w+)\)\}/g, '{$1}')
-          .replace(/\$\{(\w+)\}/g, '{$1}');
-
-        // Fix #30 (HIGH): Per-interpolation encodePath check (PR #25).
-        // Each ${...} interpolation must use encodePath, not just any occurrence in the string.
-        const interpolations = [...rawPath.matchAll(/\$\{([^}]+)\}/g)].map(m => m[1]);
-        const hasPathParams = normalizedPath.includes('{');
-        const usesEncode = hasPathParams
-          ? interpolations.every(expr => expr.includes('encodePath'))
-          : true;
-
-        calls.push({
-          file,
-          toolName: currentTool,
-          httpMethod,
-          path: normalizedPath,
-          usesEncode,
-          hasPathParams,
-          line: i + 1,
-        });
-      }
-    }
+    calls.push(...extractToolCallsFromSource(file, content));
   }
 
   return calls;
@@ -137,6 +459,57 @@ function normalizePath(path) {
  */
 function endpointKey(path, method) {
   return `${method} ${normalizePath(path)}`;
+}
+
+/**
+ * Vergleicht die Path-Parameter eines Tool-Aufrufs mit denen des Schema-Endpunkts.
+ *
+ * Nicht einfach String-Gleichheit: das Schema nutzt die generischen SvelteKit
+ * Routen-Namen (z.B. `id`, `type`), die Tools verwenden bewusst sprechende
+ * Variablennamen (z.B. `containerId`, `providerId`). Verifiziert gegen den echten
+ * Bestand (Issue #95, 2026-08): von 141 Path-Param-Vergleichen matchen nur 20 exakt
+ * als String — reine Namens-Identität wäre für dieses Repo also ein Dauer-Fehlalarm.
+ * Stattdessen: gleiche Anzahl UND pro Position ist der Schema-Name (case-insensitiv)
+ * ein Suffix des Tool-Variablennamens (`id` ⊂ `containerId`, `type` ⊂ `type`,
+ * `notificationId` ⊂ `notificationId`) — das deckt alle 141 realen Fälle ab, ohne
+ * echte Namensabweichungen (z.B. eine komplett falsche Variable an einer Position)
+ * durchzulassen.
+ * @param {string[]} callParams
+ * @param {string[]} schemaParams
+ * @returns {boolean} true wenn die Parameter als übereinstimmend gelten
+ */
+function pathParamsMatch(callParams, schemaParams) {
+  if (callParams.length !== schemaParams.length) return false;
+  for (let i = 0; i < callParams.length; i++) {
+    const call = callParams[i].toLowerCase();
+    const schema = schemaParams[i].toLowerCase();
+    if (call !== schema && !call.endsWith(schema)) return false;
+  }
+  return true;
+}
+
+/**
+ * Diffed die von einem Tool-Aufruf gesendeten Query-Param-Keys gegen die vom Schema
+ * für den Endpunkt bekannten Query-Params.
+ * @param {string[]} sentKeys Roh extrahierte Keys (inkl. ggf. whitelisteter wie `env`)
+ * @param {string[]|undefined} schemaQueryParams `ep.queryParams`
+ * @param {{ checkMissing: boolean }} options `checkMissing` nur bei Endpunkten mit
+ *   genau einer HTTP-Methode setzen (siehe Kommentar in validate())
+ * @returns {{ missing: string[], unknown: string[] }}
+ */
+function diffQueryParams(sentKeys, schemaQueryParams, { checkMissing }) {
+  const known = new Set(schemaQueryParams ?? []);
+  const sent = sentKeys.filter((k) => !WHITELISTED_QUERY_PARAMS.has(k));
+
+  const unknown = sent.filter((k) => !known.has(k));
+
+  let missing = [];
+  if (checkMissing && schemaQueryParams) {
+    const sentSet = new Set(sent);
+    missing = schemaQueryParams.filter((p) => !sentSet.has(p));
+  }
+
+  return { missing, unknown };
 }
 
 /**
@@ -173,6 +546,8 @@ function validate() {
   const orphanedTool = [];
   const paramMismatch = [];
   const missingEncode = [];
+  const queryParamMissing = [];
+  const queryParamUnknown = [];
 
   // Endpunkte die wir bewusst ignorieren (Streams, Callbacks, interne)
   const ignoredPatterns = [
@@ -233,20 +608,46 @@ function validate() {
     }
   }
 
-  // 4. Prüfe Path-Parameter-Übereinstimmung
+  // 4. Prüfe Path-Parameter-Übereinstimmung (Anzahl + Namens-Suffix, siehe pathParamsMatch())
   for (const call of toolCalls) {
     const key = endpointKey(call.path, call.httpMethod);
     const schemaEp = schemaEndpoints.get(key);
     if (schemaEp && schemaEp.pathParams) {
       const callParams = [...call.path.matchAll(/\{([^}]+)\}/g)].map(m => m[1]);
       const schemaParams = schemaEp.pathParams;
-      if (callParams.length !== schemaParams.length) {
+      if (!pathParamsMatch(callParams, schemaParams)) {
         paramMismatch.push({
           ...call,
           expected: schemaParams,
           actual: callParams,
         });
       }
+    }
+  }
+
+  // 5. Prüfe Query-Parameter (fehlend / unbekannt) — Issue #95
+  for (const call of toolCalls) {
+    if (call.queryParamKeys === null) continue; // Params als Variable übergeben, nicht statisch analysierbar
+    if (isIgnored(call.path)) continue;
+
+    const key = endpointKey(call.path, call.httpMethod);
+    const schemaEp = schemaEndpoints.get(key);
+    if (!schemaEp) continue; // ORPHANED_TOOL deckt das schon ab
+
+    // "Fehlend" nur bei Endpunkten mit GENAU EINER HTTP-Methode prüfen: das Schema
+    // fasst queryParams pro Route-DATEI zusammen (extract-dockhand-api.mjs liest jeden
+    // url.searchParams.get() im ganzen +server.ts), nicht pro Methode. Bei einer Datei
+    // mit z.B. GET+POST kann ein Param nur für die GET-Variante gelten — eine
+    // Fehlend-Prüfung würde dort legitime POST-Aufrufe fälschlich flaggen.
+    const { missing, unknown } = diffQueryParams(call.queryParamKeys, schemaEp.queryParams, {
+      checkMissing: schemaEp.methods.length === 1,
+    });
+
+    for (const p of missing) {
+      queryParamMissing.push({ ...call, queryParam: p });
+    }
+    for (const p of unknown) {
+      queryParamUnknown.push({ ...call, queryParam: p });
     }
   }
 
@@ -258,6 +659,8 @@ function validate() {
     orphanedTool,
     paramMismatch,
     missingEncode,
+    queryParamMissing,
+    queryParamUnknown,
   });
 
   writeFileSync(REPORT_FILE, report, 'utf8');
@@ -265,14 +668,21 @@ function validate() {
 
   // Zusammenfassung
   console.error('\n--- Validierungs-Ergebnis ---');
-  console.error(`  COVERED:        ${covered.length} Endpunkte haben MCP-Tools`);
-  console.error(`  MISSING_TOOL:   ${missingTool.length} Endpunkte ohne MCP-Tool`);
-  console.error(`  ORPHANED_TOOL:  ${orphanedTool.length} MCP-Tools referenzieren nicht-existente Endpunkte`);
-  console.error(`  PARAM_MISMATCH: ${paramMismatch.length} Parameter-Inkonsistenzen`);
-  console.error(`  MISSING_ENCODE: ${missingEncode.length} fehlende encodePath()-Aufrufe`);
+  console.error(`  COVERED:            ${covered.length} Endpunkte haben MCP-Tools`);
+  console.error(`  MISSING_TOOL:       ${missingTool.length} Endpunkte ohne MCP-Tool`);
+  console.error(`  ORPHANED_TOOL:      ${orphanedTool.length} MCP-Tools referenzieren nicht-existente Endpunkte`);
+  console.error(`  PARAM_MISMATCH:     ${paramMismatch.length} Path-Parameter-Inkonsistenzen`);
+  console.error(`  MISSING_ENCODE:     ${missingEncode.length} fehlende encodePath()-Aufrufe`);
+  console.error(`  QUERY_PARAM_MISSING: ${queryParamMissing.length} vom Endpunkt erwartete, nicht gesendete Query-Params`);
+  console.error(`  QUERY_PARAM_UNKNOWN: ${queryParamUnknown.length} gesendete, dem Endpunkt unbekannte Query-Params`);
 
-  // Exit-Code: Fehler nur bei kritischen Problemen
-  const hasErrors = orphanedTool.length > 0 || paramMismatch.length > 0 || missingEncode.length > 0;
+  // Exit-Code: Fehler nur bei kritischen Problemen.
+  // QUERY_PARAM_UNKNOWN ist wie ORPHANED_TOOL/PARAM_MISMATCH eindeutig ein Bug (das
+  // Tool schickt einen Key, den die Route nachweislich nicht liest) — kritisch.
+  // QUERY_PARAM_MISSING ist wie MISSING_TOOL informativ: da praktisch alle Query-Params
+  // dieser API optionale Filter sind (url.searchParams.get() ohne Pflicht-Fallback),
+  // ist "dieser eine Aufruf nutzt einen optionalen Filter nicht" oft kein Bug.
+  const hasErrors = orphanedTool.length > 0 || paramMismatch.length > 0 || missingEncode.length > 0 || queryParamUnknown.length > 0;
   if (hasErrors) {
     console.error('\n[validate] FEHLER: Kritische Mismatches gefunden!');
     process.exit(1);
@@ -283,13 +693,18 @@ function validate() {
     // Kein Fehler — neue Endpunkte sind normal
   }
 
+  if (queryParamMissing.length > 0) {
+    console.error('\n[validate] WARNUNG: Tools nutzen bekannte Query-Params des Endpunkts nicht');
+    // Kein Fehler — siehe Begründung oben (optionale Filter)
+  }
+
   console.error('\n[validate] OK');
 }
 
 /**
  * Generiert den Markdown-Report
  */
-function generateReport({ schema, covered, missingTool, orphanedTool, paramMismatch, missingEncode }) {
+function generateReport({ schema, covered, missingTool, orphanedTool, paramMismatch, missingEncode, queryParamMissing, queryParamUnknown }) {
   const lines = [];
   const now = new Date().toISOString();
 
@@ -310,6 +725,8 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
   lines.push(`| ORPHANED_TOOL | ${orphanedTool.length} |`);
   lines.push(`| PARAM_MISMATCH | ${paramMismatch.length} |`);
   lines.push(`| MISSING_ENCODE | ${missingEncode.length} |`);
+  lines.push(`| QUERY_PARAM_MISSING | ${queryParamMissing.length} |`);
+  lines.push(`| QUERY_PARAM_UNKNOWN | ${queryParamUnknown.length} |`);
   lines.push('');
 
   // Kritische Probleme
@@ -352,6 +769,19 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
     lines.push('');
   }
 
+  if (queryParamUnknown.length > 0) {
+    lines.push('## QUERY_PARAM_UNKNOWN (Kritisch)');
+    lines.push('');
+    lines.push('Das Tool sendet einen Query-Parameter, den der Endpunkt laut Schema nicht liest:');
+    lines.push('');
+    lines.push('| Tool | HTTP | Pfad | Unbekannter Parameter | Datei |');
+    lines.push('|------|------|------|------------------------|-------|');
+    for (const t of queryParamUnknown) {
+      lines.push(`| \`${t.toolName}\` | ${t.httpMethod} | \`${t.path}\` | \`${t.queryParam}\` | ${t.file}:${t.line} |`);
+    }
+    lines.push('');
+  }
+
   // Fehlende Tools (informativ)
   if (missingTool.length > 0) {
     lines.push('## MISSING_TOOL (Informativ)');
@@ -362,6 +792,20 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
     lines.push('|------|------|----------------|');
     for (const t of missingTool) {
       lines.push(`| ${t.method} | \`${t.path}\` | ${t.pathParams?.join(', ') || '-'} |`);
+    }
+    lines.push('');
+  }
+
+  if (queryParamMissing.length > 0) {
+    lines.push('## QUERY_PARAM_MISSING (Informativ)');
+    lines.push('');
+    lines.push('Der Endpunkt kennt diesen Query-Parameter, das Tool sendet ihn nicht — bei den meisten');
+    lines.push('Query-Params dieser API ist das ein optionaler Filter und kein Bug; im Einzelfall prüfen:');
+    lines.push('');
+    lines.push('| Tool | HTTP | Pfad | Fehlender Parameter | Datei |');
+    lines.push('|------|------|------|----------------------|-------|');
+    for (const t of queryParamMissing) {
+      lines.push(`| \`${t.toolName}\` | ${t.httpMethod} | \`${t.path}\` | \`${t.queryParam}\` | ${t.file}:${t.line} |`);
     }
     lines.push('');
   }
@@ -383,4 +827,21 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
   return lines.join('\n') + '\n';
 }
 
-validate();
+// Nur ausführen wenn direkt als CLI-Skript aufgerufen (nicht beim Import in Tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  validate();
+}
+
+export {
+  WHITELISTED_QUERY_PARAMS,
+  splitTopLevel,
+  extractObjectKey,
+  findMatchingClose,
+  extractCallQueryParamKeys,
+  extractToolCallsFromSource,
+  extractToolCalls,
+  normalizePath,
+  endpointKey,
+  pathParamsMatch,
+  diffQueryParams,
+};

--- a/tests/validate-mcp-tools.test.ts
+++ b/tests/validate-mcp-tools.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest';
+import {
+  splitTopLevel,
+  extractObjectKey,
+  pathParamsMatch,
+  diffQueryParams,
+  extractToolCallsFromSource,
+  WHITELISTED_QUERY_PARAMS,
+} from '../scripts/validate-mcp-tools.mjs';
+
+describe('splitTopLevel', () => {
+  it('splits simple comma-separated top-level args', () => {
+    expect(splitTopLevel('a, b, c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not split inside nested braces/brackets/parens', () => {
+    expect(splitTopLevel('{ a: 1, b: 2 }, [1, 2, 3], fn(1, 2)')).toEqual([
+      '{ a: 1, b: 2 }',
+      '[1, 2, 3]',
+      'fn(1, 2)',
+    ]);
+  });
+
+  it('does not split on commas inside strings or template literals', () => {
+    expect(splitTopLevel(`'a, b', "c, d", \`e, \${f(1, 2)}\``)).toEqual([
+      "'a, b'",
+      '"c, d"',
+      '`e, ${f(1, 2)}`',
+    ]);
+  });
+
+  it('ignores commas inside comments', () => {
+    expect(splitTopLevel('a /* x, y */, b // z, w')).toEqual(['a /* x, y */', 'b // z, w']);
+  });
+
+  it('returns a single element for input without top-level commas', () => {
+    expect(splitTopLevel('{ env: environmentId }')).toEqual(['{ env: environmentId }']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(splitTopLevel('')).toEqual([]);
+    expect(splitTopLevel('   ')).toEqual([]);
+  });
+});
+
+describe('extractObjectKey', () => {
+  it('extracts a regular key:value key', () => {
+    expect(extractObjectKey('env: environmentId')).toBe('env');
+    expect(extractObjectKey('force: force ? \'true\' : undefined')).toBe('force');
+  });
+
+  it('extracts a shorthand property key', () => {
+    expect(extractObjectKey('tail')).toBe('tail');
+    expect(extractObjectKey('  path  ')).toBe('path');
+  });
+
+  it('extracts a quoted key', () => {
+    expect(extractObjectKey("'foo-bar': 1")).toBe('foo-bar');
+    expect(extractObjectKey('"foo": 1')).toBe('foo');
+  });
+
+  it('ignores the colon inside a ternary value (key colon comes first)', () => {
+    expect(extractObjectKey('mode: force ? "hard" : "soft"')).toBe('mode');
+  });
+
+  it('returns null for a spread element', () => {
+    expect(extractObjectKey('...rest')).toBeNull();
+  });
+
+  it('returns null for a computed key', () => {
+    expect(extractObjectKey('[dynamicKey]: 1')).toBeNull();
+  });
+
+  it('returns null for empty input', () => {
+    expect(extractObjectKey('')).toBeNull();
+    expect(extractObjectKey('   ')).toBeNull();
+  });
+
+  it('does not get confused by nested objects in the value', () => {
+    expect(extractObjectKey('filter: { a: 1, b: 2 }')).toBe('filter');
+  });
+});
+
+describe('pathParamsMatch', () => {
+  it('matches when call and schema names are identical', () => {
+    expect(pathParamsMatch(['type', 'id'], ['type', 'id'])).toBe(true);
+  });
+
+  it('matches when the schema (generic) name is a case-insensitive suffix of the descriptive call name', () => {
+    // Real repo pattern: schema uses the generic SvelteKit route name ("id"), tools use
+    // descriptive variable names ("containerId", "providerId", ...).
+    expect(pathParamsMatch(['containerId'], ['id'])).toBe(true);
+    expect(pathParamsMatch(['providerId'], ['id'])).toBe(true);
+    expect(pathParamsMatch(['environmentId', 'notificationId'], ['id', 'notificationId'])).toBe(true);
+  });
+
+  it('fails when the counts differ', () => {
+    expect(pathParamsMatch(['id'], ['id', 'notificationId'])).toBe(false);
+  });
+
+  it('fails when a name at a position is genuinely unrelated (real deviation)', () => {
+    // e.g. a copy-paste bug: wrong variable used at this position
+    expect(pathParamsMatch(['scheduleId', 'notificationId'], ['type', 'id'])).toBe(false);
+  });
+});
+
+describe('diffQueryParams', () => {
+  it('flags a sent key the schema does not know as unknown', () => {
+    const { unknown, missing } = diffQueryParams(['q', 'env'], ['term', 'limit', 'registry'], {
+      checkMissing: true,
+    });
+    expect(unknown).toEqual(['q']);
+    expect(missing).toEqual(['term', 'limit', 'registry']);
+  });
+
+  it('never flags the whitelisted env scoping param as unknown', () => {
+    expect(WHITELISTED_QUERY_PARAMS.has('env')).toBe(true);
+    const { unknown } = diffQueryParams(['env'], undefined, { checkMissing: true });
+    expect(unknown).toEqual([]);
+  });
+
+  it('flags envId normally (not whitelisted) when the schema does not expect it', () => {
+    const { unknown } = diffQueryParams(['envId'], ['other'], { checkMissing: true });
+    expect(unknown).toEqual(['envId']);
+  });
+
+  it('does not flag envId when the schema explicitly expects it (e.g. /api/containers/{id}/exec)', () => {
+    const { unknown, missing } = diffQueryParams(['envId'], ['envId'], { checkMissing: true });
+    expect(unknown).toEqual([]);
+    expect(missing).toEqual([]);
+  });
+
+  it('reports no missing params when checkMissing is false, even if the schema lists some', () => {
+    const { missing } = diffQueryParams(['env'], ['tail', 'since'], { checkMissing: false });
+    expect(missing).toEqual([]);
+  });
+
+  it('reports no missing params when the schema has none', () => {
+    const { missing } = diffQueryParams(['env'], undefined, { checkMissing: true });
+    expect(missing).toEqual([]);
+  });
+
+  it('is a clean diff when everything sent is known and everything known is sent', () => {
+    const { missing, unknown } = diffQueryParams(['env', 'term', 'limit', 'registry'], ['term', 'limit', 'registry'], {
+      checkMissing: true,
+    });
+    expect(missing).toEqual([]);
+    expect(unknown).toEqual([]);
+  });
+});
+
+describe('extractToolCallsFromSource', () => {
+  it('extracts query param keys from a single-line client.get call', () => {
+    const source = `
+registerTool(server, 'get_container_stats', 'desc',
+  { environmentId: z.number() },
+  async ({ environmentId, containerId }) => {
+    return jsonResponse(await client.get(\`/api/containers/\${encodePath(containerId)}/stats\`, { env: environmentId }));
+  }
+);
+`;
+    const calls = extractToolCallsFromSource('fake.ts', source);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].toolName).toBe('get_container_stats');
+    expect(calls[0].httpMethod).toBe('GET');
+    expect(calls[0].queryParamKeys).toEqual(['env']);
+  });
+
+  it('extracts query param keys from a call whose params object spans multiple lines', () => {
+    const source = `
+registerTool(server, 'get_container_logs', 'desc',
+  { environmentId: z.number(), containerId: z.string(), tail: z.number().optional() },
+  async ({ environmentId, containerId, tail }) => {
+    const data = await client.get(\`/api/containers/\${encodePath(containerId)}/logs\`, {
+      env: environmentId,
+      tail: tail ?? 100,
+    });
+    return textResponse(data);
+  }
+);
+`;
+    const calls = extractToolCallsFromSource('fake.ts', source);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].queryParamKeys).toEqual(['env', 'tail']);
+  });
+
+  it('extracts query param keys for POST-like calls from the 3rd argument (body is 2nd)', () => {
+    const source = `
+registerTool(server, 'set_container_auto_update', 'desc',
+  { environmentId: z.number(), containerName: z.string(), policy: z.string() },
+  async ({ environmentId, containerName, policy }) => {
+    return jsonResponse(await client.post(\`/api/auto-update/\${encodePath(containerName)}\`, { policy }, { env: environmentId }));
+  }
+);
+`;
+    const calls = extractToolCallsFromSource('fake.ts', source);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].httpMethod).toBe('POST');
+    // The body ({ policy }) must NOT leak into the query param keys — only the 3rd arg counts.
+    expect(calls[0].queryParamKeys).toEqual(['env']);
+  });
+
+  it('returns null query param keys when the params argument is not an inline object literal', () => {
+    const source = `
+registerTool(server, 'weird_tool', 'desc',
+  {},
+  async ({ opts }) => {
+    return jsonResponse(await client.get('/api/system/files', opts));
+  }
+);
+`;
+    const calls = extractToolCallsFromSource('fake.ts', source);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].queryParamKeys).toBeNull();
+  });
+
+  it('RED → GREEN: reproduces the real search_registry bug class (q instead of term) and the fixed version', () => {
+    // RED: this is (structurally) the real bug found by this check in registries.ts —
+    // the route reads `term`/`limit`/`registry`, the tool sent `q` instead of `term`
+    // and never sent `registry` at all.
+    const buggySource = `
+registerTool(server, 'search_registry', 'desc',
+  { query: z.string(), environmentId: z.number().optional() },
+  async ({ query, environmentId }) => {
+    return jsonResponse(await client.get('/api/registry/search', { q: query, env: environmentId }));
+  }
+);
+`;
+    const buggyCall = extractToolCallsFromSource('registries.ts', buggySource)[0];
+    const buggyDiff = diffQueryParams(buggyCall.queryParamKeys, ['limit', 'registry', 'term'], {
+      checkMissing: true,
+    });
+    expect(buggyDiff.unknown).toEqual(['q']);
+    expect(buggyDiff.missing.sort()).toEqual(['limit', 'registry', 'term']);
+
+    // GREEN: sending the real key names produces a clean diff.
+    const fixedSource = `
+registerTool(server, 'search_registry', 'desc',
+  { query: z.string(), environmentId: z.number().optional() },
+  async ({ query, environmentId }) => {
+    return jsonResponse(await client.get('/api/registry/search', { term: query, env: environmentId }));
+  }
+);
+`;
+    const fixedCall = extractToolCallsFromSource('registries.ts', fixedSource)[0];
+    const fixedDiff = diffQueryParams(fixedCall.queryParamKeys, ['limit', 'registry', 'term'], {
+      checkMissing: true,
+    });
+    expect(fixedDiff.unknown).toEqual([]);
+    // `limit`/`registry` are legitimately optional here and not part of this red/green
+    // scenario — only `term` (the actual bug) is asserted as no longer missing.
+    expect(fixedDiff.missing).not.toContain('term');
+  });
+
+  it('does not confuse a tool-level query param diff with sibling tools in the same file', () => {
+    const source = `
+registerTool(server, 'tool_a', 'desc', {}, async () => {
+  return jsonResponse(await client.get('/api/a', { env: 1, foo: 'x' }));
+});
+
+registerTool(server, 'tool_b', 'desc', {}, async () => {
+  return jsonResponse(await client.get('/api/b', { env: 1 }));
+});
+`;
+    const calls = extractToolCallsFromSource('fake.ts', source);
+    expect(calls).toHaveLength(2);
+    expect(calls.find((c) => c.toolName === 'tool_a')?.queryParamKeys).toEqual(['env', 'foo']);
+    expect(calls.find((c) => c.toolName === 'tool_b')?.queryParamKeys).toEqual(['env']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #95. Extends `scripts/validate-mcp-tools.mjs` so it catches the
*class* of query-param mismatches that #81 was one instance of (schema
expects `envId`, tool sends only `env`), instead of relying on someone
spotting each one by hand.

- **Query-param diff**: extracts the query-param keys a tool call
  actually sends (parses the `client.get/post/put/delete(path, body?,
  params?)` call's params object — handles calls whose params object
  spans multiple lines) and diffs them against `ep.queryParams` from the
  schema.
  - `QUERY_PARAM_UNKNOWN` (critical, fails the run): tool sends a key the
    endpoint doesn't read at all.
  - `QUERY_PARAM_MISSING` (informative only): endpoint knows a key the
    tool never sends. Kept non-fatal and restricted to endpoints with a
    single HTTP method — almost every query param in this API is an
    optional filter (`url.searchParams.get()`, no required-fallback), and
    the schema aggregates `queryParams` per **route file**, not per
    method, so a naive missing-check on a GET+POST file would flag
    legitimate POST calls for GET-only filters.
  - `env` (the universal environment-scoping param, already filtered out
    of the schema by `extract-dockhand-api.mjs`) is whitelisted and never
    flagged as unknown. `envId` and everything else is checked normally.
- **Path-param check sharpened**: from a pure `.length` comparison to a
  per-position, name-aware comparison (`pathParamsMatch`). Literal string
  equality against the schema's generic SvelteKit route names (`id`,
  `type`, ...) doesn't work here — tools use descriptive variable names
  (`containerId`, `providerId`, ...), and I verified that would false-positive
  on **121 of 141** real path-param comparisons. A case-insensitive suffix
  match (schema name is a suffix of the call's variable name, e.g. `id` ⊂
  `containerId`) covers all 141 real cases with **zero** false positives,
  while still catching a genuinely wrong variable at a position.

## Scharfer Lauf gegen das aktuelle Schema (committed, Commit `123e04d1`)

```
COVERED:             283
MISSING_TOOL:         27  (unchanged, pre-existing, informative)
ORPHANED_TOOL:         0
PARAM_MISMATCH:        0  (verified: 0 false positives from the new name-aware check)
MISSING_ENCODE:        0
QUERY_PARAM_MISSING:  21  (informative)
QUERY_PARAM_UNKNOWN:   1  (critical)
```

### QUERY_PARAM_UNKNOWN — 1 finding, and it's a real bug

| Tool | HTTP | Pfad | Unbekannter Parameter | Datei |
|------|------|------|------------------------|-------|
| `search_registry` | GET | `/api/registry/search` | `q` | registries.ts:68 |

Verified against the real upstream route
(`finsys/dockhand` `src/routes/api/registry/search/+server.ts`):

```ts
export const GET: RequestHandler = async ({ url }) => {
	const term = url.searchParams.get('term');
	const limit = parseInt(url.searchParams.get('limit') || '25', 10);
	const registryId = url.searchParams.get('registry');

	if (!term) {
		return json({ error: 'Search term is required' }, { status: 400 });
	}
	...
```

`search_registry` sends `{ q: query, env: environmentId }` — it has
never sent `term`. **Every call to `search_registry` hits Dockhand's 400
"Search term is required" response** and always searches Docker Hub only
(the `registry` filter is never sent either, `registryId` stays
undefined server-side). This is exactly the bug class #95 set out to
catch automatically — happy to file a separate fix issue if wanted,
kept out of scope here since #95 is about the check itself.

### QUERY_PARAM_MISSING — 21 findings (informative, not gating)

<details>
<summary>Full list (tool → endpoint → missing param)</summary>

| Tool | HTTP | Pfad | Fehlender Parameter | Datei |
|------|------|------|----------------------|-------|
| `get_container_logs` | GET | `/api/containers/{containerId}/logs` | `since` | containers.ts:47 |
| `get_container_logs` | GET | `/api/containers/{containerId}/logs` | `until` | containers.ts:47 |
| `list_container_files` | GET | `/api/containers/{containerId}/files` | `simpleLs` | containers.ts:195 |
| `download_container_file` | GET | `/api/containers/{containerId}/files/download` | `format` | containers.ts:273 |
| `get_containers_stats` | GET | `/api/containers/stats` | `debug` | containers.ts:340 |
| `get_merged_logs` | GET | `/api/logs/merged` | `since` | dashboard.ts:70 |
| `get_merged_logs` | GET | `/api/logs/merged` | `until` | dashboard.ts:70 |
| `remove_image` | DELETE | `/api/images/{imageId}` | `force` | images.ts:48 |
| `export_image` | GET | `/api/images/{imageId}/export` | `compress` | images.ts:88 |
| `search_registry` | GET | `/api/registry/search` | `limit` | registries.ts:68 |
| `search_registry` | GET | `/api/registry/search` | `term` | registries.ts:68 |
| `search_registry` | GET | `/api/registry/search` | `registry` | registries.ts:68 |
| `get_registry_tags` | GET | `/api/registry/tags` | `page` | registries.ts:87 |
| `get_registry_tags` | GET | `/api/registry/tags` | `pageSize` | registries.ts:87 |
| `get_registry_tags` | GET | `/api/registry/tags` | `registry` | registries.ts:87 |
| `restart_stack` | POST | `/api/stacks/{name}/restart` | `mode` | stacks.ts:76 |
| `delete_stack` | DELETE | `/api/stacks/{name}` | `volumes` | stacks.ts:99 |
| `get_stack_default_path` | GET | `/api/stacks/default-path` | `location` | stacks.ts:529 |
| `prune_images` | POST | `/api/prune/images` | `dangling` | system.ts:170 |
| `export_volume` | GET | `/api/volumes/{volumeName}/export` | `format` | volumes.ts:98 |
| `export_volume` | GET | `/api/volumes/{volumeName}/export` | `path` | volumes.ts:98 |

</details>

Most of these look like legitimate "tool doesn't expose every optional
filter as a parameter yet" cases (e.g. `since`/`until` on logs, `force`
on `remove_image`), not bugs — worth a human pass at some point, but I
did not change any tool behavior in this PR to stay scoped to #95.
`search_registry`'s three misses here are the flip side of the one real
`QUERY_PARAM_UNKNOWN` bug above.

## Tests

New `tests/validate-mcp-tools.test.ts`, 31 cases covering the new
parsing/diffing helpers in isolation (no dependency on the real schema
file, so these stay green regardless of upstream API drift):

- `splitTopLevel`: single-line, nested braces/brackets/parens, commas
  inside strings/template-literals/comments, empty input.
- `extractObjectKey`: `key: value`, shorthand `{ foo }`, quoted keys,
  ternary values (key colon vs. ternary colon), spread, computed keys.
- `pathParamsMatch`: exact match, suffix match (the real repo
  convention), count mismatch, genuine name deviation (red case).
- `diffQueryParams`: unknown/missing detection, `env` whitelisting,
  `envId` handled normally, `checkMissing:false` behavior.
- `extractToolCallsFromSource`: single-line calls, multi-line params
  object, POST body vs. params-arg separation, non-object params
  argument (skipped, not statically analyzable), multiple tools in one
  file not cross-contaminating.
- **Red/green pair reproducing the `search_registry` bug shape**: a
  constructed "buggy" tool source (`{ q: query, ... }`) is asserted to
  produce `unknown: ['q']` / `missing: [limit, registry, term]`; the
  "fixed" version (`{ term: query, ... }`) is asserted to no longer flag
  `term` as unknown or missing.

Full suite: **402/402 passing**, `tsc` build clean.

## Not in scope here

- Fixing `search_registry` itself (the real bug found above) — flagging
  it in this PR/report per the issue's "note it, don't necessarily fix
  it" framing; happy to open a follow-up if wanted.
- Body-field diffing (#142-class checks) — that's a different, larger
  problem (matching body fields against server-side `body.x` reads) and
  explicitly out of scope for #95.

**Not merging this** — leaving it for review per the task.
