### PR TITLE
fix(tools): update_container — require a body, validate settings keys (#142)

### DIFF
--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -8,6 +8,41 @@ import type { DockhandClient } from '../client/dockhand-client.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
 
+/**
+ * Keys accepted in `update_container`'s `settings` fallback (#142).
+ *
+ * Source of truth: Finsys/dockhand v1.0.41 (commit 905c4a0).
+ *   - `startAfterUpdate` / `repullImage` are top-level control flags the handler
+ *     destructures out of the request body BEFORE the rest is treated as
+ *     `CreateContainerOptions` (src/routes/api/containers/[id]/update/+server.ts:26
+ *     `const { startAfterUpdate, repullImage, ...options } = body;`).
+ *   - Everything else must match a `CreateContainerOptions` field
+ *     (src/lib/server/docker.ts:1351-1453) exactly, or Dockhand silently drops it
+ *     while still recreating the container (see `createContainer()`, which only
+ *     ever reads named fields off `options` — an unknown key like `command`
+ *     instead of `cmd` is never referenced anywhere and has no effect).
+ *
+ * Update this set when re-validating against a newer Dockhand release
+ * (.claude/skills/dockhand-mcp-dev/references/upstream-validation.md).
+ */
+const UPDATE_CONTAINER_ALLOWED_SETTINGS_KEYS = new Set([
+  // top-level control flags, not part of CreateContainerOptions
+  'startAfterUpdate', 'repullImage',
+  // CreateContainerOptions fields
+  'name', 'image', 'ports', 'volumes', 'volumeBinds', 'env', 'labels', 'cmd',
+  'entrypoint', 'workingDir', 'restartPolicy', 'restartMaxRetries', 'networkMode',
+  'additionalNetworks', 'networks', 'networkAliases', 'networkIpv4Address',
+  'networkIpv6Address', 'networkGwPriority', 'networkConfigs', 'user', 'privileged',
+  'healthcheck', 'memory', 'memoryReservation', 'memorySwap', 'cpuShares', 'cpuQuota',
+  'cpuPeriod', 'nanoCpus', 'capAdd', 'capDrop', 'devices', 'dns', 'dnsSearch',
+  'dnsOptions', 'securityOpt', 'ulimits', 'tty', 'stdinOpen', 'oomKillDisable',
+  'pidsLimit', 'shmSize', 'tmpfs', 'sysctls', 'logDriver', 'logOptions', 'ipcMode',
+  'pidMode', 'utsMode', 'hostname', 'cgroupParent', 'stopSignal', 'init',
+  'stopTimeout', 'macAddress', 'extraHosts', 'deviceRequests', 'runtime',
+  'readonlyRootfs', 'cpusetCpus', 'cpusetMems', 'groupAdd', 'memorySwappiness',
+  'usernsMode', 'domainname',
+]);
+
 export function registerContainerTools(server: McpServer, client: DockhandClient): void {
 
   registerTool(server, 'list_containers', 'List all containers in a Dockhand environment, returning summary fields for every container; use `get_container` for a single container\'s details or `inspect_container` for the full low-level Docker JSON.',
@@ -133,14 +168,53 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'update_container', 'Recreate a single container with updated settings (image, environment, restart policy, etc.) for a specific container ID; use `batch_update_containers` to pull the latest image for multiple containers at once, or `rename_container` to change only the container name.',
+  registerTool(server, 'update_container', 'Recreate a single container with updated settings for a specific container ID. Explicit parameters cover the common fields (image, cmd, entrypoint, env, labels, restartPolicy, networkMode, workingDir, startAfterUpdate); `settings` is a fallback for the remaining CreateContainerOptions fields (e.g. ports, volumeBinds, healthcheck, memory limits, repullImage) and is merged underneath the explicit parameters. Unrecognized `settings` keys are rejected — Dockhand silently ignores fields that do not match its own field names while still recreating the container (e.g. "cmd", not "command"). At least one field is required: Dockhand always recreates the container and has no meaningful no-argument update. Use `batch_update_containers` to pull the latest image for multiple containers at once, or `rename_container` to change only the container name.',
     {
       environmentId: z.number().describe('Environment ID'),
       containerId: z.string().describe('Container ID'),
-      settings: z.record(z.string(), z.unknown()).optional().describe('Container settings to update'),
+      image: z.string().optional().describe('Docker image (e.g. nginx:alpine)'),
+      cmd: z.array(z.string()).optional().describe('Command to run, overriding the image default (e.g. ["sleep", "7200"])'),
+      entrypoint: z.array(z.string()).optional().describe('Entrypoint override'),
+      env: z.array(z.string()).optional().describe('Environment variables (KEY=VALUE format)'),
+      labels: z.record(z.string(), z.string()).optional().describe('Container labels'),
+      restartPolicy: z.string().optional().describe('Restart policy (e.g. unless-stopped)'),
+      networkMode: z.string().optional().describe('Network mode'),
+      workingDir: z.string().optional().describe('Working directory inside the container'),
+      startAfterUpdate: z.boolean().optional().describe('Start the recreated container after updating'),
+      settings: z.record(z.string(), z.unknown()).optional().describe('Additional CreateContainerOptions fields not covered above (e.g. ports, volumeBinds, healthcheck, memory, capAdd, repullImage); merged underneath the explicit parameters, unrecognized keys are rejected'),
     },
-    async ({ environmentId, containerId, settings }) => {
-      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/update`, settings, { env: environmentId }));
+    async ({ environmentId, containerId, image, cmd, entrypoint, env: envVars, labels, restartPolicy, networkMode, workingDir, startAfterUpdate, settings }) => {
+      if (settings) {
+        const unknownKeys = Object.keys(settings).filter((key) => !UPDATE_CONTAINER_ALLOWED_SETTINGS_KEYS.has(key));
+        if (unknownKeys.length > 0) {
+          throw new Error(
+            `update_container: settings contains unrecognized key(s): ${unknownKeys.join(', ')}. ` +
+            'Dockhand silently drops fields that do not match its CreateContainerOptions field names ' +
+            'while still recreating the container — double-check the field name (e.g. "cmd", not "command").'
+          );
+        }
+      }
+
+      const body: Record<string, unknown> = {};
+      if (settings) Object.assign(body, settings);
+      if (image !== undefined) body.image = image;
+      if (cmd !== undefined) body.cmd = cmd;
+      if (entrypoint !== undefined) body.entrypoint = entrypoint;
+      if (envVars !== undefined) body.env = envVars;
+      if (labels !== undefined) body.labels = labels;
+      if (restartPolicy !== undefined) body.restartPolicy = restartPolicy;
+      if (networkMode !== undefined) body.networkMode = networkMode;
+      if (workingDir !== undefined) body.workingDir = workingDir;
+      if (startAfterUpdate !== undefined) body.startAfterUpdate = startAfterUpdate;
+
+      if (Object.keys(body).length === 0) {
+        throw new Error(
+          'update_container requires at least one field to update (e.g. image, cmd, restartPolicy, ' +
+          'or settings) — Dockhand always recreates the container and has no meaningful no-argument update.'
+        );
+      }
+
+      return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/update`, body, { env: environmentId }));
     }
   );
 

--- a/tests/update-container-contract.test.ts
+++ b/tests/update-container-contract.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Behavioural tests for `update_container` (#142).
+ *
+ * Dockhand's POST /api/containers/{id}/update handler (Finsys/dockhand v1.0.41,
+ * `src/routes/api/containers/[id]/update/+server.ts`) does two things that make an
+ * under-validated MCP tool dangerous:
+ *
+ *   1. It unconditionally parses a JSON body (`await request.json()`). A request with
+ *      no body throws "Unexpected end of JSON input" -> HTTP 500. The old schema made
+ *      `settings` optional, so the no-argument call this tool advertised as valid was
+ *      guaranteed to fail server-side with an unhelpful, Dockhand-attributed error.
+ *   2. It merges the body straight into `CreateContainerOptions`
+ *      (`src/lib/server/docker.ts`, `updateContainer()`/`createContainer()`) without any
+ *      schema validation. A key that isn't one of the real field names (e.g. `command`
+ *      instead of `cmd`) is silently dropped, and the container is still *recreated* —
+ *      so a typo doesn't just fail to apply, it can leave a running container broken
+ *      while the tool reports success.
+ *
+ * These tests lock in the fix: the tool now (a) refuses a no-argument call itself, with
+ * a clear message, before ever sending a request, and (b) rejects unrecognized `settings`
+ * keys the same way, instead of forwarding them into a request Dockhand will silently
+ * mangle.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { registerContainerTools } from '../src/tools/containers.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: true;
+}>;
+
+interface MockClient {
+  post: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Register the container tools against a fake MCP server that captures each tool's
+ * (already error-wrapped, see src/utils/tool-helper.ts) handler by name, plus a mocked
+ * client. Mirrors the fixture in tests/stack-env-merge-behavior.test.ts.
+ */
+function setup(): { handler: ToolHandler; client: MockClient } {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, cb: ToolHandler) => {
+      handlers.set(name, cb);
+    },
+  };
+  const client: MockClient = {
+    post: vi.fn().mockResolvedValue({ success: true, id: 'abc123' }),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerContainerTools(server as any, client as any);
+  const handler = handlers.get('update_container');
+  if (!handler) throw new Error('update_container handler was not registered');
+  return { handler, client };
+}
+
+function jsonOut(res: Awaited<ReturnType<ToolHandler>>): Record<string, unknown> {
+  return JSON.parse(res.content[0].text) as Record<string, unknown>;
+}
+
+describe('update_container — settings contract (#142)', () => {
+  it('rejects a call with no fields at all, without contacting Dockhand (regression for the guaranteed 500)', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({ environmentId: 9, containerId: 'abc123' });
+
+    expect(res.isError).toBe(true);
+    expect(jsonOut(res).error).toMatch(/at least one field/i);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty settings object with no other fields, without contacting Dockhand', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({ environmentId: 9, containerId: 'abc123', settings: {} });
+
+    expect(res.isError).toBe(true);
+    expect(jsonOut(res).error).toMatch(/at least one field/i);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('accepts a call with only an explicit field set (image) and sends it as the request body', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({ environmentId: 9, containerId: 'abc123', image: 'alpine:3.21' });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      { image: 'alpine:3.21' },
+      { env: 9 },
+    );
+  });
+
+  it('rejects settings with the exact typo from #142 ("command" instead of "cmd") before recreating the container', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      settings: { name: 'repro-updctr', image: 'alpine:3.21', command: ['sleep', '7200'], startAfterUpdate: true },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(jsonOut(res).error).toMatch(/command/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('rejects settings with any unrecognized key, naming it in the error', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      settings: { totallyMadeUpField: 'x' },
+    });
+
+    expect(res.isError).toBe(true);
+    expect(jsonOut(res).error).toMatch(/totallyMadeUpField/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('accepts settings keys that are real CreateContainerOptions fields not exposed as explicit parameters (e.g. ports, memory)', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      settings: { ports: { '80/tcp': { HostPort: '8080' } }, memory: 536870912 },
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      { ports: { '80/tcp': { HostPort: '8080' } }, memory: 536870912 },
+      { env: 9 },
+    );
+  });
+
+  it('accepts the startAfterUpdate/repullImage control flags via settings (top-level body fields the handler destructures before touching CreateContainerOptions)', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      settings: { startAfterUpdate: true, repullImage: true, image: 'alpine:3.21' },
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      { startAfterUpdate: true, repullImage: true, image: 'alpine:3.21' },
+      { env: 9 },
+    );
+  });
+
+  it('exposes startAfterUpdate as an explicit parameter, merged alongside other explicit fields', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      image: 'alpine:3.21',
+      cmd: ['sleep', '7200'],
+      startAfterUpdate: true,
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      { image: 'alpine:3.21', cmd: ['sleep', '7200'], startAfterUpdate: true },
+      { env: 9 },
+    );
+  });
+
+  it('lets explicit parameters win over a conflicting key in settings (mirrors the update_environment additionalSettings precedent)', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      image: 'alpine:3.22',
+      settings: { image: 'alpine:3.21' },
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      { image: 'alpine:3.22' },
+      { env: 9 },
+    );
+  });
+
+  it('sends all explicit fields (cmd, entrypoint, env, labels, restartPolicy, networkMode, workingDir) correctly named in the body', async () => {
+    const { handler, client } = setup();
+
+    const res = await handler({
+      environmentId: 9,
+      containerId: 'abc123',
+      cmd: ['sleep', '7200'],
+      entrypoint: ['/bin/sh', '-c'],
+      env: ['FOO=bar'],
+      labels: { team: 'ops' },
+      restartPolicy: 'unless-stopped',
+      networkMode: 'bridge',
+      workingDir: '/data',
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/containers/abc123/update',
+      {
+        cmd: ['sleep', '7200'],
+        entrypoint: ['/bin/sh', '-c'],
+        env: ['FOO=bar'],
+        labels: { team: 'ops' },
+        restartPolicy: 'unless-stopped',
+        networkMode: 'bridge',
+        workingDir: '/data',
+      },
+      { env: 9 },
+    );
+  });
+});


