### PR TITLE
fix(tools): correct required/optional query params for 6 tools

### DIFF
--- a/src/tools/dashboard.ts
+++ b/src/tools/dashboard.ts
@@ -76,12 +76,10 @@ export function registerDashboardTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'clear_activity', 'Permanently delete (truncate) the activity log for the entire environment scope; pair with `get_activity_feed` to inspect the current entries before clearing, or `get_activity_stats` for aggregate counts that survive a clear.',
-    {
-      environmentId: z.number().describe('Environment ID'),
-    },
-    async ({ environmentId }) => {
-      return jsonResponse(await client.delete('/api/activity', { environmentId }));
+  registerTool(server, 'clear_activity', 'Permanently delete (truncate) the ENTIRE activity log across all environments — the real endpoint has no environment scoping and always clears globally; pair with `get_activity_feed` to inspect the current entries before clearing, or `get_activity_stats` for aggregate counts that survive a clear.',
+    {},
+    async () => {
+      return jsonResponse(await client.delete('/api/activity'));
     }
   );
 }

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -52,13 +52,13 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'trigger_git_webhook', 'Fire the incoming webhook for a Git-based stack to trigger a manual deploy; use `get_git_webhook` to inspect webhook details before firing.',
+  registerTool(server, 'trigger_git_webhook', "Fire a Git-based stack's webhook via the real GET manual-trigger path to force a deploy check; the POST path is reserved for GitHub/GitLab's own signed webhook calls (verified via request headers) and cannot be triggered manually. Use `get_git_webhook` to inspect webhook details before firing.",
     {
       stackId: z.number().describe('Git stack ID'),
-      token: z.string().optional().describe('Webhook secret token'),
+      secret: z.string().describe("Webhook secret, matched against the stack's configured secret (required by the real endpoint)"),
     },
-    async ({ stackId, token }) => {
-      return jsonResponse(await client.post(`/api/git/stacks/${encodePath(stackId)}/webhook`, undefined, token ? { token } : undefined));
+    async ({ stackId, secret }) => {
+      return jsonResponse(await client.get(`/api/git/stacks/${encodePath(stackId)}/webhook`, { secret }));
     }
   );
 

--- a/src/tools/images.ts
+++ b/src/tools/images.ts
@@ -89,12 +89,17 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
     }
   );
 
-  registerTool(server, 'list_image_scans', 'List the cached vulnerability-scan results across all images in an environment (read-only summary view); contrast with `scan_image` (POST) which actually runs a fresh scan for a single image, or `get_image_history` for layer provenance instead of CVE data.',
+  registerTool(server, 'list_image_scans', 'Retrieve the cached vulnerability-scan result for a single image (read-only lookup, returns `{found, result}`); contrast with `scan_image` (POST) which actually runs a fresh scan, or `get_image_history` for layer provenance instead of CVE data.',
     {
-      environmentId: z.number().describe('Environment ID'),
+      image: z.string().describe('Image name/reference to look up (required by the real endpoint)'),
+      environmentId: z.number().optional().describe('Environment ID'),
+      scanner: z.enum(['grype', 'trivy']).optional().describe('Filter the cached result by scanner type'),
     },
-    async ({ environmentId }) => {
-      return jsonResponse(await client.get('/api/images/scan', { env: environmentId }));
+    async ({ image, environmentId, scanner }) => {
+      const query: Record<string, string | number | undefined> = { image };
+      if (environmentId !== undefined) query.env = environmentId;
+      if (scanner) query.scanner = scanner;
+      return jsonResponse(await client.get('/api/images/scan', query));
     }
   );
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -217,20 +217,26 @@ export function registerSystemTools(server: McpServer, client: DockhandClient): 
     }
   );
 
