### PR TITLE
docs(tools): name accepted in-place fields for update_container_runtime

### DIFF
--- a/src/tools/containers.ts
+++ b/src/tools/containers.ts
@@ -43,6 +43,44 @@ const UPDATE_CONTAINER_ALLOWED_SETTINGS_KEYS = new Set([
   'usernsMode', 'domainname',
 ]);
 
+/**
+ * Fields accepted by `update_container_runtime`'s in-place update, i.e.
+ * Docker's `POST /containers/{id}/update` — the only Docker API that
+ * changes container properties without recreating the container.
+ *
+ * Source of truth: Finsys/dockhand v1.0.41 (commit 905c4a0),
+ * `IN_PLACE_UPDATE_FIELDS` in src/lib/server/docker.ts:1236-1280. Dockhand
+ * filters the request body against exactly this allowlist server-side and
+ * silently drops anything outside it (not an error) — by design, so a
+ * caller cannot sneak a recreate-only field (image, env, ports, ...)
+ * through this path (src/routes/api/containers/[id]/update-runtime/+server.ts).
+ *
+ * This tool still sends `config` unfiltered (`z.record`) and lets the
+ * server enforce the allowlist (#155 keeps this non-breaking) — this
+ * constant exists only to name the accepted keys in the tool/schema
+ * description below, and to anchor the regression test in
+ * tests/update-container-runtime-fields.test.ts.
+ *
+ * Update this list (and the description strings below) when re-validating
+ * against a newer Dockhand release
+ * (.claude/skills/dockhand-mcp-dev/references/upstream-validation.md).
+ */
+export const UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS = [
+  // Restart policy — the headline use case (dockhand#1153)
+  'RestartPolicy',
+  // CPU
+  'CpuShares', 'CpuPeriod', 'CpuQuota', 'CpuRealtimePeriod', 'CpuRealtimeRuntime',
+  'CpusetCpus', 'CpusetMems', 'NanoCpus',
+  // Memory
+  'Memory', 'MemorySwap', 'MemoryReservation', 'MemorySwappiness', 'KernelMemory',
+  // Block I/O
+  'BlkioWeight', 'BlkioWeightDevice',
+  'BlkioDeviceReadBps', 'BlkioDeviceWriteBps',
+  'BlkioDeviceReadIOps', 'BlkioDeviceWriteIOps',
+  // Misc
+  'PidsLimit',
+] as const;
+
 export function registerContainerTools(server: McpServer, client: DockhandClient): void {
 
   registerTool(server, 'list_containers', 'List all containers in a Dockhand environment, returning summary fields for every container; use `get_container` for a single container\'s details or `inspect_container` for the full low-level Docker JSON.',
@@ -474,11 +512,11 @@ export function registerContainerTools(server: McpServer, client: DockhandClient
     }
   );
 
-  registerTool(server, 'update_container_runtime', 'Update the runtime configuration (e.g. resource limits, restart policy) of an existing container in place; for image or environment changes use `update_container`, and for lifecycle actions see `restart_container`.',
+  registerTool(server, 'update_container_runtime', 'Update the runtime configuration (restart policy, CPU/memory limits, block I/O weights, pids limit) of an existing container in place via Docker native update API, never recreating the container. Accepts config keys RestartPolicy, CpuShares, CpuPeriod, CpuQuota, CpuRealtimePeriod, CpuRealtimeRuntime, CpusetCpus, CpusetMems, NanoCpus, Memory, MemorySwap, MemoryReservation, MemorySwappiness, KernelMemory, BlkioWeight, BlkioWeightDevice, BlkioDeviceReadBps, BlkioDeviceWriteBps, BlkioDeviceReadIOps, BlkioDeviceWriteIOps, PidsLimit; any other key is silently ignored by the server, not an error. For image or environment changes use `update_container`, and for lifecycle actions see `restart_container`.',
     {
       containerId: z.string().describe('Container ID or name'),
       environmentId: z.number().describe('Environment ID'),
-      config: z.record(z.string(), z.unknown()).describe('Runtime configuration to apply'),
+      config: z.record(z.string(), z.unknown()).describe('Runtime configuration to apply. Accepted keys (Docker in-place update allowlist): RestartPolicy, CpuShares, CpuPeriod, CpuQuota, CpuRealtimePeriod, CpuRealtimeRuntime, CpusetCpus, CpusetMems, NanoCpus, Memory, MemorySwap, MemoryReservation, MemorySwappiness, KernelMemory, BlkioWeight, BlkioWeightDevice, BlkioDeviceReadBps, BlkioDeviceWriteBps, BlkioDeviceReadIOps, BlkioDeviceWriteIOps, PidsLimit. Any other key is silently ignored by the server, not an error.'),
     },
     async ({ containerId, environmentId, config }) => {
       return jsonResponse(await client.post(`/api/containers/${encodePath(containerId)}/update-runtime`, config, { env: environmentId }));

--- a/tests/update-container-runtime-fields.test.ts
+++ b/tests/update-container-runtime-fields.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for #155 (DX follow-up to #142/#154).
+ *
+ * `update_container_runtime` wraps Dockhand's in-place container update
+ * (`POST /api/containers/{id}/update-runtime`, Finsys/dockhand v1.0.41,
+ * `IN_PLACE_UPDATE_FIELDS` in src/lib/server/docker.ts:1236-1280). The
+ * server-side allowlist was already correctly enforced (unknown keys are
+ * silently dropped, never an error, never a recreate — see #155's
+ * re-scoping) — but the MCP tool's `config` schema was a bare
+ * `z.record(z.string(), z.unknown())` and neither the tool description nor
+ * the `config` parameter description named a single accepted field, even
+ * though upstream documents the exact list.
+ *
+ * These tests lock in the fix: both descriptions now name every accepted
+ * field, sourced from the exported `UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS`
+ * constant (single source of truth, see the comment above it in
+ * src/tools/containers.ts), and the schema stays non-breaking — it still
+ * accepts arbitrary keys and lets the server enforce the allowlist, exactly
+ * as it did before #155.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import {
+  registerContainerTools,
+  UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS,
+} from '../src/tools/containers.js';
+
+interface Registration {
+  description: string;
+  schema: Record<string, z.ZodTypeAny>;
+}
+
+/**
+ * Register the container tools against a fake MCP server that captures each
+ * tool's (name, description, schema) triple. Mirrors the fixture in
+ * tests/update-container-contract.test.ts, extended to also capture the
+ * schema so the `config` field's `.describe()` text can be inspected.
+ */
+function captureRegistrations(): Map<string, Registration> {
+  const registrations = new Map<string, Registration>();
+  const server = {
+    tool: (name: string, description: string, schema: Record<string, z.ZodTypeAny>) => {
+      registrations.set(name, { description, schema });
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerContainerTools(server as any, {} as any);
+  return registrations;
+}
+
+describe('update_container_runtime — accepted field names surfaced (#155)', () => {
+  const registrations = captureRegistrations();
+  const registration = registrations.get('update_container_runtime');
+  const expectedFieldList = UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS.join(', ');
+
+  it('is registered', () => {
+    expect(registration).toBeDefined();
+  });
+
+  it('tool description names every accepted field from the upstream allowlist, in the documented order', () => {
+    expect(registration?.description).toContain(expectedFieldList);
+  });
+
+  it('config parameter description names every accepted field from the upstream allowlist, in the documented order', () => {
+    const configDescription = registration?.schema.config?.description;
+    expect(configDescription).toBeDefined();
+    expect(configDescription).toContain(expectedFieldList);
+  });
+
+  it('the accepted-fields constant matches the real Dockhand IN_PLACE_UPDATE_FIELDS allowlist (Finsys/dockhand v1.0.41, docker.ts:1236-1280)', () => {
+    // Regression guard: if this list and the upstream allowlist ever
+    // diverge, update_container_runtime documents fields the server does
+    // not accept, or omits fields it does. Keep this list, and the
+    // description strings in src/tools/containers.ts, in sync per
+    // .claude/skills/dockhand-mcp-dev/references/upstream-validation.md.
+    expect([...UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS]).toEqual([
+      'RestartPolicy',
+      'CpuShares', 'CpuPeriod', 'CpuQuota', 'CpuRealtimePeriod', 'CpuRealtimeRuntime',
+      'CpusetCpus', 'CpusetMems', 'NanoCpus',
+      'Memory', 'MemorySwap', 'MemoryReservation', 'MemorySwappiness', 'KernelMemory',
+      'BlkioWeight', 'BlkioWeightDevice',
+      'BlkioDeviceReadBps', 'BlkioDeviceWriteBps',
+      'BlkioDeviceReadIOps', 'BlkioDeviceWriteIOps',
+      'PidsLimit',
+    ]);
+  });
+
+  it('config schema still accepts arbitrary keys — non-breaking, the server enforces the allowlist, not the client (#155 explicitly keeps this out of scope, see #142\'s counterexample reasoning)', () => {
+    const configSchema = registration?.schema.config;
+    expect(configSchema).toBeDefined();
+    const parsed = configSchema?.parse({
+      RestartPolicy: { Name: 'always' },
+      SomeFutureDockerField: 42,
+    });
+    expect(parsed).toEqual({ RestartPolicy: { Name: 'always' }, SomeFutureDockerField: 42 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #155 (item 1 only — see below for item 2).

`update_container_runtime`'s `config` schema was a bare `z.record(z.string(), z.unknown())` with no indication of which keys actually take effect, even though Dockhand documents them precisely: [`IN_PLACE_UPDATE_FIELDS`](https://github.com/Finsys/dockhand/blob/v1.0.41/src/lib/server/docker.ts#L1236-L1280) (`Finsys/dockhand` v1.0.41, commit `905c4a0`).

- Added an exported `UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS` constant (source of truth, same pattern already established for `UPDATE_CONTAINER_ALLOWED_SETTINGS_KEYS` next to it) listing all 21 accepted fields, grouped and commented exactly as upstream: restart policy, CPU, memory, block I/O, misc (`PidsLimit`).
- Named every field in both the tool description and the `config` parameter description.
- Added a note that unknown keys are silently ignored by the server (not an error) — matching the real handler behavior confirmed in #155's re-scoping.

**Non-breaking, discoverability-only:** the `config` schema itself stays `z.record` — it still accepts arbitrary keys. The server ([`update-runtime/+server.ts`](https://github.com/Finsys/dockhand/blob/v1.0.41/src/routes/api/containers/%5Bid%5D/update-runtime/%2Bserver.ts)) already enforces the allowlist and silently drops anything outside it, so no client-side validation was added — this PR only makes the accepted fields visible to whoever calls the tool.

Item 2 from #155 (surfacing which keys were dropped on a partially-valid payload) is **out of scope** here — the issue itself notes the upstream response doesn't return that information, so it's not fixable client-side without an upstream change.

## Test plan

- [x] New `tests/update-container-runtime-fields.test.ts`: asserts the tool description and the `config` parameter description both name every field from `UPDATE_CONTAINER_RUNTIME_ACCEPTED_FIELDS` in order; pins the constant itself against the real upstream allowlist as a drift guard; confirms the schema still accepts arbitrary keys (non-breaking).
- [x] `npx vitest run` — 25 test files, 494 tests, all green (including the pre-existing `tests/tool-descriptions.test.ts` static-analysis audit, unaffected by the longer description strings).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean.
- [x] `node scripts/validate-mcp-tools.mjs` — 0 `ORPHANED_TOOL`, 0 `PARAM_MISMATCH`, 0 `MISSING_ENCODE`; unrelated pre-existing `MISSING_TOOL` warnings only.

Field list independently re-verified against `Finsys/dockhand` tag `v1.0.41` (commit `905c4a004dafe1cbad4ed2babc2c532d7f4018b8`, matches the commit cited in #155) in an isolated clone before writing this PR.

Refs #142, #154.