### PR DESCRIPTION
Closes #142

## Root cause (verified against the real Dockhand handler, not our schema/docs)

Checked out `Finsys/dockhand` at commit `905c4a0` (tag `v1.0.41`, matches the version named in
#142 and the commit `docs/dockhand-api-schema.json` was last synced from).

**Bug 1 — guaranteed 500 with no arguments.**
`src/routes/api/containers/[id]/update/+server.ts` parses the body unconditionally:

```ts
const body = await request.json();
const { startAfterUpdate, repullImage, ...options } = body;
```

With our old schema (`settings: z.record(...).optional()`), an argument-less call sent
`client.post(path, undefined, ...)` → no request body → `request.json()` throws
`"Unexpected end of JSON input"` → the endpoint's catch-all returns
`{"error":"Failed to update container","details":"Unexpected end of JSON input"}` with HTTP 500.
There is no code path in the handler that tolerates an empty/absent body, so this was not an edge
case — every no-argument call was guaranteed to fail, with an error that points at Dockhand rather
than at the call.

**Bug 2 — unknown keys are silently dropped while the container is recreated.**
The body flows straight into `updateContainer()` / `createContainer()`
(`src/lib/server/docker.ts:1351-1453` for the `CreateContainerOptions` interface,
`createContainer()` starting at line 1455). `createContainer()` only ever reads specific named
fields off `options` (`options.cmd`, `options.image`, `options.ports`, …) — there is no schema
validation anywhere in the chain. A key that doesn't match exactly (`command` instead of `cmd`) is
therefore never read by anything and has zero effect, while `updateContainer()` unconditionally
stops the old container, renames it, and creates a new one from the merged options. The result
observed in #142: `{"command": [...]}` was dropped, the recreated container fell back to the image
default `CMD` (`/bin/sh`), and exited immediately — while the tool reported `{"success": true}`.

## Fix

1. **Body is now guaranteed non-empty.** Added explicit optional parameters for the common fields
   (`image`, `cmd`, `entrypoint`, `env`, `labels`, `restartPolicy`, `networkMode`, `workingDir`,
   `startAfterUpdate`), keeping `settings` as a fallback record for the remaining
   `CreateContainerOptions` fields. This mirrors the shape `update_environment` already uses
   (explicit named parameters + an `additionalSettings`/`settings` fallback, explicit fields
   winning on conflict) — the pattern #17 settled on for `update_environment`,
   `create_git_credential`, and `create_git_repository`. If neither explicit fields nor `settings`
   end up populating the body, the tool throws a clear "at least one field required" error
   *before* making any request.
2. **`settings` keys are now validated against the real field list.** Built the allow-list
   directly from `CreateContainerOptions` (`src/lib/server/docker.ts:1351-1453`) plus the two
   top-level control flags the handler destructures before touching `CreateContainerOptions`
   (`startAfterUpdate`, `repullImage`). An unrecognized key is rejected with the offending key
   name in the error, instead of being forwarded into a request Dockhand will silently mangle.

## Design decision that needs review confirmation

#142 offered three options for the unknown-key problem: (1) make `settings` required outright,
(2) add explicit typed parameters for the common fields with `settings` as fallback, (3) at
minimum document the accepted keys. I implemented (2) — which makes (1) unnecessary in its literal
form, since most calls now populate the body via explicit fields rather than `settings` — plus a
**stricter, not explicitly requested** measure: I made **unrecognized `settings` keys a hard
rejection** rather than just documenting them (option 3), i.e. **fail-loud instead of
Dockhand's own silent-drop**.

Trade-off to confirm: the allow-list (~65 `CreateContainerOptions` field names) is copied from the
upstream interface at v1.0.41 and must be kept in sync by hand
(`.claude/skills/dockhand-mcp-dev/` in the downstream homelab repo has the re-validation workflow
for future Dockhand releases). If upstream adds a new `CreateContainerOptions` field before we
re-validate, a caller using that new field via `settings` would get a false rejection until the
list is updated. I judged that acceptable — a loud, immediate rejection is far cheaper than the
silent, delayed container breakage this issue reports — but it's a real maintenance commitment
this repo is now taking on, so flagging it explicitly rather than presenting it as the obviously
correct choice.

Also **out of scope, flagged for a follow-up**: the issue notes `update_container_runtime` takes
`config: z.record(...)` with the same unvalidated-passthrough shape. Not touched here to keep this
PR focused on the two defects actually reported against `update_container`.

## Tests (TDD — red before green)

New `tests/update-container-contract.test.ts`, mocking the MCP server registration and the
Dockhand client (same fixture pattern as `tests/stack-env-merge-behavior.test.ts`), 10 cases:

- no-argument call → rejected client-side, `client.post` never called
- empty `settings: {}` with nothing else → same rejection
- single explicit field (`image`) → sent correctly, no settings needed
- the exact repro from #142 (`settings: {..., command: [...]}`) → rejected, error names `command`
- an arbitrary unrecognized key → rejected, error names it
- a real but rare `CreateContainerOptions` field not exposed explicitly (`ports`, `memory`) →
  passed through
- `startAfterUpdate`/`repullImage` via `settings` (backward compatible with the old
  settings-only shape) → passed through
- `startAfterUpdate` as an explicit parameter → passed through
- explicit field wins over a conflicting key in `settings`
- all seven remaining explicit fields sent correctly named

`npx vitest run` — 463/463 pass (20 files). `tsc --noEmit` / `tsc` (build) clean.
`node scripts/validate-mcp-tools.mjs` against the live schema (commit `905c4a00`, matching the
version checked out for this fix): `ORPHANED_TOOL: 0`, `PARAM_MISMATCH: 0`, no new issues.

**Not run:** `npm run lint` (`eslint` is referenced in `package.json`'s `lint` script but is not
declared as a dependency in this repo as of this branch — pre-existing, unrelated to this change).

**Not merging** — separate review requested per the task this PR was produced under.