### PR TITLE
fix(registries): align get_registry_catalog with the real /api/registry/catalog contract

### DIFF
--- a/src/tools/registries.ts
+++ b/src/tools/registries.ts
@@ -70,12 +70,15 @@ export function registerRegistryTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'get_registry_catalog', 'Retrieve the full image catalog of the configured Docker registry; use `search_registry` for filtered results or `get_registry_tags` for image tags.',
+  registerTool(server, 'get_registry_catalog', 'Retrieve the full image catalog of a configured Docker registry (registries are global, not scoped to an environment); use `search_registry` for filtered results or `get_registry_tags` for image tags.',
     {
-      environmentId: z.number().optional().describe('Environment ID'),
+      registry: z.number().describe('Registry ID (use list_registries to discover)'),
+      last: z.string().optional().describe('Pagination cursor from a previous response (opaque, returned as pagination.nextLast)'),
     },
-    async ({ environmentId }) => {
-      return jsonResponse(await client.get('/api/registry/catalog', environmentId ? { env: environmentId } : undefined));
+    async ({ registry, last }) => {
+      const query: Record<string, string | number> = { registry };
+      if (last !== undefined) query.last = last;
+      return jsonResponse(await client.get('/api/registry/catalog', query));
     }
   );
 

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -135,4 +135,23 @@ describe('Dockhand API contract alignment', () => {
     expect(block).not.toMatch(/\bq:\s*query\b/);
     expect(block).not.toMatch(/\benv:\s*environmentId\b/);
   });
+
+  it('get_registry_catalog matches the real /api/registry/catalog contract: registry (required), last (optional), no env', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/registry/catalog/+server.ts, commit
+    // 905c4a0): `export const GET: RequestHandler = async ({ url }) => { const registryId =
+    // url.searchParams.get('registry'); const lastParam = url.searchParams.get('last'); //
+    // For pagination if (!registryId) { return json({ error: 'Registry ID is required' },
+    // { status: 400 }); } ... }`. The handler never reads `env`/`environmentId` at all —
+    // registries are global, not per-environment. The old tool sent
+    // `environmentId ? { env: environmentId } : undefined`, which the real handler ignores
+    // entirely AND never sent `registry` — every call 400ed with "Registry ID is required".
+    // (Found via the required/optional-aware query-param check, mcp-dockhand#148.)
+    const block = extractToolBlock(registriesSource, 'get_registry_catalog');
+
+    expect(block).toMatch(/registry:\s*z\.number\(\)/);
+    expect(block).toMatch(/last:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/client\.get\('\/api\/registry\/catalog'/);
+    expect(block).not.toMatch(/environmentId/);
+    expect(block).not.toMatch(/\benv:\s*environmentId\b/);
+  });
 });


### PR DESCRIPTION
## Problem

`get_registry_catalog` sendet nie den vom echten Handler zwingend verlangten
Query-Param `registry` — jeder Aufruf schlägt garantiert mit `400 Registry ID is
required` fehl.

Ground truth (`Finsys/dockhand` `src/routes/api/registry/catalog/+server.ts`, verifiziert
gegen Commit `905c4a0`):

```ts
export const GET: RequestHandler = async ({ url }) => {
	try {
		const registryId = url.searchParams.get('registry');
		const lastParam = url.searchParams.get('last'); // For pagination

		if (!registryId) {
			return json({ error: 'Registry ID is required' }, { status: 400 });
		}
		...
```

Der Handler liest **weder** `env` noch `environmentId` — Registries sind global, nicht
pro-Environment gescoped. Der bisherige Tool-Call
(`environmentId ? { env: environmentId } : undefined`) sendete also einen Parameter, den
der Handler ignoriert, und **nie** den Parameter, den er zwingend braucht.

Gefunden über den required/optional-aware Query-Param-Check aus #148 — der Ternary-Bug
dort hatte diesen Aufruf vorher komplett aus der Prüfung genommen.

Closes #150

## Fix

- `registry: z.number()` (required, "Registry ID (use list_registries to discover)")
- `last: z.string().optional()` (Pagination-Cursor, aus `pagination.nextLast` vorheriger
  Antworten)
- `environmentId` entfernt (wird vom Handler nie gelesen)
- Tool-Beschreibung korrigiert (kein Environment-Bezug mehr)

## TDD

RED → GREEN in `tests/api-contracts.test.ts`, analog zum bestehenden
`search_registry`-Contract-Test (PR #147): Regex-Assertions gegen den extrahierten
`registerTool('get_registry_catalog', ...)`-Block prüfen `registry: z.number()`,
`last: z.string().optional()`, den `client.get('/api/registry/catalog', ...)`-Aufruf, und
dass `environmentId` nirgends mehr auftaucht.

Kein Live-Test (kein Dockhand-Zugang in diesem Environment) — wie beim
`search_registry`-Präzedenzfall ausschließlich source-code-verifiziert.

`npm run build`, `npm run typecheck`, `npx vitest run` grün (405/405).

**Nicht gemerged** — offen zur Review.
