### PR TITLE
docs: auto-generated API coverage report (replaces dead sticky-issue tracker)

### DIFF
--- a/.github/workflows/api-schema-sync.yml
+++ b/.github/workflows/api-schema-sync.yml
@@ -50,66 +50,25 @@ jobs:
         run: node scripts/validate-mcp-tools.mjs
         continue-on-error: true
 
-      - name: Update sticky coverage tracker
-        if: always() && hashFiles('validation-report.md') != ''
-        uses: actions/github-script@v9
-        env:
-          REPORT_PATH: validation-report.md
-          MARKER_START: '<!-- validator-report:start -->'
-          MARKER_END: '<!-- validator-report:end -->'
-        with:
-          script: |
-            const fs = require('fs');
+      - name: Generate coverage doc
+        # Läuft unabhängig davon, ob Validate kritische Mismatches gefunden hat (z.B.
+        # ORPHANED_TOOL) — die Coverage-Übersicht (COVERED/MISSING_TOOL) ist davon
+        # unabhängig und soll trotzdem aktuell bleiben.
+        if: always()
+        run: node scripts/generate-coverage-doc.mjs
 
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'coverage-tracker',
-              state: 'open',
-              per_page: 5,
-            });
-
-            if (issues.data.length === 0) {
-              core.warning('No open issue with label "coverage-tracker" found — skipping sticky update.');
-              return;
-            }
-            if (issues.data.length > 1) {
-              const nums = issues.data.map(i => `#${i.number}`).join(', ');
-              core.warning(`Multiple issues carry label "coverage-tracker" (${nums}). Skipping update to avoid clobbering.`);
-              return;
-            }
-
-            const issue = issues.data[0];
-            const body = issue.body || '';
-            const startMarker = process.env.MARKER_START;
-            const endMarker = process.env.MARKER_END;
-            const pattern = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}`);
-
-            if (!pattern.test(body)) {
-              core.warning(`Issue #${issue.number} has no validator-report markers — skipping update.`);
-              return;
-            }
-
-            const report = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
-            const today = new Date().toISOString().split('T')[0];
-            const runLink = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const stamp = `> _Last sync: ${today} — [run log](${runLink})_\n\n`;
-            const replacement = `${startMarker}\n${stamp}${report}\n${endMarker}`;
-            const newBody = body.replace(pattern, replacement);
-
-            if (newBody === body) {
-              core.info(`Issue #${issue.number} already up to date — no change.`);
-              return;
-            }
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              body: newBody,
-            });
-
-            core.info(`Updated sticky coverage tracker issue #${issue.number}`);
+      - name: Commit coverage doc update
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet docs/coverage.md; then
+            git add docs/coverage.md
+            git commit -m "docs: update API coverage report (automated)"
+            git push
+          else
+            echo "docs/coverage.md unverändert — kein Commit"
+          fi
 
       - name: Create issue on validation failure
         if: steps.validate.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/Docker-ghcr.io-blue)](https://github.com/strausmann/mcp-dockhand/pkgs/container/mcp-dockhand)
 
-An MCP (Model Context Protocol) server that exposes **130+ Dockhand API endpoints** as MCP tools. Manage your entire Docker infrastructure through AI assistants.
+An MCP (Model Context Protocol) server that exposes the Dockhand API as MCP tools. Manage your entire Docker infrastructure through AI assistants.
+
+**API coverage:** 88.7% of in-scope Dockhand endpoints (282/318) have an MCP tool — see [`docs/coverage.md`](docs/coverage.md) for the full, auto-updated breakdown by area.
 
 [Dockhand](https://github.com/fnsys/dockhand) is a Docker management server that connects to multiple Docker hosts via Hawser agents. This MCP server provides full programmatic access to all Dockhand features.
 
 ## Features
 
-- **130+ MCP Tools** covering all Dockhand API endpoints
+- **280+ MCP Tools** covering the Dockhand API — see [`docs/coverage.md`](docs/coverage.md) for exact, auto-updated coverage
 - **Streamable HTTP Transport** (MCP Spec 2025-03-26) for Docker container hosting
 - **Session-based Auth** with auto-relogin on 401
 - **SSE Support** for deploy operations (start, stop, down, restart)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,98 @@
+# MCP-Dockhand — API-Coverage
+
+> **Auto-generiert** von `scripts/generate-coverage-doc.mjs` — nicht von Hand editieren.
+> Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
+> Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
+
+**Erzeugt:** 2026-08-10T09:28:04.886Z
+**Dockhand-Upstream-Commit:** `905c4a004dafe1cbad4ed2babc2c532d7f4018b8`
+**Schema-Endpunkte gesamt:** 235
+
+## Coverage
+
+**88.7%** (282/318 in-Scope-Endpunkte haben ein MCP-Tool)
+
+| Status | Anzahl |
+|--------|--------|
+| COVERED | 282 |
+| MISSING_TOOL | 36 |
+| ORPHANED_TOOL | 0 |
+| Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |
+
+## MISSING_TOOL — nach Bereich
+
+Endpunkte, die laut Schema existieren, aber (noch) kein MCP-Tool haben — gruppiert nach dem
+ersten Pfad-Segment nach `/api/`:
+
+### backup (29)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/backup/configs` | - |
+| POST | `/api/backup/configs` | - |
+| DELETE | `/api/backup/configs/{id}` | id |
+| GET | `/api/backup/configs/{id}` | id |
+| PUT | `/api/backup/configs/{id}` | id |
+| POST | `/api/backup/configs/{id}/run` | id |
+| POST | `/api/backup/configs/{id}/stop` | id |
+| GET | `/api/backup/destinations` | - |
+| POST | `/api/backup/destinations` | - |
+| DELETE | `/api/backup/destinations/{id}` | id |
+| GET | `/api/backup/destinations/{id}` | id |
+| PUT | `/api/backup/destinations/{id}` | id |
+| POST | `/api/backup/destinations/{id}/init` | id |
+| POST | `/api/backup/destinations/{id}/rotate-key` | id |
+| POST | `/api/backup/destinations/{id}/task` | id |
+| POST | `/api/backup/destinations/{id}/test` | id |
+| POST | `/api/backup/destinations/{id}/verify` | id |
+| POST | `/api/backup/destinations/test` | - |
+| POST | `/api/backup/restore` | - |
+| POST | `/api/backup/restore/preview` | - |
+| POST | `/api/backup/restore/stop` | - |
+| GET | `/api/backup/snapshots` | - |
+| DELETE | `/api/backup/snapshots/{id}` | id |
+| GET | `/api/backup/snapshots/{id}/browse` | id |
+| GET | `/api/backup/snapshots/{id}/dump` | id |
+| GET | `/api/backup/snapshots/{id}/metadata` | id |
+| GET | `/api/backup/snapshots/diff` | - |
+| GET | `/api/backup/stack-dir-listing` | - |
+| GET | `/api/backup/stack-path` | - |
+
+### environments (2)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/environments/{id}/remote-stacks-dir` | id |
+| POST | `/api/environments/{id}/remote-stacks-dir` | id |
+
+### git (1)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| POST | `/api/git/stacks/{id}/webhook` | id |
+
+### registry (1)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/registry/tag-info` | - |
+
+### settings (2)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/settings/navigation` | - |
+| PUT | `/api/settings/navigation` | - |
+
+### stacks (1)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/stacks/{name}/delete-preview` | name |
+
+## Details
+
+Der vollständige Report inkl. aller COVERED-Endpunkte und weiterer Prüfungen
+(PARAM_MISMATCH, MISSING_ENCODE, QUERY_PARAM_*) entsteht bei jedem Lauf von
+`node scripts/validate-mcp-tools.mjs` als `validation-report.md` (nicht eingecheckt).
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-dockhand",
   "version": "1.11.0",
-  "description": "MCP Server for Dockhand Docker Management - exposes 130+ API endpoints as MCP tools",
+  "description": "MCP Server for Dockhand Docker Management - exposes the Dockhand API as MCP tools (see docs/coverage.md for exact coverage)",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
@@ -13,6 +13,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "api:extract": "node scripts/extract-dockhand-api.mjs",
+    "api:validate": "node scripts/validate-mcp-tools.mjs",
+    "api:coverage-doc": "node scripts/generate-coverage-doc.mjs",
     "prepare": "husky"
   },
   "keywords": [

--- a/scripts/generate-coverage-doc.mjs
+++ b/scripts/generate-coverage-doc.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * Coverage-Doc-Generator
+ *
+ * Erzeugt `docs/coverage.md` — die eingecheckte, dauerhaft sichtbare API-Coverage-
+ * Übersicht (Ablösung des toten Sticky-Issue-#60-Mechanismus, siehe api-schema-sync.yml).
+ *
+ * Nutzt dieselbe Berechnung wie `validate-mcp-tools.mjs` (`computeValidation()`), damit
+ * die Zahlen garantiert übereinstimmen. Schreibt IMMER (auch wenn validate-mcp-tools.mjs
+ * kritische Mismatches findet und mit Exit 1 abbricht) — Coverage-Sichtbarkeit soll nicht
+ * an einem unabhängigen Fehler (z.B. ORPHANED_TOOL) hängen.
+ *
+ * Verwendung:
+ *   node scripts/generate-coverage-doc.mjs
+ */
+
+import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadSchema, extractToolCalls, computeValidation } from './validate-mcp-tools.mjs';
+import { buildCoverageDoc } from './lib/coverage-report.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = resolve(__dirname, '..');
+const COVERAGE_DOC = join(PROJECT_ROOT, 'docs', 'coverage.md');
+
+// Die Zeile mit dem Erzeugungs-Zeitstempel — beim Vergleich "hat sich der Inhalt
+// wirklich geändert?" ausgeblendet, analog zu extract-dockhand-api.mjs (dort
+// `generatedAt: ''`), sonst würde JEDER Lauf (z.B. der tägliche Cron) einen Commit
+// erzeugen, obwohl sich an Coverage/Endpunkten nichts geändert hat.
+const TIMESTAMP_LINE = /^\*\*Erzeugt:\*\* .*$/m;
+
+function stripTimestamp(content) {
+  return content.replace(TIMESTAMP_LINE, '**Erzeugt:** <normalized>');
+}
+
+function main() {
+  const schema = loadSchema();
+  const toolCalls = extractToolCalls();
+  const { covered, missingTool, orphanedTool, excludedCount } = computeValidation(schema, toolCalls);
+
+  const doc = buildCoverageDoc({
+    generatedAt: new Date().toISOString(),
+    sourceCommit: schema.sourceCommit,
+    schemaEndpointCount: schema.endpointCount,
+    covered,
+    missingTool,
+    orphanedTool,
+    excludedCount,
+  });
+
+  const inScope = covered.length + missingTool.length;
+  const percent = inScope === 0 ? '0.0' : ((covered.length / inScope) * 100).toFixed(1);
+
+  if (existsSync(COVERAGE_DOC)) {
+    const existing = readFileSync(COVERAGE_DOC, 'utf8');
+    if (stripTimestamp(existing) === stripTimestamp(doc)) {
+      console.error(`[coverage-doc] Unverändert (${percent}%, ${covered.length}/${inScope}) — kein Schreibvorgang`);
+      return;
+    }
+  }
+
+  writeFileSync(COVERAGE_DOC, doc, 'utf8');
+  console.error(`[coverage-doc] Geschrieben: ${COVERAGE_DOC}`);
+  console.error(`[coverage-doc] Coverage: ${percent}% (${covered.length}/${inScope})`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { main, stripTimestamp };

--- a/scripts/lib/coverage-report.mjs
+++ b/scripts/lib/coverage-report.mjs
@@ -1,0 +1,157 @@
+/**
+ * Reine Markdown-Erzeugung für docs/coverage.md — die eingecheckte, dauerhaft
+ * sichtbare Coverage-Übersicht (Gegenstück zum flüchtigen, gitignoreten
+ * `validation-report.md`).
+ *
+ * Alle Funktionen hier sind reine Funktionen ohne I/O: sie nehmen die bereits von
+ * `validate-mcp-tools.mjs` berechneten Buckets (`computeValidation()`) entgegen und
+ * bauen daraus Markdown. Der eigentliche Datei-Schreib-Vorgang lebt in
+ * `generate-coverage-doc.mjs`.
+ */
+
+/**
+ * Extrahiert den "Bereich" (erstes Pfad-Segment nach /api/) aus einem Endpoint-Pfad,
+ * z.B. `/api/backup/schedule` → `backup`, `/api/stacks/{id}/env` → `stacks`.
+ * @param {string} path
+ * @returns {string}
+ */
+function areaOf(path) {
+  const match = path.match(/^\/api\/([^/]+)/);
+  return match ? match[1] : path;
+}
+
+/**
+ * Gruppiert MISSING_TOOL-Einträge nach Bereich, alphabetisch sortiert. Innerhalb eines
+ * Bereichs werden die Einträge nach Pfad, dann nach HTTP-Methode sortiert.
+ * @param {Array<{path: string, method: string, pathParams?: string[]}>} missingTool
+ * @returns {Array<{area: string, entries: Array}>}
+ */
+function groupMissingByArea(missingTool) {
+  const byArea = new Map();
+  for (const entry of missingTool) {
+    const area = areaOf(entry.path);
+    if (!byArea.has(area)) byArea.set(area, []);
+    byArea.get(area).push(entry);
+  }
+
+  const areas = [...byArea.keys()].sort((a, b) => a.localeCompare(b));
+  return areas.map((area) => {
+    const entries = byArea
+      .get(area)
+      .slice()
+      .sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
+    return { area, entries };
+  });
+}
+
+/**
+ * Baut den vollständigen Markdown-Inhalt von docs/coverage.md.
+ * @param {object} input
+ * @param {string} input.generatedAt ISO-Timestamp der Erzeugung
+ * @param {string} input.sourceCommit Voller Dockhand-Upstream-Commit-Hash aus dem Schema
+ * @param {number} input.schemaEndpointCount Gesamtzahl der Endpunkte im Schema (inkl. ausgeschlossener)
+ * @param {Array<{path: string, method: string, tools: string[]}>} input.covered
+ * @param {Array<{path: string, method: string, pathParams?: string[]}>} input.missingTool
+ * @param {Array<{toolName: string, httpMethod: string, path: string, file: string, line: number}>} input.orphanedTool
+ * @param {number} input.excludedCount Anzahl bewusst ausgeschlossener Endpunkte (IGNORED_PATTERNS)
+ * @returns {string}
+ */
+function buildCoverageDoc({
+  generatedAt,
+  sourceCommit,
+  schemaEndpointCount,
+  covered,
+  missingTool,
+  orphanedTool,
+  excludedCount,
+}) {
+  const inScope = covered.length + missingTool.length;
+  const percent = inScope === 0 ? 0 : (covered.length / inScope) * 100;
+  const percentStr = percent.toFixed(1);
+
+  const lines = [];
+
+  lines.push('# MCP-Dockhand — API-Coverage');
+  lines.push('');
+  lines.push(
+    '> **Auto-generiert** von `scripts/generate-coverage-doc.mjs` — nicht von Hand editieren.'
+  );
+  lines.push(
+    '> Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei'
+  );
+  lines.push('> Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.');
+  lines.push('');
+  lines.push(`**Erzeugt:** ${generatedAt}`);
+  lines.push(`**Dockhand-Upstream-Commit:** \`${sourceCommit}\``);
+  lines.push(`**Schema-Endpunkte gesamt:** ${schemaEndpointCount}`);
+  lines.push('');
+
+  lines.push('## Coverage');
+  lines.push('');
+  lines.push(`**${percentStr}%** (${covered.length}/${inScope} in-Scope-Endpunkte haben ein MCP-Tool)`);
+  lines.push('');
+  lines.push('| Status | Anzahl |');
+  lines.push('|--------|--------|');
+  lines.push(`| COVERED | ${covered.length} |`);
+  lines.push(`| MISSING_TOOL | ${missingTool.length} |`);
+  lines.push(`| ORPHANED_TOOL | ${orphanedTool.length} |`);
+  lines.push(`| Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | ${excludedCount} |`);
+  lines.push('');
+
+  if (missingTool.length > 0) {
+    lines.push('## MISSING_TOOL — nach Bereich');
+    lines.push('');
+    lines.push(
+      'Endpunkte, die laut Schema existieren, aber (noch) kein MCP-Tool haben — gruppiert nach dem'
+    );
+    lines.push('ersten Pfad-Segment nach `/api/`:');
+    lines.push('');
+
+    const grouped = groupMissingByArea(missingTool);
+    for (const { area, entries } of grouped) {
+      lines.push(`### ${area} (${entries.length})`);
+      lines.push('');
+      lines.push('| HTTP | Pfad | Path-Parameter |');
+      lines.push('|------|------|----------------|');
+      for (const e of entries) {
+        lines.push(`| ${e.method} | \`${e.path}\` | ${e.pathParams?.join(', ') || '-'} |`);
+      }
+      lines.push('');
+    }
+  } else {
+    lines.push('## MISSING_TOOL');
+    lines.push('');
+    lines.push('Keine — alle in-Scope-Endpunkte haben ein MCP-Tool.');
+    lines.push('');
+  }
+
+  if (orphanedTool.length > 0) {
+    lines.push('## ORPHANED_TOOL');
+    lines.push('');
+    lines.push(
+      'MCP-Tools, die einen Endpunkt referenzieren, der laut Schema nicht (mehr) existiert:'
+    );
+    lines.push('');
+    lines.push('| Tool | HTTP | Pfad | Datei |');
+    lines.push('|------|------|------|-------|');
+    for (const t of orphanedTool) {
+      lines.push(`| \`${t.toolName}\` | ${t.httpMethod} | \`${t.path}\` | ${t.file}:${t.line} |`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Details');
+  lines.push('');
+  lines.push(
+    'Der vollständige Report inkl. aller COVERED-Endpunkte und weiterer Prüfungen'
+  );
+  lines.push(
+    '(PARAM_MISMATCH, MISSING_ENCODE, QUERY_PARAM_*) entsteht bei jedem Lauf von'
+  );
+  lines.push('`node scripts/validate-mcp-tools.mjs` als `validation-report.md` (nicht eingecheckt).');
+  lines.push('');
+
+  return lines.join('\n') + '\n';
+}
+
+export { areaOf, groupMissingByArea, buildCoverageDoc };

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -307,16 +307,46 @@ function diffQueryParams(sentKeys, schemaParams, { checkMissing }) {
   return { missingRequired, unknown };
 }
 
+// Endpunkte die wir bewusst ignorieren (Streams, Callbacks, interne)
+const IGNORED_PATTERNS = [
+  '/api/auth/login',           // Login wird nicht über MCP gemacht
+  '/api/auth/oidc/callback',   // OAuth Callback
+  '/stream',                   // SSE Streams (werden über postSSE abgedeckt)
+  '/api/debug/',               // Debug-Endpunkte
+  '/api/self-update',          // Self-Update (gefährlich über MCP)
+  '/api/events',               // SSE Event-Stream
+  '/api/jobs/',                // Interne Job-Verwaltung
+  '/api/hawser/connect',       // Hawser Agent-Verbindung
+  '/api/environments/{*}/icon',          // Icon-Upload (binary)
+  '/api/environments/{*}/disk-warning',  // Disk-Warning (intern)
+  '/api/profile/avatar',                 // Avatar-Upload (binary)
+];
+
 /**
- * Hauptvalidierung
+ * Prüft, ob ein Pfad zu den bewusst ausgeschlossenen Endpunkten gehört (Streams,
+ * Callbacks, interne Routen — siehe IGNORED_PATTERNS).
+ * @param {string} path
+ * @returns {boolean}
  */
-function validate() {
-  const schema = loadSchema();
-  const toolCalls = extractToolCalls();
+function isIgnored(path) {
+  const normalized = normalizePath(path);
+  return IGNORED_PATTERNS.some((p) => normalized.includes(p) || normalized === normalizePath(p));
+}
 
-  console.error(`[validate] Schema: ${schema.endpointCount} Endpunkte (Commit: ${schema.sourceCommit.substring(0, 8)})`);
-  console.error(`[validate] MCP Tools: ${toolCalls.length} API-Aufrufe gefunden`);
-
+/**
+ * Reine Berechnung der Validierungs-Buckets aus Schema + extrahierten Tool-Aufrufen —
+ * ohne I/O (kein Datei-Read, kein console.error). Wird sowohl von der CLI-Validierung
+ * (`validate()`) als auch vom Coverage-Doc-Generator (`generate-coverage-doc.mjs`)
+ * genutzt, damit beide garantiert dieselben Zahlen liefern.
+ * @param {object} schema Geladenes docs/dockhand-api-schema.json
+ * @param {Array} toolCalls Rückgabe von extractToolCalls()
+ * @returns {{
+ *   covered: Array, missingTool: Array, orphanedTool: Array, paramMismatch: Array,
+ *   missingEncode: Array, queryParamMissingRequired: Array, queryParamUnknown: Array,
+ *   excludedCount: number
+ * }}
+ */
+function computeValidation(schema, toolCalls) {
   // Baue Lookup-Maps
   const schemaEndpoints = new Map();
   for (const ep of schema.endpoints) {
@@ -343,33 +373,17 @@ function validate() {
   const missingEncode = [];
   const queryParamMissingRequired = [];
   const queryParamUnknown = [];
-
-  // Endpunkte die wir bewusst ignorieren (Streams, Callbacks, interne)
-  const ignoredPatterns = [
-    '/api/auth/login',           // Login wird nicht über MCP gemacht
-    '/api/auth/oidc/callback',   // OAuth Callback
-    '/stream',                   // SSE Streams (werden über postSSE abgedeckt)
-    '/api/debug/',               // Debug-Endpunkte
-    '/api/self-update',          // Self-Update (gefährlich über MCP)
-    '/api/events',               // SSE Event-Stream
-    '/api/jobs/',                // Interne Job-Verwaltung
-    '/api/hawser/connect',       // Hawser Agent-Verbindung
-    '/api/environments/{*}/icon',          // Icon-Upload (binary)
-    '/api/environments/{*}/disk-warning',  // Disk-Warning (intern)
-    '/api/profile/avatar',                 // Avatar-Upload (binary)
-  ];
-
-  function isIgnored(path) {
-    const normalized = normalizePath(path);
-    return ignoredPatterns.some(p => normalized.includes(p) || normalized === normalizePath(p));
-  }
+  let excludedCount = 0;
 
   // 1. Prüfe Schema-Endpunkte → COVERED oder MISSING_TOOL
   for (const ep of schema.endpoints) {
     for (const method of ep.methods) {
       const key = endpointKey(ep.path, method);
 
-      if (isIgnored(ep.path)) continue;
+      if (isIgnored(ep.path)) {
+        excludedCount++;
+        continue;
+      }
 
       if (toolEndpoints.has(key)) {
         covered.push({ path: ep.path, method, tools: toolEndpoints.get(key).map(t => t.toolName) });
@@ -447,6 +461,40 @@ function validate() {
       queryParamUnknown.push({ ...call, queryParam: p });
     }
   }
+
+  return {
+    covered,
+    missingTool,
+    orphanedTool,
+    paramMismatch,
+    missingEncode,
+    queryParamMissingRequired,
+    queryParamUnknown,
+    excludedCount,
+  };
+}
+
+/**
+ * Hauptvalidierung (CLI-Einstiegspunkt: lädt Schema + Tool-Aufrufe von der Platte,
+ * berechnet die Buckets über computeValidation(), schreibt den Report, setzt den
+ * Exit-Code).
+ */
+function validate() {
+  const schema = loadSchema();
+  const toolCalls = extractToolCalls();
+
+  console.error(`[validate] Schema: ${schema.endpointCount} Endpunkte (Commit: ${schema.sourceCommit.substring(0, 8)})`);
+  console.error(`[validate] MCP Tools: ${toolCalls.length} API-Aufrufe gefunden`);
+
+  const {
+    covered,
+    missingTool,
+    orphanedTool,
+    paramMismatch,
+    missingEncode,
+    queryParamMissingRequired,
+    queryParamUnknown,
+  } = computeValidation(schema, toolCalls);
 
   // Report generieren
   const report = generateReport({
@@ -635,6 +683,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   WHITELISTED_QUERY_PARAMS,
+  IGNORED_PATTERNS,
   splitTopLevel,
   extractObjectKey,
   findMatchingClose,
@@ -645,4 +694,7 @@ export {
   endpointKey,
   pathParamsMatch,
   diffQueryParams,
+  isIgnored,
+  computeValidation,
+  loadSchema,
 };

--- a/tests/coverage-report.test.ts
+++ b/tests/coverage-report.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { areaOf, groupMissingByArea, buildCoverageDoc } from '../scripts/lib/coverage-report.mjs';
+
+describe('areaOf', () => {
+  it('extracts the first path segment after /api/', () => {
+    expect(areaOf('/api/backup/schedule')).toBe('backup');
+    expect(areaOf('/api/stacks/{id}/env')).toBe('stacks');
+    expect(areaOf('/api/containers/{id}')).toBe('containers');
+  });
+
+  it('falls back to the full path when there is no /api/ prefix', () => {
+    expect(areaOf('/weird/path')).toBe('/weird/path');
+  });
+
+  it('handles a bare /api/ with no further segment', () => {
+    expect(areaOf('/api/')).toBe('/api/');
+    expect(areaOf('/api')).toBe('/api');
+  });
+});
+
+describe('groupMissingByArea', () => {
+  it('groups entries by area and sorts areas alphabetically', () => {
+    const missing = [
+      { path: '/api/backup/schedule', method: 'GET', pathParams: [] },
+      { path: '/api/stacks/{id}/env', method: 'PUT', pathParams: ['id'] },
+      { path: '/api/backup/restore', method: 'POST', pathParams: [] },
+    ];
+    const grouped = groupMissingByArea(missing);
+    expect(grouped.map((g) => g.area)).toEqual(['backup', 'stacks']);
+    expect(grouped[0].entries).toHaveLength(2);
+    expect(grouped[1].entries).toHaveLength(1);
+  });
+
+  it('sorts entries within an area by path then method', () => {
+    const missing = [
+      { path: '/api/backup/schedule', method: 'POST', pathParams: [] },
+      { path: '/api/backup/schedule', method: 'GET', pathParams: [] },
+      { path: '/api/backup/history', method: 'GET', pathParams: [] },
+    ];
+    const [group] = groupMissingByArea(missing);
+    expect(group.entries.map((e) => `${e.method} ${e.path}`)).toEqual([
+      'GET /api/backup/history',
+      'GET /api/backup/schedule',
+      'POST /api/backup/schedule',
+    ]);
+  });
+
+  it('returns an empty array for no missing endpoints', () => {
+    expect(groupMissingByArea([])).toEqual([]);
+  });
+});
+
+describe('buildCoverageDoc', () => {
+  const baseInput = {
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    sourceCommit: '905c4a004dafe1cbad4ed2babc2c532d7f4018b8',
+    schemaEndpointCount: 235,
+    covered: [
+      { path: '/api/containers', method: 'GET', tools: ['list_containers'] },
+      { path: '/api/containers/{id}', method: 'GET', tools: ['get_container'] },
+    ],
+    missingTool: [
+      { path: '/api/backup/schedule', method: 'GET', pathParams: [] },
+      { path: '/api/backup/restore', method: 'POST', pathParams: [] },
+      { path: '/api/stacks/{id}/env', method: 'PUT', pathParams: ['id'] },
+    ],
+    orphanedTool: [],
+    excludedCount: 11,
+  };
+
+  it('is marked as auto-generated and states the source commit', () => {
+    const doc = buildCoverageDoc(baseInput);
+    expect(doc).toContain('Auto-generiert');
+    expect(doc).toContain('905c4a00');
+  });
+
+  it('computes coverage percentage from covered vs. covered+missing (in-scope endpoints)', () => {
+    // 2 covered + 3 missing = 5 in-scope, 2/5 = 40.0%
+    const doc = buildCoverageDoc(baseInput);
+    expect(doc).toContain('40.0%');
+    expect(doc).toContain('2/5');
+  });
+
+  it('reports 100% when there is no missing tool at all', () => {
+    const doc = buildCoverageDoc({ ...baseInput, missingTool: [] });
+    expect(doc).toContain('100.0%');
+  });
+
+  it('groups MISSING_TOOL entries by area with counts', () => {
+    const doc = buildCoverageDoc(baseInput);
+    expect(doc).toContain('backup');
+    expect(doc).toContain('stacks');
+    // backup area has 2 missing endpoints
+    expect(doc).toMatch(/backup.*\(2\)/);
+    expect(doc).toMatch(/stacks.*\(1\)/);
+  });
+
+  it('lists individual missing endpoints with method and path', () => {
+    const doc = buildCoverageDoc(baseInput);
+    expect(doc).toContain('/api/backup/schedule');
+    expect(doc).toContain('/api/backup/restore');
+    expect(doc).toContain('/api/stacks/{id}/env');
+  });
+
+  it('includes the excluded-endpoints count', () => {
+    const doc = buildCoverageDoc(baseInput);
+    expect(doc).toContain('11');
+  });
+
+  it('includes an ORPHANED_TOOL section only when there are orphaned tools', () => {
+    const clean = buildCoverageDoc(baseInput);
+    expect(clean).not.toContain('## ORPHANED_TOOL');
+
+    const withOrphans = buildCoverageDoc({
+      ...baseInput,
+      orphanedTool: [
+        { toolName: 'ghost_tool', httpMethod: 'GET', path: '/api/removed', file: 'ghost.ts', line: 42 },
+      ],
+    });
+    expect(withOrphans).toContain('ORPHANED_TOOL');
+    expect(withOrphans).toContain('ghost_tool');
+    expect(withOrphans).toContain('ghost.ts:42');
+  });
+
+  it('does not crash when there are no missing endpoints at all', () => {
+    const doc = buildCoverageDoc({ ...baseInput, missingTool: [] });
+    expect(doc).toContain('# ');
+  });
+});

--- a/tests/generate-coverage-doc.test.ts
+++ b/tests/generate-coverage-doc.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { stripTimestamp } from '../scripts/generate-coverage-doc.mjs';
+import { buildCoverageDoc } from '../scripts/lib/coverage-report.mjs';
+
+/**
+ * generate-coverage-doc.mjs schreibt docs/coverage.md nur, wenn sich der Inhalt
+ * (ignoriert man den Erzeugungs-Zeitstempel) tatsächlich geändert hat — sonst würde
+ * jeder tägliche Cron-Lauf einen leeren Commit erzeugen, obwohl sich an
+ * Coverage/Endpunkten nichts geändert hat. Diese Tests decken die dafür genutzte
+ * `stripTimestamp()`-Normalisierung ab (das eigentliche main() macht Datei-I/O gegen
+ * die echten Projektdateien und wird deshalb nicht direkt unit-getestet).
+ */
+
+const baseInput = {
+  sourceCommit: '905c4a004dafe1cbad4ed2babc2c532d7f4018b8',
+  schemaEndpointCount: 235,
+  covered: [{ path: '/api/containers', method: 'GET', tools: ['list_containers'] }],
+  missingTool: [{ path: '/api/backup/schedule', method: 'GET', pathParams: [] }],
+  orphanedTool: [],
+  excludedCount: 11,
+};
+
+describe('stripTimestamp', () => {
+  it('treats two docs that only differ in the "Erzeugt" timestamp as identical', () => {
+    const docA = buildCoverageDoc({ ...baseInput, generatedAt: '2026-08-10T09:00:00.000Z' });
+    const docB = buildCoverageDoc({ ...baseInput, generatedAt: '2026-08-11T05:00:00.000Z' });
+
+    expect(docA).not.toBe(docB); // sanity: they really do differ before normalization
+    expect(stripTimestamp(docA)).toBe(stripTimestamp(docB));
+  });
+
+  it('still treats docs as different when the actual coverage data changed', () => {
+    const docA = buildCoverageDoc({ ...baseInput, generatedAt: '2026-08-10T09:00:00.000Z' });
+    const docB = buildCoverageDoc({
+      ...baseInput,
+      generatedAt: '2026-08-10T09:00:00.000Z',
+      missingTool: [],
+    });
+
+    expect(stripTimestamp(docA)).not.toBe(stripTimestamp(docB));
+  });
+});


### PR DESCRIPTION
## Problem

There is no auditable, always-current coverage number in this repo:

- The daily `api-schema-sync` workflow posted its full validation report as a sticky comment on **issue #60**, labeled `coverage-tracker`. Issue #60 was **closed on 2026-05-16** — the update step has since been a silent no-op (`core.warning()` only, no failure). Nobody has seen a coverage update in ~3 months.
- `validation-report.md` (the full table incl. all COVERED endpoints) is `.gitignore`d.
- `README.md` hardcoded a vague "130+ endpoints" claim that's now stale (286 actual `client.*` call sites) and was never going to self-correct.

## Solution

- **`scripts/lib/coverage-report.mjs`** — pure markdown builder: coverage %, COVERED/MISSING_TOOL/ORPHANED_TOOL/excluded counts, `MISSING_TOOL` grouped by API area (first `/api/<area>/...` segment) with per-area counts and endpoint tables.
- **`scripts/generate-coverage-doc.mjs`** — CLI wrapper that reuses `computeValidation()` (extracted from `validate-mcp-tools.mjs` as a pure, exported function so the numbers can never drift from `npm run api:validate`). Skips the write when only the `Erzeugt:` timestamp changed, so a daily cron run without real coverage changes doesn't produce an empty commit — same pattern `extract-dockhand-api.mjs` already uses for the schema file.
- **`docs/coverage.md`** — the new eingecheckte, always-visible report (see excerpt below).
- **Workflow**: replaced the dead sticky-issue step with "generate coverage doc" + "commit if changed" (mirrors the existing schema-commit step). Runs with `if: always()` so a real `ORPHANED_TOOL` validation failure doesn't also block the coverage numbers from refreshing.
- **`README.md`** / **`package.json`**: swapped the hardcoded "130+ endpoints" claims for a pointer to `docs/coverage.md`.
- New tests: `tests/coverage-report.test.ts` (doc builder, area grouping), `tests/generate-coverage-doc.test.ts` (timestamp-normalization no-op logic).

## `docs/coverage.md` excerpt (generated against schema commit `905c4a00`)

```markdown
## Coverage

**88.7%** (282/318 in-Scope-Endpunkte haben ein MCP-Tool)

| Status | Anzahl |
|--------|--------|
| COVERED | 282 |
| MISSING_TOOL | 36 |
| ORPHANED_TOOL | 0 |
| Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |

## MISSING_TOOL — nach Bereich

### backup (29)
...
### environments (2)
...
### git (1)
...
### registry (1)
...
### settings (2)
...
### stacks (1)
...
```

## Scope

Coverage visibility only. No new MCP tools were added, no body-contract checks changed.

## Test plan

- [x] `npx vitest run` — 510/510 tests green (494 pre-existing + 16 new)
- [x] `node scripts/validate-mcp-tools.mjs` — unchanged output (282 COVERED / 36 MISSING_TOOL / 0 critical), exit 0
- [x] `node scripts/generate-coverage-doc.mjs` — writes `docs/coverage.md`; run twice in a row confirmed the second run is a no-op ("Unverändert — kein Schreibvorgang")
- [x] `npm run build` (`tsc`) — clean

## Issue #60

#60 (`coverage-tracker`) is the reason this exists — recommend closing it with a comment pointing at `docs/coverage.md` as its replacement once this merges.