### PR TITLE
fix(auth): make login failures diagnosable and fix trailing-slash 307

### DIFF
--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DockhandConfig, SessionInfo } from '../types/dockhand.js';
+import { describeLoginFailure, normalizeBaseUrl } from '../utils/url.js';
 
 const SESSION_TIMEOUT_MS = 23 * 60 * 60 * 1000; // 23h (conservative, actual is 24h)
 
@@ -34,7 +35,7 @@ export class SessionManager {
   }
 
   private async performLogin(): Promise<void> {
-    const url = `${this.config.url}/api/auth/login`;
+    const url = `${normalizeBaseUrl(this.config.url)}/api/auth/login`;
 
     const response = await fetch(url, {
       method: 'POST',
@@ -51,9 +52,15 @@ export class SessionManager {
     const responseBody = await response.text().catch(() => '');
 
     if (!response.ok) {
-      throw new Error(
-        `Dockhand login failed (HTTP ${response.status}): ${responseBody || response.statusText}`
-      );
+      const detail = describeLoginFailure(response.status, response.headers.get('location'), responseBody, response.statusText);
+      // Fail loud: a login failure only ever surfaces to the caller as a
+      // structured MCP tool error (src/utils/tool-helper.ts), which is never
+      // written to stderr/docker logs on its own. Log it here unconditionally
+      // (no LOG_LEVEL gate — the server doesn't implement log levels at all)
+      // so a failed login is always diagnosable from `docker logs`. See
+      // Issue #116.
+      console.error(`[session] Login failed for ${this.config.username}: HTTP ${response.status} — ${detail}`);
+      throw new Error(`Dockhand login failed (HTTP ${response.status}): ${detail}`);
     }
 
     // Extract session cookie from Set-Cookie header

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -5,6 +5,7 @@
 
 import { SessionManager } from '../auth/session.js';
 import type { DockhandConfig, SSEResult } from '../types/dockhand.js';
+import { normalizeBaseUrl } from '../utils/url.js';
 
 /** Timeout for SSE streaming responses (5 minutes). */
 const SSE_TIMEOUT_MS = 300_000;
@@ -14,7 +15,7 @@ export class DockhandClient {
   private baseUrl: string;
 
   constructor(config: DockhandConfig) {
-    this.baseUrl = config.url.replace(/\/+$/, '');
+    this.baseUrl = normalizeBaseUrl(config.url);
     this.session = new SessionManager(config);
   }
 

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -31,7 +31,14 @@ export function registerTool<T extends ZodShape>(
     try {
       return await callback(args);
     } catch (error) {
-      return errorResponse(error instanceof Error ? error.message : 'Unknown error');
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      // Fail loud: a thrown error here (e.g. a lazily-triggered Dockhand
+      // login failure) would otherwise only ever reach the caller as a
+      // structured MCP tool-error response — never written to
+      // stderr/docker logs. Log it unconditionally so every tool failure
+      // is diagnosable from container logs alone. See Issue #116.
+      console.error(`[tool:${name}] ${message}`);
+      return errorResponse(message);
     }
   });
   /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,48 @@
+/**
+ * URL normalization helpers shared by DockhandClient and SessionManager.
+ *
+ * Both classes build request URLs from the same `DOCKHAND_URL` config value,
+ * but historically did so independently: DockhandClient stripped a trailing
+ * slash before combining paths via `new URL(path, baseUrl)`, while
+ * SessionManager concatenated `${config.url}/api/auth/login` directly. A
+ * `DOCKHAND_URL` with a trailing slash (e.g. `https://host/`) therefore
+ * produced a double-slash login URL (`https://host//api/auth/login`).
+ *
+ * Dockhand's `hooks.server.ts` auth gate matches the login route against a
+ * public-path allowlist by exact pathname (`/api/auth/login`) or
+ * `startsWith('/api/')`; a double-slash pathname (`//api/auth/login`)
+ * matches neither, so the request falls through to the "unauthenticated UI
+ * route" branch and gets redirected (`307` to `/login?redirect=...`) instead
+ * of being processed as a login attempt. See Issue #116.
+ */
+
+/** Strip one or more trailing slashes from a base URL. */
+export function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * Build a diagnostic message for a login response that failed.
+ *
+ * A 3xx status with `redirect: 'manual'` means the server redirected the
+ * login request instead of processing it — most commonly caused by a
+ * misconfigured base URL (trailing slash, wrong path) or a reverse proxy
+ * rewrite, not a rejected credential. Surfacing the Location header (when
+ * present) turns an opaque "HTTP 307: Temporary Redirect" into an
+ * actionable hint instead of a silent dead end.
+ */
+export function describeLoginFailure(
+  status: number,
+  location: string | null,
+  bodyText: string,
+  statusText: string,
+): string {
+  if (status >= 300 && status < 400) {
+    const target = location ? `"${location}"` : '(no Location header)';
+    return (
+      `redirected to ${target} instead of authenticating — check DOCKHAND_URL for a ` +
+      `trailing slash or a reverse-proxy rewrite in front of Dockhand`
+    );
+  }
+  return bodyText || statusText;
+}

--- a/tests/session-login.test.ts
+++ b/tests/session-login.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SessionManager } from '../src/auth/session.js';
+import type { DockhandConfig } from '../src/types/dockhand.js';
+
+interface MockResponseInit {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body?: string;
+  setCookie?: string[];
+  location?: string | null;
+}
+
+function mockResponse(init: MockResponseInit) {
+  const headerMap = new Map<string, string>();
+  if (init.location !== undefined && init.location !== null) {
+    headerMap.set('location', init.location);
+  }
+  return {
+    ok: init.ok,
+    status: init.status,
+    statusText: init.statusText,
+    text: vi.fn().mockResolvedValue(init.body ?? ''),
+    headers: {
+      getSetCookie: () => init.setCookie ?? [],
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+    },
+  };
+}
+
+function config(overrides: Partial<DockhandConfig> = {}): DockhandConfig {
+  return {
+    url: 'https://dockhand.example.com',
+    username: 'admin',
+    password: 'p@ss!w0rd#$%',
+    ...overrides,
+  };
+}
+
+describe('SessionManager login', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('logs in successfully and stores the session cookie (happy path)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123; Path=/; HttpOnly'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    const cookie = await manager.getCookie();
+
+    expect(cookie).toBe('session=abc123');
+    expect(manager.isAuthenticated()).toBe(true);
+  });
+
+  it('sends a password containing special characters unmodified in the JSON body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const complexPassword = 'a"b\\c$d!e&f#g%h\'i`j<k>l{m}n unicode-äöü-中文';
+    const manager = new SessionManager(config({ username: 'Mixed.Case_User', password: complexPassword }));
+    await manager.getCookie();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const sentBody = JSON.parse(requestInit.body as string) as { username: string; password: string };
+    expect(sentBody.password).toBe(complexPassword);
+    expect(sentBody.username).toBe('Mixed.Case_User');
+  });
+
+  it('builds the login URL without a double slash when DOCKHAND_URL has a trailing slash', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config({ url: 'https://dockhand.example.com/' }));
+    await manager.getCookie();
+
+    const [calledUrl] = fetchMock.mock.calls[0];
+    expect(calledUrl).toBe('https://dockhand.example.com/api/auth/login');
+  });
+
+  it('throws a diagnostic error and logs it when login is redirected (HTTP 307)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 307,
+        statusText: 'Temporary Redirect',
+        body: '',
+        location: '/login?redirect=%2Fapi%2Fauth%2Flogin',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const manager = new SessionManager(config());
+
+    await expect(manager.getCookie()).rejects.toThrow(/HTTP 307/);
+    await expect(manager.getCookie()).rejects.toThrow(/trailing slash/);
+
+    const logged = errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    expect(logged).toContain('/login?redirect=%2Fapi%2Fauth%2Flogin');
+  });
+
+  it('throws with the response body on a rejected login (HTTP 401)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        body: '{"error":"Invalid username or password"}',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+
+    await expect(manager.getCookie()).rejects.toThrow(/Invalid username or password/);
+  });
+
+  it('propagates a network error (fetch rejects) instead of failing silently', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+
+    await expect(manager.getCookie()).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('throws when no Set-Cookie header is present in an otherwise-ok response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', body: '{"success":true}', setCookie: [] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+
+    await expect(manager.getCookie()).rejects.toThrow(/No session cookie received/);
+  });
+
+  it('reuses the cached cookie on a second call instead of logging in again', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    await manager.getCookie();
+    await manager.getCookie();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent login attempts into a single in-flight request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    const [cookieA, cookieB] = await Promise.all([manager.getCookie(), manager.getCookie()]);
+
+    expect(cookieA).toBe('session=abc123');
+    expect(cookieB).toBe('session=abc123');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins multiple Set-Cookie headers with a semicolon', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        setCookie: ['session=abc123; Path=/; HttpOnly', 'csrf=xyz789; Path=/'],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    const cookie = await manager.getCookie();
+
+    expect(cookie).toBe('session=abc123; csrf=xyz789');
+  });
+
+  it('falls back to the raw set-cookie header when getSetCookie() is unavailable', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: vi.fn().mockResolvedValue(''),
+      headers: {
+        // No getSetCookie() at all — older/alternate fetch implementations.
+        get: (name: string) => (name.toLowerCase() === 'set-cookie' ? 'session=fallback123; Path=/' : null),
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    const cookie = await manager.getCookie();
+
+    expect(cookie).toBe('session=fallback123');
+  });
+
+  it('logs in again after invalidate()', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const manager = new SessionManager(config());
+    await manager.getCookie();
+    manager.invalidate();
+    expect(manager.isAuthenticated()).toBe(false);
+    await manager.getCookie();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/tool-error-logging.test.ts
+++ b/tests/tool-error-logging.test.ts
@@ -1,0 +1,105 @@
+/**
+ * registerTool() (src/utils/tool-helper.ts) is the single chokepoint every
+ * MCP tool callback runs through. Before this fix a thrown error (e.g. a
+ * failed Dockhand login surfacing lazily on the first `client.get()` call
+ * inside a tool) was caught and turned into a structured MCP error response
+ * — but never logged anywhere. Since the login failure itself only ever
+ * throws (see src/auth/session.ts), and nothing between the throw and this
+ * wrapper logs it either, the failure was completely invisible in
+ * `docker logs`, matching Issue #116 part 2: "no corresponding log output ...
+ * even with LOG_LEVEL=debug set" (LOG_LEVEL isn't read anywhere in the
+ * codebase — it's a no-op).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { registerTool } from '../src/utils/tool-helper.js';
+
+interface CapturedTool {
+  name: string;
+  description: string;
+  schema: unknown;
+  handler: (args: unknown) => Promise<{ content: { type: string; text: string }[]; isError?: true }>;
+}
+
+function fakeServer() {
+  const tools = new Map<string, CapturedTool>();
+  return {
+    tools,
+    // Mirrors the subset of McpServer.tool() that registerTool() calls.
+    tool(name: string, description: string, schema: unknown, handler: CapturedTool['handler']) {
+      tools.set(name, { name, description, schema, handler });
+    },
+  };
+}
+
+describe('registerTool error logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('logs the tool name and error message when the callback throws (fail loud)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const server = fakeServer();
+
+    registerTool(server as never, 'health_check', 'desc', {}, async () => {
+      throw new Error('Dockhand login failed (HTTP 307): redirected to "/login?redirect=..." instead of authenticating');
+    });
+
+    const result = await server.tools.get('health_check')!.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Dockhand login failed');
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = errorSpy.mock.calls[0].join(' ');
+    expect(logged).toContain('health_check');
+    expect(logged).toContain('Dockhand login failed');
+  });
+
+  it('logs "Unknown error" for a thrown non-Error value without crashing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const server = fakeServer();
+
+    registerTool(server as never, 'get_system_info', 'desc', {}, async () => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'boom';
+    });
+
+    const result = await server.tools.get('get_system_info')!.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Unknown error');
+    const logged = errorSpy.mock.calls[0].join(' ');
+    expect(logged).toContain('get_system_info');
+    expect(logged).toContain('Unknown error');
+  });
+
+  it('does not log anything when the callback succeeds (happy path)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const server = fakeServer();
+
+    registerTool(server as never, 'get_host_info', 'desc', { id: z.number() }, async ({ id }) => {
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ id }) }] };
+    });
+
+    const result = await server.tools.get('get_host_info')!.handler({ id: 42 });
+
+    expect(result.isError).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('propagates a network-error message from a rejected client call and still logs it', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const server = fakeServer();
+
+    registerTool(server as never, 'list_containers', 'desc', {}, async () => {
+      throw new Error('fetch failed: ECONNREFUSED 100.100.200.50:443');
+    });
+
+    const result = await server.tools.get('list_containers')!.handler({});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('ECONNREFUSED');
+    expect(errorSpy.mock.calls[0].join(' ')).toContain('ECONNREFUSED');
+  });
+});

--- a/tests/url-normalize.test.ts
+++ b/tests/url-normalize.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { describeLoginFailure, normalizeBaseUrl } from '../src/utils/url.js';
+
+describe('normalizeBaseUrl', () => {
+  it('leaves a URL without a trailing slash untouched', () => {
+    expect(normalizeBaseUrl('https://dockhand.example.com')).toBe('https://dockhand.example.com');
+  });
+
+  it('strips a single trailing slash', () => {
+    expect(normalizeBaseUrl('https://dockhand.example.com/')).toBe('https://dockhand.example.com');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeBaseUrl('https://dockhand.example.com///')).toBe('https://dockhand.example.com');
+  });
+
+  it('does not touch slashes that are part of the path', () => {
+    expect(normalizeBaseUrl('https://dockhand.example.com/dockhand/')).toBe(
+      'https://dockhand.example.com/dockhand',
+    );
+  });
+});
+
+describe('describeLoginFailure', () => {
+  it('builds an actionable hint for a redirect with a Location header', () => {
+    const message = describeLoginFailure(307, '/login?redirect=%2Fapi%2Fauth%2Flogin', '', 'Temporary Redirect');
+    expect(message).toContain('/login?redirect=%2Fapi%2Fauth%2Flogin');
+    expect(message).toContain('trailing slash');
+    expect(message).toContain('reverse-proxy');
+  });
+
+  it('builds a hint for a redirect without a Location header', () => {
+    const message = describeLoginFailure(307, null, '', 'Temporary Redirect');
+    expect(message).toContain('no Location header');
+    expect(message).toContain('trailing slash');
+  });
+
+  it('falls back to the response body for a non-redirect failure', () => {
+    const message = describeLoginFailure(401, null, '{"error":"Invalid username or password"}', 'Unauthorized');
+    expect(message).toBe('{"error":"Invalid username or password"}');
+  });
+
+  it('falls back to the status text when the body is empty', () => {
+    const message = describeLoginFailure(500, null, '', 'Internal Server Error');
+    expect(message).toBe('Internal Server Error');
+  });
+});


### PR DESCRIPTION
## Summary

Issue #116 reports two symptoms with a complex `DOCKHAND_PASSWORD` (special characters):

1. Login fails with `HTTP 307: Temporary Redirect` (or a generic tool-execution error), while the *exact same credentials* succeed via a manual `wget --post-data` login from inside the same container.
2. No log line at all appears in `docker logs mcp-dockhand`, even with `LOG_LEVEL=debug` set — there's no way to diagnose the failure from container logs alone.

## Root-cause investigation (against the real code, not assumption)

**Password-encoding hypothesis does not hold up.** `SessionManager.performLogin()` (`src/auth/session.ts`) builds the login body via plain `JSON.stringify({ username, password, provider: 'local' })`. `JSON.stringify` escapes any string content correctly regardless of character set — there's no manual string interpolation, URL-encoding, or shell step involved anywhere between reading `process.env.DOCKHAND_PASSWORD` (`src/index.ts`) and this call. A new regression test sends a password containing `"`, `\`, `$`, `!`, `&`, `#`, backticks, `<`/`>`, and unicode, and asserts it arrives byte-for-byte in the JSON body — it already passes against the pre-fix code, confirming this path was never the actual bug.

**Found instead: a real, reproducible cause for the exact reported `HTTP 307` symptom, independent of password content.**

`DockhandClient`'s constructor already normalizes the base URL (`config.url.replace(/\/+$/, '')`) before building request URLs via `new URL(path, baseUrl)`. `SessionManager.performLogin()` did **not** — it built the login URL as `` `${this.config.url}/api/auth/login` `` directly from the raw config value. A `DOCKHAND_URL` with a trailing slash (e.g. `https://host/`, a very common way to set an env var) therefore produced `https://host//api/auth/login` — a double-slash path.

Checked against the real upstream handler (`Finsys/dockhand`, `src/hooks.server.ts`):

```ts
const PUBLIC_PATHS = ['/login', '/api/auth/login', /* ... */];
function isPublicPath(pathname: string): boolean {
  return PUBLIC_PATHS.some(path => pathname === path || pathname.startsWith(path + '/'));
}
// ...
if (isPublicPath(event.url.pathname)) { /* let it through, unauthenticated */ }
if (!user) {
  if (event.url.pathname.startsWith('/api/')) { /* return 401 JSON */ }
  // UI routes:
  redirect(307, `/login?redirect=${redirectUrl}`);
}
```
https://github.com/Finsys/dockhand/blob/main/src/hooks.server.ts

`isPublicPath('//api/auth/login')` is `false` (`'//api/auth/login' !== '/api/auth/login'` and it doesn't start with `'/api/auth/login/'`), **and** `'//api/auth/login'.startsWith('/api/')` is also `false` (it starts with `'//'`). The request falls through both branches and hits the UI-route fallback: `redirect(307, '/login?redirect=...')`. That is exactly `HTTP 307: Temporary Redirect` with an empty body — matching the issue's first failure mode precisely.

This also explains why a manual `wget` test against the same public URL from inside the container can succeed while the app's own request fails: `wget --post-data=... https://<domain>/api/auth/login` (typed by hand, no trailing slash) never has the double-slash defect that only affects the URL `SessionManager` builds from `config.url`.

