### PR TITLE
fix(registries): align search_registry with the real /api/registry/search contract

### DIFF
--- a/src/tools/registries.ts
+++ b/src/tools/registries.ts
@@ -61,11 +61,12 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
 
   registerTool(server, 'search_registry', 'Search the configured registry for images matching a query; use `get_registry_catalog` for a full image list or `get_registry_tags` for available tags.',
     {
-      query: z.string().describe('Search query'),
-      environmentId: z.number().optional().describe('Environment ID'),
+      term: z.string().describe('Search term'),
+      limit: z.number().optional().describe('Maximum number of results (default: 25)'),
+      registry: z.number().optional().describe('Registry ID to search (use list_registries to discover); omit to search Docker Hub'),
     },
-    async ({ query, environmentId }) => {
-      return jsonResponse(await client.get('/api/registry/search', { q: query, env: environmentId }));
+    async ({ term, limit, registry }) => {
+      return jsonResponse(await client.get('/api/registry/search', { term, limit, registry }));
     }
   );
 

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -8,6 +8,7 @@ const stacksSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'stacks.
 const systemSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'system.ts'), 'utf-8');
 const usersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'users.ts'), 'utf-8');
 const containersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'containers.ts'), 'utf-8');
+const registriesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'registries.ts'), 'utf-8');
 
 function extractToolBlock(source: string, toolName: string): string {
   const startPattern = new RegExp(
@@ -115,5 +116,23 @@ describe('Dockhand API contract alignment', () => {
     // Description must not promise one-shot command execution/output the API cannot deliver.
     expect(block).not.toMatch(/Execute a one-shot command/i);
     expect(block).toMatch(/does not run|cannot run|no.*output|terminal attach/i);
+  });
+
+  it('search_registry matches the real /api/registry/search contract: term (required), limit + registry (optional), no env', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/registry/search/+server.ts, v1.0.40):
+    // `export const GET: RequestHandler = async ({ url }) => { const term = url.searchParams.get('term');
+    // const limit = parseInt(url.searchParams.get('limit') || '25', 10); const registryId =
+    // url.searchParams.get('registry'); if (!term) return json({ error: 'Search term is required' }, { status: 400 }); }`
+    // The handler never reads `q` or `env` at all — this endpoint has no environment concept
+    // (it searches a registry, not a Docker host). The old tool sent { q: query, env: environmentId },
+    // which the real handler ignores entirely, so `!term` always fired the 400 in production.
+    const block = extractToolBlock(registriesSource, 'search_registry');
+
+    expect(block).toMatch(/term:\s*z\.string\(\)/);
+    expect(block).toMatch(/limit:\s*z\.number\(\)\.optional\(\)/);
+    expect(block).toMatch(/registry:\s*z\.number\(\)\.optional\(\)/);
+    expect(block).toMatch(/client\.get\('\/api\/registry\/search'/);
+    expect(block).not.toMatch(/\bq:\s*query\b/);
+    expect(block).not.toMatch(/\benv:\s*environmentId\b/);
   });
 });


### PR DESCRIPTION
## Bug

`search_registry` sendet `{ q: query, env: environmentId }` an `GET /api/registry/search`. Der reale Upstream-Handler (`Finsys/dockhand` `v1.0.40`, `src/routes/api/registry/search/+server.ts`) liest ausschließlich:

```ts
const term = url.searchParams.get('term');
const limit = parseInt(url.searchParams.get('limit') || '25', 10);
const registryId = url.searchParams.get('registry');

if (!term) {
	return json({ error: 'Search term is required' }, { status: 400 });
}
```

`q` und `env` werden vom Handler nie gelesen — der Endpoint hat kein Environment-Konzept (Registry-Suche, kein Docker-Host-Bezug). Damit schlug **jeder** reale Aufruf mit `400 "Search term is required"` fehl.

Gefunden über den erweiterten Validator aus #145 (`QUERY_PARAM_UNKNOWN`, kritisch).

Closes #146

## Fix

- Tool-Schema `{ query, environmentId }` → `{ term, limit?, registry? }` (Feldname direkt auf den Handler ausgerichtet, um die Verwechslung nicht zu wiederholen)
- `client.get('/api/registry/search', { term, limit, registry })`
- `environmentId`/`env` komplett entfernt

## Tests (TDD: RED → GREEN)

Neuer Contract-Test in `tests/api-contracts.test.ts` (`search_registry matches the real /api/registry/search contract`), mit dem Handler-Zitat als Beleg im Kommentar. Vor dem Fix rot (erwartet `term:`/`limit:`/`registry:` im Zod-Schema, nicht vorhanden), nach dem Fix grün.

```
node scripts/validate-mcp-tools.mjs
QUERY_PARAM_UNKNOWN: 0   (vorher: 1)
QUERY_PARAM_MISSING: 18  (vorher: 21 — die 3 search_registry-Einträge term/limit/registry sind weg)
Exit-Code: 0
```

- `npm run build` — clean
- `npx vitest run` — 404/404 grün (405 inkl. dem neuen Test)

## Scope

Nur `search_registry` — der einzige echte Pflicht-Param-Bug unter den 21 `QUERY_PARAM_MISSING`-Treffern aus #145. Die übrigen 20 sind gegen den echten Handler-Code geprüft und ausschließlich optionale Filter (Default-Werte, kein `400`-Guard) — kein Bug, siehe Issue #146 und die Einzel-Belege im PR-Diff-Kommentar unten.