-  registerTool(server, 'write_system_file', 'Create or overwrite a file on the Dockhand server filesystem (not inside a container — use `write_container_file_content` for that). Pair with `list_system_files` to discover the path namespace and `get_system_file_content` to read back the result.',
+  registerTool(server, 'write_system_file', 'Create a directory on the Dockhand server filesystem at an absolute path (not inside a container — use `write_container_file_content` for that). The real endpoint only creates directories; it does not accept or persist file content. Pair with `list_system_files` to discover the path namespace and `get_system_file_content` to read back existing files.',
     {
-      path: z.string().describe('Absolute path on the Dockhand server'),
-      content: z.string().describe('File content to write'),
+      path: z.string().describe('Absolute path on the Dockhand server to create as a directory'),
     },
-    async ({ path, content }) => {
-      return jsonResponse(await client.post('/api/system/files', { content }, { path }));
+    async ({ path }) => {
+      return jsonResponse(await client.post('/api/system/files', { path }));
     }
   );
 
-  registerTool(server, 'reset_scanner_settings', 'Permanently reset the vulnerability-scanner settings (Trivy/Grype) to their defaults; read the current values first with `get_scanner_settings`, or use `update_scanner_settings` for targeted changes instead of a full reset.',
-    {},
-    async () => {
-      return jsonResponse(await client.delete('/api/settings/scanner'));
+  registerTool(server, 'reset_scanner_settings', 'Permanently reset the vulnerability-scanner settings (Trivy/Grype) to their defaults by removing the scanner images for an environment; read the current values first with `get_scanner_settings`, or use `update_scanner_settings` for targeted changes instead of a full reset.',
+    {
+      environmentId: z.number().describe('Environment ID (required by the real endpoint)'),
+      removeImages: z.boolean().describe('Must be true to confirm scanner image removal (required by the real endpoint)'),
+      scanner: z.enum(['grype', 'trivy']).optional().describe('Limit removal to one scanner; omit to remove both'),
+    },
+    async ({ environmentId, removeImages, scanner }) => {
+      const query: Record<string, string | number | undefined> = { env: environmentId };
+      if (removeImages) query.removeImages = 'true';
+      if (scanner) query.scanner = scanner;
+      return jsonResponse(await client.delete('/api/settings/scanner', query));
     }
   );
 

--- a/src/tools/users.ts
+++ b/src/tools/users.ts
@@ -51,10 +51,15 @@ export function registerUserTools(server: McpServer, client: DockhandClient): vo
     }
   );
 
-  registerTool(server, 'delete_user', 'Permanently delete a Dockhand user account by ID; use `list_users` to confirm the target before removing.',
-    { userId: z.number().describe('User ID') },
-    async ({ userId }) => {
-      return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}`));
+  registerTool(server, 'delete_user', 'Permanently delete a Dockhand user account by ID; use `list_users` to confirm the target before removing. If this is the last remaining admin account, the real endpoint returns 409 unless `confirmDisableAuth` is set (deleting it disables authentication entirely).',
+    {
+      userId: z.number().describe('User ID'),
+      confirmDisableAuth: z.boolean().optional().describe('Confirm deleting the last remaining admin user, which disables authentication (only required when userId is the last admin — the real endpoint 409s without it)'),
+    },
+    async ({ userId, confirmDisableAuth }) => {
+      const query: Record<string, string | number | undefined> = {};
+      if (confirmDisableAuth) query.confirmDisableAuth = 'true';
+      return jsonResponse(await client.delete(`/api/users/${encodePath(userId)}`, query));
     }
   );
 

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -9,6 +9,9 @@ const systemSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'system.
 const usersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'users.ts'), 'utf-8');
 const containersSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'containers.ts'), 'utf-8');
 const registriesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'registries.ts'), 'utf-8');
+const imagesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'images.ts'), 'utf-8');
+const dashboardSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'dashboard.ts'), 'utf-8');
+const gitStacksSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'git-stacks.ts'), 'utf-8');
 
 function extractToolBlock(source: string, toolName: string): string {
   const startPattern = new RegExp(
@@ -153,5 +156,112 @@ describe('Dockhand API contract alignment', () => {
     expect(block).toMatch(/client\.get\('\/api\/registry\/catalog'/);
     expect(block).not.toMatch(/environmentId/);
     expect(block).not.toMatch(/\benv:\s*environmentId\b/);
+  });
+
+  it('write_system_file sends path in the POST body, not as a query param (real endpoint only creates a directory)', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/system/files/+server.ts, commit 905c4a0):
+    // `export const POST: RequestHandler = async ({ request, cookies }) => { const body = await
+    // request.json(); const path = body.path; if (!path || typeof path !== 'string') return
+    // json({ error: 'Path is required' }, { status: 400 }); ... mkdirSync(path, { recursive:
+    // true }); return json({ success: true, path }); }`. The handler reads `path` exclusively
+    // from the parsed JSON body — it never touches `url.searchParams` at all. The old tool sent
+    // `client.post('/api/system/files', { content }, { path })`: `path` went out as a query
+    // param the handler never reads, so `body.path` was always undefined and every call 400ed
+    // with "Path is required". The handler also never reads `content` from anywhere — this
+    // endpoint creates an (empty) directory, it does not write file content.
+    const block = extractToolBlock(systemSource, 'write_system_file');
+
+    expect(block).toMatch(/path:\s*z\.string\(\)/);
+    expect(block).toMatch(/client\.post\('\/api\/system\/files',\s*\{\s*path\s*\}\)/);
+    expect(block).not.toMatch(/content:\s*z\.string\(\)/);
+  });
+
+  it('list_image_scans matches the real GET /api/images/scan contract: image (required), env + scanner (optional)', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/images/scan/+server.ts, commit 905c4a0):
+    // `export const GET: RequestHandler = async ({ url, cookies }) => { const imageName =
+    // url.searchParams.get('image'); const envIdParam = url.searchParams.get('env'); const
+    // scanner = url.searchParams.get('scanner') as 'grype' | 'trivy' | undefined; ... if
+    // (!imageName) return json({ error: 'Image name is required' }, { status: 400 }); ... }`.
+    // This is a single-image cached-result lookup (returns { found, result }), not a listing
+    // across the whole environment. The old tool only sent `env` and never `image` — every call
+    // 400ed with "Image name is required".
+    const block = extractToolBlock(imagesSource, 'list_image_scans');
+
+    expect(block).toMatch(/image:\s*z\.string\(\)/);
+    expect(block).toMatch(/environmentId:\s*z\.number\(\)\.optional\(\)/);
+    expect(block).toMatch(/client\.get\('\/api\/images\/scan',\s*query\)/);
+    expect(block).toMatch(/\{\s*image\s*\}/);
+    expect(block).toMatch(/query\.env\s*=\s*environmentId/);
+  });
+
+  it('reset_scanner_settings matches the real DELETE /api/settings/scanner contract: env + removeImages (required), scanner (optional)', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/settings/scanner/+server.ts, commit
+    // 905c4a0): `export const DELETE: RequestHandler = async ({ url, cookies }) => { const
+    // removeImagesFlag = url.searchParams.get('removeImages') === 'true'; const scanner =
+    // url.searchParams.get('scanner'); const envId = url.searchParams.get('env'); ... if
+    // (!removeImagesFlag) return json({ error: 'removeImages parameter required' }, { status:
+    // 400 }); if (!parsedEnvId) return json({ error: 'Environment ID required' }, { status: 400
+    // }); ... }`. The old tool called `client.delete('/api/settings/scanner')` with an empty
+    // input schema — no query params at all — so every call 400ed on the very first guard
+    // ("removeImages parameter required").
+    const block = extractToolBlock(systemSource, 'reset_scanner_settings');
+
+    expect(block).toMatch(/environmentId:\s*z\.number\(\)/);
+    expect(block).toMatch(/removeImages:\s*z\.boolean\(\)/);
+    expect(block).toMatch(/scanner:\s*z\.enum\(\[['"]grype['"],\s*['"]trivy['"]\]\)\.optional\(\)/);
+    expect(block).toMatch(/client\.delete\('\/api\/settings\/scanner'/);
+    expect(block).toMatch(/env:\s*environmentId/);
+    expect(block).toMatch(/removeImages\s*=\s*['"]true['"]/);
+  });
+
+  it('delete_user forwards confirmDisableAuth as a query param (conditionally required on the last-admin path)', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/users/[id]/+server.ts, commit 905c4a0):
+    // `export const DELETE: RequestHandler = async (event) => { ... const confirmDisableAuth =
+    // url.searchParams.get('confirmDisableAuth') === 'true'; ... if (auth.authEnabled &&
+    // userIsAdmin) { const adminCount = await countAdminUsers(); if (adminCount <= 1) { if
+    // (!confirmDisableAuth) return json({ error: 'This is the last admin user', isLastAdmin:
+    // true, ... }, { status: 409 }); ... } } ... }`. Deleting a non-last-admin user works
+    // without it; deleting the sole remaining admin 409s unless `confirmDisableAuth=true` is
+    // sent. The old tool never sent this param at all, so that path could never be confirmed.
+    const block = extractToolBlock(usersSource, 'delete_user');
+
+    expect(block).toMatch(/confirmDisableAuth:\s*z\.boolean\(\)\.optional\(\)/);
+    expect(block).toMatch(/confirmDisableAuth\s*=\s*['"]true['"]/);
+    expect(block).toMatch(/client\.delete\(`\/api\/users\/\$\{encodePath\(userId\)\}`/);
+  });
+
+  it('clear_activity matches the real DELETE /api/activity contract: no query params, clears globally', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/activity/+server.ts, commit 905c4a0):
+    // `export const DELETE: RequestHandler = async ({ cookies }) => { const auth = await
+    // authorize(cookies); if (auth.authEnabled && !await auth.can('activity', 'delete')) return
+    // json({ error: 'Permission denied' }, { status: 403 }); try { await clearContainerEvents();
+    // return json({ success: true }); } ... }`. The handler destructures only `{ cookies }` —
+    // it never reads `url.searchParams` at all, so there is no environment scoping: a DELETE
+    // always clears the ENTIRE activity log. The old tool sent a required `environmentId` as
+    // `{ environmentId }` in the query string, which the real handler silently ignores.
+    const block = extractToolBlock(dashboardSource, 'clear_activity');
+
+    expect(block).toMatch(/client\.delete\('\/api\/activity'\)/);
+    expect(block).not.toMatch(/environmentId/);
+  });
+
+  it('trigger_git_webhook uses the real GET manual-trigger path with a `secret` query param, not POST+token', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/git/stacks/[id]/webhook/+server.ts, commit
+    // 905c4a0): the POST handler is reserved for GitHub/GitLab's own webhook calls — it verifies
+    // an HMAC signature read from the `x-hub-signature-256`/`x-gitlab-token` REQUEST HEADERS
+    // (`verifyWebhookSignature(payload, signature, gitStack.webhookSecret)`) and never reads any
+    // query param at all, so the old tool's `{ token }` query param on POST was always ignored —
+    // signature verification failed and every call 401ed. The handler also explicitly documents
+    // a GET path for this: `// Also support GET for simple polling/manual triggers` — `export
+    // const GET: RequestHandler = async (event) => { ... const secret =
+    // url.searchParams.get('secret'); if (secret !== gitStack.webhookSecret) return json({
+    // error: 'Invalid webhook secret' }, { status: 401 }); ... deployGitStack(id, { force: false
+    // }); ... }`. That GET+`secret` path is the correct, real manual-trigger contract.
+    const block = extractToolBlock(gitStacksSource, 'trigger_git_webhook');
+
+    expect(block).toMatch(/secret:\s*z\.string\(\)/);
+    expect(block).toMatch(/client\.get\(`\/api\/git\/stacks\/\$\{encodePath\(stackId\)\}\/webhook`,\s*\{\s*secret\s*\}\)/);
+    expect(block).not.toMatch(/client\.post\(`\/api\/git\/stacks/);
+    expect(block).not.toMatch(/\btoken\b/);
   });
 });


### PR DESCRIPTION
## Summary

Aligns six tools against the real `Finsys/dockhand` handler code (commit `905c4a0`, the exact `sourceCommit` recorded in `docs/dockhand-api-schema.json` at the time of this fix), closing the remaining findings listed in #152 (surfaced by the required/optional-aware query-param validator, #149; `get_registry_catalog` was already fixed in #151).

Each fix below is validated directly against the real handler source (quoted in the accompanying contract test in `tests/api-contracts.test.ts`), per the `dockhand-mcp-dev` upstream-validation workflow — not against our own extracted schema or the tool's prior description.

| Tool | Old contract (broken) | Real contract | Evidence |
|---|---|---|---|
| `write_system_file` | `POST /api/system/files` with `path` as a **query param**, `content` in body | Handler reads `path` **only** from the JSON body (`body.path`) and never touches `url.searchParams`; it only creates a directory — `content` is never read anywhere | [`src/routes/api/system/files/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/system/files/%2Bserver.ts) |
| `list_image_scans` | `GET /api/images/scan` sent only `env`, never `image` | `image` is **required** (400 "Image name is required" without it); `env`/`scanner` optional. This is a single-image cached-result lookup (`{found, result}`), not a per-environment listing | [`src/routes/api/images/scan/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/images/scan/%2Bserver.ts) |
| `reset_scanner_settings` | `DELETE /api/settings/scanner`, empty input schema, no query params sent | Requires **both** `removeImages=true` and `env` (each 400s alone); `scanner` optional | [`src/routes/api/settings/scanner/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/settings/scanner/%2Bserver.ts) |
| `delete_user` | `DELETE /api/users/{id}`, never sent `confirmDisableAuth` | `confirmDisableAuth` is read from the query string; only required on the last-remaining-admin path (409 without it) | [`src/routes/api/users/[id]/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/users/%5Bid%5D/%2Bserver.ts) |
| `clear_activity` | `DELETE /api/activity` sent a required `environmentId` | Handler destructures only `{ cookies }` — no environment scoping exists at all, it always clears the entire activity log | [`src/routes/api/activity/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/activity/%2Bserver.ts) |
| `trigger_git_webhook` | `POST .../webhook` with `{ token }` as a query param | POST verifies an HMAC signature read from **request headers** (`x-hub-signature-256`/`x-gitlab-token`) and never reads any query param — the query `token` was always ignored (401). The handler explicitly documents a `GET` path for manual triggers (`// Also support GET for simple polling/manual triggers`), reading `secret` from the query string | [`src/routes/api/git/stacks/[id]/webhook/+server.ts`](https://github.com/Finsys/dockhand/blob/905c4a00/src/routes/api/git/stacks/%5Bid%5D/webhook/%2Bserver.ts) |

**Note on `write_system_file` and `list_image_scans`:** both required going slightly beyond the literal "query param vs. body" framing in #152 once the real handler was read — `write_system_file`'s `content` field is not read by any code path (the endpoint only creates directories, it cannot write file content in this Dockhand version), and `list_image_scans` is a single-image lookup, not an environment-wide listing. I updated the tool descriptions to match reality rather than leave a misleading (if no-longer-400ing) surface. Flagging in case a genuine "write arbitrary file content on the host" capability is wanted — that would need a new upstream endpoint, it doesn't exist today.

## Test plan

- [x] TDD: added 6 new contract tests to `tests/api-contracts.test.ts` (RED against the old source, GREEN after the fix), each quoting the real handler as ground truth
- [x] `npx vitest run` — 453/453 tests pass (19 files)
- [x] `npm run build` (`tsc`) — clean
- [x] `node scripts/validate-mcp-tools.mjs` — 0 `QUERY_PARAM_MISSING_REQUIRED`, 0 `QUERY_PARAM_UNKNOWN` across all tools (the exact bar #152 set for "done")
- [ ] CI (GitHub Actions) — will run on push, not yet observed by me

Closes #152