## Fixes

- **`src/utils/url.ts` (new):** `normalizeBaseUrl()` shared by `DockhandClient` and `SessionManager` — one normalization path instead of two independent (and inconsistent) ones. `describeLoginFailure()` turns a 3xx login response into an actionable message: it surfaces the `Location` header and hints at a trailing-slash/reverse-proxy misconfiguration, instead of the previous opaque `HTTP 307: Temporary Redirect`.
- **`src/auth/session.ts`:** uses `normalizeBaseUrl()` for the login URL; on a failed login, calls `console.error(...)` with the diagnostic detail **before** throwing.
- **`src/utils/tool-helper.ts`:** `registerTool()`'s catch block now always logs `[tool:<name>] <message>` via `console.error` before returning the structured MCP error response. This is the actual fix for the "no log output at all" complaint — `registerTool` is the single chokepoint every tool callback runs through (including the lazy first-login triggered by any tool's first `client.get()`/`client.post()` call), and it never logged anything at all. `LOG_LEVEL` is not read anywhere in this codebase (confirmed via grep) — it was a no-op in the reporter's compose file regardless of value.

## Test plan

- [x] TDD: every behavioral change has a failing test first (RED) — see the two commits' worth of `npx vitest run` output during development (double-slash URL, redirect-diagnostic message + logging, tool-error logging).
- [x] `npx vitest run` — 487/487 tests pass (23 files), including 3 new test files (`tests/url-normalize.test.ts`, `tests/session-login.test.ts`, `tests/tool-error-logging.test.ts`).
- [x] `src/auth/session.ts` coverage: 97.61% statements / 91.66% branches / 100% lines (was 0% before this PR).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` clean.
- [x] `node scripts/validate-mcp-tools.mjs` — OK, no new PARAM_MISMATCH/ORPHANED_TOOL introduced.
- [ ] `npm run lint` — not runnable in the dev sandbox this PR was prepared in (`eslint: not found`; it's referenced by the `lint` script but isn't a project devDependency, so this is a pre-existing environment gap unrelated to this change).

Refs #116

