### PR TITLE
fix(docker): healthcheck probes 127.0.0.1 instead of localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,10 @@ RUN npm ci --omit=dev --ignore-scripts && npm cache clean --force
 COPY --from=build /app/dist ./dist
 USER mcp
 EXPOSE 8080
-HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://localhost:8080/health || exit 1
+# Use 127.0.0.1 explicitly, not localhost: on Alpine/musl, BusyBox wget
+# resolves "localhost" to the IPv6 loopback (::1) first, but the server
+# only binds the IPv4 wildcard address (0.0.0.0), so every probe against
+# "localhost" fails with "Connection refused" even though the server is
+# healthy (fixes #92, #84).
+HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://127.0.0.1:8080/health || exit 1
 CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       - DOCKHAND_PASSWORD=${DOCKHAND_PASSWORD}
       - MCP_PORT=8080
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      # 127.0.0.1, not localhost: avoids the IPv6-loopback resolution issue
+      # on Alpine/musl (see Dockerfile HEALTHCHECK comment, fixes #92, #84).
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/tests/healthcheck-loopback.test.ts
+++ b/tests/healthcheck-loopback.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Regression test for #92 / #84: the container HEALTHCHECK (Dockerfile) and
+// the compose healthcheck (docker-compose.yml) must probe the IPv4 loopback
+// address 127.0.0.1 explicitly, never the hostname "localhost".
+//
+// Root cause: the server binds only the IPv4 wildcard address (see
+// src/index.ts `host: process.env['MCP_HOST'] || '0.0.0.0'`), while on
+// Alpine/musl images BusyBox `wget` resolves "localhost" to the IPv6
+// loopback (::1) first. With nothing listening on [::1]:8080, every
+// healthcheck probe against "localhost" fails with "Connection refused"
+// even though the server is fully healthy — the container is reported
+// `unhealthy` forever.
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function extractHealthcheckCommands(text: string): string[] {
+  const commands: string[] = [];
+
+  // Dockerfile: `HEALTHCHECK ... CMD <command>`
+  const dockerfileMatch = text.match(/^HEALTHCHECK\b.*$/m);
+  if (dockerfileMatch) {
+    commands.push(dockerfileMatch[0]);
+  }
+
+  // docker-compose.yml: `test: ["CMD", "wget", "-qO-", "http://..."]`
+  const composeMatch = text.match(/test:\s*\[[^\]]*]/);
+  if (composeMatch) {
+    commands.push(composeMatch[0]);
+  }
+
+  return commands;
+}
+
+describe('container healthcheck uses IPv4 loopback (127.0.0.1), not localhost', () => {
+  it('Dockerfile HEALTHCHECK targets 127.0.0.1', () => {
+    const dockerfile = readFileSync(join(repoRoot, 'Dockerfile'), 'utf-8');
+    const [healthcheckLine] = extractHealthcheckCommands(dockerfile);
+
+    expect(healthcheckLine).toBeDefined();
+    expect(healthcheckLine).toContain('127.0.0.1:8080/health');
+    expect(healthcheckLine).not.toMatch(/localhost:8080/);
+  });
+
+  it('docker-compose.yml healthcheck test targets 127.0.0.1', () => {
+    const compose = readFileSync(join(repoRoot, 'docker-compose.yml'), 'utf-8');
+    const [healthcheckTest] = extractHealthcheckCommands(compose);
+
+    expect(healthcheckTest).toBeDefined();
+    expect(healthcheckTest).toContain('127.0.0.1:8080/health');
+    expect(healthcheckTest).not.toMatch(/localhost:8080/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the permanent false-`unhealthy` state reported in #92 and #84 — same root cause, one fix.

**Root cause:** the server binds only the IPv4 wildcard address (`src/index.ts`: `host: process.env['MCP_HOST'] || '0.0.0.0'`, used in `app.listen(config.port, host, ...)` in `src/server.ts`). Both the `Dockerfile` `HEALTHCHECK` and the `docker-compose.yml` `healthcheck` probe `http://localhost:8080/health`. On Alpine/musl (`node:22-alpine`), BusyBox `wget` resolves `localhost` to the IPv6 loopback `::1` first — but nothing listens on `[::1]:8080`, so the probe fails with `Connection refused` on every single check, forever. The MCP server itself is fully functional the entire time (`/health` and `/mcp` both respond fine over IPv4) — it's purely a false health signal.

## Fix

Pin both healthchecks to `127.0.0.1` explicitly instead of the hostname `localhost`:

- `Dockerfile`: `HEALTHCHECK --interval=30s --timeout=5s CMD wget -qO- http://127.0.0.1:8080/health || exit 1`
- `docker-compose.yml`: `test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/health"]`

This is deterministic regardless of `/etc/hosts` resolution order/libc, and needs no server-side dual-stack binding change.

## Verification

- Built the image locally (`docker build .`) and ran a container with dummy, non-secret env values.
- `docker inspect --format '{{.State.Health.Status}}'` → `healthy`, `FailingStreak: 0`.
- Negative control inside the *same* container (confirms the reported mechanism):
  - `wget -qO- http://127.0.0.1:8080/health` → `200 OK`
  - `wget -qO- http://[::1]:8080/health` → `Connection refused` (exactly the failure mode described in both issues)
- Added a regression test (`tests/healthcheck-loopback.test.ts`) that reads `Dockerfile` and `docker-compose.yml` and asserts the healthcheck command targets `127.0.0.1`, never `localhost` — guards against the fix being silently reverted.
- Full suite: `npm run build` clean, `npx vitest run` → 21 files / 465 tests passed (including the 2 new ones).

## Test plan

- [x] `npm run build`
- [x] `npx vitest run` (465/465 passing)
- [x] `docker build` + container smoke test → `healthy`, `FailingStreak: 0`
- [x] Negative control confirms root cause (IPv6 loopback probe still refused)

Closes #92
Closes #84