### PR TITLE
fix(tools): align 5 tool body contracts with real Dockhand handlers

### DIFF
--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -9,18 +9,18 @@
 > Body-Contract-Validierungs-Plans ist bewusst informativ; die Beförderung ins Gate (mindestens
 > `BODY_PARAM_MISSING_REQUIRED`) ist Phase P2, nach einer FP-freien Voll-Sweep-Triage.
 
-**Erzeugt:** 2026-08-10T11:46:38.167Z
+**Erzeugt:** 2026-08-10T13:22:38.678Z
 
 ## Zusammenfassung
 
 | Typ | Anzahl | Bedeutung |
 |-----|--------|-----------|
-| BODY_PARAM_MISSING_REQUIRED | 44 | Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142). |
-| BODY_PARAM_UNKNOWN | 16 | Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Ausschluss der Query-/Path-Parameter der Operation). |
-| UNTYPED_PASSTHROUGH | 43 | Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl der Endpunkt einen aufgelösten Contract hat — statisch nicht vollständig prüfbar. |
+| BODY_PARAM_MISSING_REQUIRED | 38 | Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142). |
+| BODY_PARAM_UNKNOWN | 13 | Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Ausschluss der Query-/Path-Parameter der Operation). |
+| UNTYPED_PASSTHROUGH | 42 | Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl der Endpunkt einen aufgelösten Contract hat — statisch nicht vollständig prüfbar. |
 | BODY_CONTRACT_UNRESOLVED | 35 | Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehlende `@openapi`-JSDoc-Annotation im Dockhand-Fork). |
 
-## BODY_PARAM_MISSING_REQUIRED (44)
+## BODY_PARAM_MISSING_REQUIRED (38)
 
 Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142).
 
@@ -30,12 +30,10 @@ Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required ge
 | `activate_license` | POST | `/api/license` | `key` | system.ts:138 |
 | `add_label` | POST | `/api/labels` | `action` | labels.ts:25 |
 | `adopt_stack` | POST | `/api/stacks/adopt` | `stacks` | stacks.ts:465 |
-| `clone_volume` | POST | `/api/volumes/{volumeName}/clone` | `name` | volumes.ts:88 |
 | `create_config_set` | POST | `/api/config-sets` | `name` | users.ts:250 |
 | `create_container_file` | POST | `/api/containers/{containerId}/files/create` | `type` | containers.ts:337 |
 | `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | `notificationId` | environments.ts:236 |
-| `create_git_repository` | POST | `/api/git/repositories` | `name` | git-stacks.ts:167 |
-| `create_git_stack` | POST | `/api/git/stacks` | `stackName` | git-stacks.ts:225 |
+| `create_git_stack` | POST | `/api/git/stacks` | `stackName` | git-stacks.ts:231 |
 | `create_ldap_provider` | POST | `/api/auth/ldap` | `name` | auth.ts:65 |
 | `create_ldap_provider` | POST | `/api/auth/ldap` | `serverUrl` | auth.ts:65 |
 | `create_ldap_provider` | POST | `/api/auth/ldap` | `baseDn` | auth.ts:65 |
@@ -51,19 +49,15 @@ Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required ge
 | `create_role` | POST | `/api/roles` | `permissions` | users.ts:114 |
 | `create_template_source` | POST | `/api/templates/sources` | `name` | templates.ts:41 |
 | `create_template_source` | POST | `/api/templates/sources` | `url` | templates.ts:41 |
-| `create_volume` | POST | `/api/volumes` | `name` | volumes.ts:118 |
+| `create_volume` | POST | `/api/volumes` | `name` | volumes.ts:116 |
 | `list_batch_operations` | POST | `/api/batch` | `operation` | system.ts:193 |
 | `list_batch_operations` | POST | `/api/batch` | `entityType` | system.ts:193 |
 | `list_batch_operations` | POST | `/api/batch` | `items` | system.ts:193 |
-| `push_image` | POST | `/api/images/push` | `imageId` | images.ts:68 |
-| `push_image` | POST | `/api/images/push` | `registryId` | images.ts:68 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `variables` | stacks.ts:389 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `content` | stacks.ts:397 |
-| `request_git_preview_env` | POST | `/api/git/preview-env` | `composePath` | git-stacks.ts:214 |
-| `scan_image` | POST | `/api/images/scan` | `imageName` | images.ts:78 |
 | `set_favorite_groups` | POST | `/api/preferences/favorite-groups` | `action` | users.ts:212 |
 | `set_favorites` | POST | `/api/preferences/favorites` | `action` | users.ts:191 |
-| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | `path` | git-stacks.ts:259 |
+| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | `path` | git-stacks.ts:265 |
 | `set_grid_preferences` | POST | `/api/preferences/grid` | `gridId` | users.ts:232 |
 | `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `order` | preferences.ts:24 |
 | `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `hidden` | preferences.ts:24 |
@@ -71,7 +65,7 @@ Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required ge
 | `test_notification_config` | POST | `/api/notifications/test` | `type` | notifications.ts:65 |
 | `trigger_test_notification` | POST | `/api/notifications/trigger-test` | `eventType` | notifications.ts:72 |
 
-## BODY_PARAM_UNKNOWN (16)
+## BODY_PARAM_UNKNOWN (13)
 
 Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Ausschluss der Query-/Path-Parameter der Operation).
 
@@ -82,19 +76,16 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:465 |
 | `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:465 |
 | `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:465 |
-| `clone_volume` | POST | `/api/volumes/{volumeName}/clone` | `newName` | volumes.ts:88 |
 | `create_container_file` | POST | `/api/containers/{containerId}/files/create` | `content` | containers.ts:337 |
 | `create_environment` | POST | `/api/environments` | `url` | environments.ts:93 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
-| `push_image` | POST | `/api/images/push` | `image` | images.ts:68 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:389 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:397 |
-| `scan_image` | POST | `/api/images/scan` | `imageId` | images.ts:78 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
 | `set_user_roles` | POST | `/api/users/{userId}/roles` | `roles` | users.ts:93 |
 | `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:161 |
 
-## UNTYPED_PASSTHROUGH (43)
+## UNTYPED_PASSTHROUGH (42)
 
 Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl der Endpunkt einen aufgelösten Contract hat — statisch nicht vollständig prüfbar.
 
@@ -104,8 +95,7 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `create_container` | POST | `/api/containers` | - | containers.ts:284 |
 | `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | - | environments.ts:236 |
 | `create_git_credential` | POST | `/api/git/credentials` | - | git-stacks.ts:98 |
-| `create_git_repository` | POST | `/api/git/repositories` | - | git-stacks.ts:167 |
-| `create_git_stack` | POST | `/api/git/stacks` | - | git-stacks.ts:225 |
+| `create_git_stack` | POST | `/api/git/stacks` | - | git-stacks.ts:231 |
 | `create_ldap_provider` | POST | `/api/auth/ldap` | - | auth.ts:65 |
 | `create_network` | POST | `/api/networks` | - | networks.ts:60 |
 | `create_notification` | POST | `/api/notifications` | - | notifications.ts:25 |
@@ -113,11 +103,11 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `create_registry` | POST | `/api/registries` | - | registries.ts:25 |
 | `create_template_compose` | POST | `/api/templates/compose` | - | templates.ts:25 |
 | `create_template_source` | POST | `/api/templates/sources` | - | templates.ts:41 |
-| `create_volume` | POST | `/api/volumes` | - | volumes.ts:118 |
+| `create_volume` | POST | `/api/volumes` | - | volumes.ts:116 |
 | `set_dashboard_preferences` | POST | `/api/dashboard/preferences` | - | dashboard.ts:29 |
 | `set_environment_image_prune` | POST | `/api/environments/{environmentId}/image-prune` | - | environments.ts:219 |
 | `set_environment_update_check` | POST | `/api/environments/{environmentId}/update-check` | - | environments.ts:202 |
-| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | - | git-stacks.ts:259 |
+| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | - | git-stacks.ts:265 |
 | `set_grid_preferences` | POST | `/api/preferences/grid` | - | users.ts:232 |
 | `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | - | preferences.ts:24 |
 | `test_notification_config` | POST | `/api/notifications/test` | - | notifications.ts:65 |
@@ -130,8 +120,8 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `update_environment_notification` | PUT | `/api/environments/{environmentId}/notifications/{notificationId}` | - | environments.ts:267 |
 | `update_general_settings` | POST | `/api/settings/general` | - | system.ts:97 |
 | `update_git_credential` | PUT | `/api/git/credentials/{credentialId}` | - | git-stacks.ts:129 |
-| `update_git_repository` | PUT | `/api/git/repositories/{repositoryId}` | - | git-stacks.ts:278 |
-| `update_git_stack` | PUT | `/api/git/stacks/{stackId}` | - | git-stacks.ts:235 |
+| `update_git_repository` | PUT | `/api/git/repositories/{repositoryId}` | - | git-stacks.ts:284 |
+| `update_git_stack` | PUT | `/api/git/stacks/{stackId}` | - | git-stacks.ts:241 |
 | `update_ldap_provider` | PUT | `/api/auth/ldap/{providerId}` | - | auth.ts:155 |
 | `update_notification` | PUT | `/api/notifications/{notificationId}` | - | notifications.ts:42 |
 | `update_oidc_provider` | PUT | `/api/auth/oidc/{providerId}` | - | auth.ts:179 |
@@ -151,9 +141,9 @@ Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehl
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `check_container_updates` | POST | `/api/containers/check-updates` | - | containers.ts:421 |
-| `deploy_git_repository` | POST | `/api/git/repositories/{repositoryId}/deploy` | - | git-stacks.ts:181 |
+| `deploy_git_repository` | POST | `/api/git/repositories/{repositoryId}/deploy` | - | git-stacks.ts:174 |
 | `deploy_git_stack` | POST | `/api/git/stacks/{stackId}/deploy` | - | git-stacks.ts:30 |
-| `deploy_git_stack_stream` | POST | `/api/git/stacks/{stackId}/deploy-stream` | - | git-stacks.ts:249 |
+| `deploy_git_stack_stream` | POST | `/api/git/stacks/{stackId}/deploy-stream` | - | git-stacks.ts:255 |
 | `logout` | POST | `/api/auth/logout` | - | auth.ts:210 |
 | `pause_container` | POST | `/api/containers/{containerId}/pause` | - | containers.ts:184 |
 | `prune_all` | POST | `/api/prune/all` | - | system.ts:156 |
@@ -161,7 +151,7 @@ Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehl
 | `prune_images` | POST | `/api/prune/images` | - | system.ts:170 |
 | `prune_networks` | POST | `/api/prune/networks` | - | system.ts:177 |
 | `prune_volumes` | POST | `/api/prune/volumes` | - | system.ts:184 |
-| `receive_git_webhook` | POST | `/api/git/webhook/{webhookId}` | - | git-stacks.ts:302 |
+| `receive_git_webhook` | POST | `/api/git/webhook/{webhookId}` | - | git-stacks.ts:308 |
 | `release_volume_browse` | POST | `/api/volumes/{volumeName}/browse/release` | - | volumes.ts:75 |
 | `restart_container` | POST | `/api/containers/{containerId}/restart` | - | containers.ts:174 |
 | `restart_stack` | POST | `/api/stacks/{name}/restart` | - | stacks.ts:76 |
@@ -172,10 +162,10 @@ Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehl
 | `start_stack` | POST | `/api/stacks/{name}/start` | - | stacks.ts:56 |
 | `stop_container` | POST | `/api/containers/{containerId}/stop` | - | containers.ts:164 |
 | `stop_stack` | POST | `/api/stacks/{name}/stop` | - | stacks.ts:66 |
-| `sync_git_repository` | POST | `/api/git/repositories/{repositoryId}/sync` | - | git-stacks.ts:188 |
+| `sync_git_repository` | POST | `/api/git/repositories/{repositoryId}/sync` | - | git-stacks.ts:181 |
 | `sync_git_stack` | POST | `/api/git/stacks/{stackId}/sync` | - | git-stacks.ts:37 |
 | `test_environment` | POST | `/api/environments/{environmentId}/test` | - | environments.ts:147 |
-| `test_git_repository` | POST | `/api/git/repositories/{repositoryId}/test` | - | git-stacks.ts:195 |
+| `test_git_repository` | POST | `/api/git/repositories/{repositoryId}/test` | - | git-stacks.ts:188 |
 | `test_git_stack` | POST | `/api/git/stacks/{stackId}/test` | - | git-stacks.ts:44 |
 | `test_ldap_provider` | POST | `/api/auth/ldap/{providerId}/test` | - | auth.ts:79 |
 | `test_notification` | POST | `/api/notifications/{notificationId}/test` | - | notifications.ts:56 |

--- a/src/tools/git-stacks.ts
+++ b/src/tools/git-stacks.ts
@@ -146,24 +146,17 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'create_git_repository', 'Register a new Git repository configuration with a URL, branch, and optional credential; use `list_git_repositories` to verify the entry and `deploy_git_repository` to trigger the first deploy.',
+  registerTool(server, 'create_git_repository', 'Register a new Git repository configuration with a name, URL, branch, and optional credential; use `list_git_repositories` to verify the entry and `deploy_git_repository` to trigger the first deploy.',
     {
+      name: z.string().describe('Repository name (required by the real endpoint)'),
       url: z.string().describe('Git repository URL (HTTPS or SSH)'),
-      branch: z.string().optional().describe('Branch to track (default: main or master)'),
+      branch: z.string().optional().describe('Branch to track (default: main)'),
       credentialId: z.number().optional().describe('ID of the Git credential to use for authentication'),
-      composePath: z.string().optional().describe('Path to docker-compose file within the repository'),
-      envFilePath: z.string().optional().describe('Path to .env file within the repository'),
-      stackName: z.string().optional().describe('Name for the stack created from this repository'),
-      additionalConfig: z.record(z.string(), z.unknown()).optional().describe('Additional configuration not covered by explicit parameters'),
     },
-    async ({ url, branch, credentialId, composePath, envFilePath, stackName, additionalConfig }) => {
-      // Fix #30 (MEDIUM): Merge additionalConfig FIRST so explicit fields always win (PR #29)
-      const body: Record<string, unknown> = { ...additionalConfig, url };
+    async ({ name, url, branch, credentialId }) => {
+      const body: Record<string, unknown> = { name, url };
       if (branch !== undefined) body.branch = branch;
       if (credentialId !== undefined) body.credentialId = credentialId;
-      if (composePath !== undefined) body.composePath = composePath;
-      if (envFilePath !== undefined) body.envFilePath = envFilePath;
-      if (stackName !== undefined) body.stackName = stackName;
       return jsonResponse(await client.post('/api/git/repositories', body));
     }
   );
@@ -208,10 +201,23 @@ export function registerGitStackTools(server: McpServer, client: DockhandClient)
     }
   );
 
-  registerTool(server, 'request_git_preview_env', 'Request a transient preview environment configuration for Git-based deployments; complements `deploy_git_stack` and `deploy_git_repository` for ephemeral testing workflows.',
-    {},
-    async () => {
-      return jsonResponse(await client.post('/api/git/preview-env'));
+  registerTool(server, 'request_git_preview_env', 'Clone a Git repository (existing `repositoryId` or a new `url`) to a temp directory and read its env files for a preview environment editor; complements `deploy_git_stack` and `deploy_git_repository` for ephemeral testing workflows.',
+    {
+      composePath: z.string().describe('Path to the compose file within the repository (required by the real endpoint)'),
+      repositoryId: z.number().optional().describe('Existing repository ID; use this OR url'),
+      url: z.string().optional().describe('New repository URL; use this OR repositoryId'),
+      branch: z.string().optional().describe('Branch to use when url is given (default: main)'),
+      credentialId: z.number().optional().describe('Credential ID to use when url is given'),
+      envFilePath: z.string().optional().describe('Path to an additional .env file within the repository'),
+    },
+    async ({ composePath, repositoryId, url, branch, credentialId, envFilePath }) => {
+      const body: Record<string, unknown> = { composePath };
+      if (repositoryId !== undefined) body.repositoryId = repositoryId;
+      if (url !== undefined) body.url = url;
+      if (branch !== undefined) body.branch = branch;
+      if (credentialId !== undefined) body.credentialId = credentialId;
+      if (envFilePath !== undefined) body.envFilePath = envFilePath;
+      return jsonResponse(await client.post('/api/git/preview-env', body));
     }
   );
 

--- a/src/tools/images.ts
+++ b/src/tools/images.ts
@@ -62,20 +62,29 @@ export function registerImageTools(server: McpServer, client: DockhandClient): v
   registerTool(server, 'push_image', 'Push a locally tagged Docker image to a remote registry (outbound registry transfer); to apply or change a tag before pushing use `tag_image`, or use `pull_image` for the opposite inbound direction.',
     {
       environmentId: z.number().describe('Environment ID'),
-      image: z.string().describe('Image name with tag'),
+      imageId: z.string().describe('Local image ID to push (required by the real endpoint)'),
+      registryId: z.number().describe('Target registry ID (required by the real endpoint)'),
+      imageName: z.string().optional().describe('Source tag to push if the image has multiple/no resolvable tag (falls back to the image\'s first RepoTag)'),
+      newTag: z.string().optional().describe('Custom target tag/name in the registry (default: derived from the source image name)'),
     },
-    async ({ environmentId, image }) => {
-      return jsonResponse(await client.post('/api/images/push', { image }, { env: environmentId }));
+    async ({ environmentId, imageId, registryId, imageName, newTag }) => {
+      const body: Record<string, unknown> = { imageId, registryId };
+      if (imageName !== undefined) body.imageName = imageName;
+      if (newTag !== undefined) body.newTag = newTag;
+      return jsonResponse(await client.post('/api/images/push', body, { env: environmentId }));
     }
   );
 
   registerTool(server, 'scan_image', 'Run a vulnerability scan (CVE analysis via Trivy/Grype) against a Docker image; for layer provenance use `get_image_history` instead, and use `export_image` to extract the image filesystem for offline analysis.',
     {
       environmentId: z.number().describe('Environment ID'),
-      imageId: z.string().describe('Image ID to scan'),
+      imageName: z.string().describe('Image name/reference to scan (required by the real endpoint)'),
+      scanner: z.enum(['grype', 'trivy']).optional().describe('Force a specific scanner instead of the configured default'),
     },
-    async ({ environmentId, imageId }) => {
-      return jsonResponse(await client.post('/api/images/scan', { imageId }, { env: environmentId }));
+    async ({ environmentId, imageName, scanner }) => {
+      const body: Record<string, unknown> = { imageName };
+      if (scanner !== undefined) body.scanner = scanner;
+      return jsonResponse(await client.post('/api/images/scan', body, { env: environmentId }));
     }
   );
 

--- a/src/tools/volumes.ts
+++ b/src/tools/volumes.ts
@@ -80,12 +80,10 @@ export function registerVolumeTools(server: McpServer, client: DockhandClient): 
     {
       environmentId: z.number().describe('Environment ID'),
       volumeName: z.string().describe('Source volume name'),
-      newName: z.string().optional().describe('Name for the cloned volume'),
+      name: z.string().describe('Name for the cloned volume (required by the real endpoint)'),
     },
-    async ({ environmentId, volumeName, newName }) => {
-      const body: Record<string, unknown> = {};
-      if (newName) body.newName = newName;
-      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/clone`, body, { env: environmentId }));
+    async ({ environmentId, volumeName, name }) => {
+      return jsonResponse(await client.post(`/api/volumes/${encodePath(volumeName)}/clone`, { name }, { env: environmentId }));
     }
   );
 

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -12,6 +12,7 @@ const registriesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'reg
 const imagesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'images.ts'), 'utf-8');
 const dashboardSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'dashboard.ts'), 'utf-8');
 const gitStacksSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'git-stacks.ts'), 'utf-8');
+const volumesSource = readFileSync(join(__dirname, '..', 'src', 'tools', 'volumes.ts'), 'utf-8');
 
 function extractToolBlock(source: string, toolName: string): string {
   const startPattern = new RegExp(
@@ -263,5 +264,86 @@ describe('Dockhand API contract alignment', () => {
     expect(block).toMatch(/client\.get\(`\/api\/git\/stacks\/\$\{encodePath\(stackId\)\}\/webhook`,\s*\{\s*secret\s*\}\)/);
     expect(block).not.toMatch(/client\.post\(`\/api\/git\/stacks/);
     expect(block).not.toMatch(/\btoken\b/);
+  });
+
+  it('clone_volume sends the source volume clone target as body.name (required), not optional body.newName', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/volumes/[name]/clone/+server.ts, v1.0.41):
+    // `const body = await request.json(); const newName = body.name; if (!newName) return
+    // json({ error: 'New volume name is required' }, { status: 400 });`. The handler reads the
+    // target name exclusively from `body.name` and always requires it — there is no `newName`
+    // field anywhere in the handler. The old tool sent an optional `newName` field, which the
+    // real handler never reads, so `body.name` was always undefined and every call 400ed with
+    // "New volume name is required" (mcp-dockhand#167).
+    const block = extractToolBlock(volumesSource, 'clone_volume');
+
+    expect(block).toMatch(/name:\s*z\.string\(\)/);
+    expect(block).not.toMatch(/newName/);
+    expect(block).toMatch(/\{\s*name\s*\}/);
+  });
+
+  it('create_git_repository sends name as a required body field, not just url', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/git/repositories/+server.ts, v1.0.41):
+    // `const data = await request.json(); if (!data.name || typeof data.name !== 'string')
+    // return json({ error: 'Name is required' }, { status: 400 }); if (!data.url || typeof
+    // data.url !== 'string') return json({ error: 'Repository URL is required' }, { status:
+    // 400 });`. Both `name` and `url` are required; `branch`/`credentialId` are optional
+    // (`data.branch || 'main'`, `data.credentialId || null`). The old tool's zod schema never
+    // included `name` at all, so it could never be sent — every call 400ed with "Name is
+    // required" before `url` was even checked (mcp-dockhand#167).
+    const block = extractToolBlock(gitStacksSource, 'create_git_repository');
+
+    expect(block).toMatch(/name:\s*z\.string\(\)(?!\.optional)/);
+    expect(block).toMatch(/url:\s*z\.string\(\)(?!\.optional)/);
+    expect(block).toMatch(/\{\s*name,\s*url\s*\}/);
+  });
+
+  it('push_image sends imageId and registryId as required body fields, not just image', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/images/push/+server.ts, v1.0.41): `const {
+    // imageId, imageName, registryId, newTag } = await request.json(); if (!imageId ||
+    // !registryId) return json({ error: 'Image ID and registry ID are required' }, { status:
+    // 400 });`. The handler never reads `image` at all — it needs the local image ID plus the
+    // target registry ID; `imageName` (fallback source tag) and `newTag` (custom target tag)
+    // are optional. The old tool sent only `{ image }`, a field the real handler never reads —
+    // every call 400ed with "Image ID and registry ID are required" (mcp-dockhand#167).
+    const block = extractToolBlock(imagesSource, 'push_image');
+
+    expect(block).toMatch(/imageId:\s*z\.string\(\)(?!\.optional)/);
+    expect(block).toMatch(/registryId:\s*z\.number\(\)(?!\.optional)/);
+    expect(block).not.toMatch(/\bimage:\s*z\.string\(\)/);
+    expect(block).toMatch(/imageId,\s*\n?\s*registryId/);
+  });
+
+  it('scan_image sends imageName as the required body field, not imageId', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/images/scan/+server.ts, v1.0.41): `const
+    // body = await request.json(); const { imageName, scanner: forceScannerType } = body; if
+    // (!imageName) return json({ error: 'Image name is required' }, { status: 400 });`. The
+    // handler reads `imageName` (a name/reference, not a Docker image ID) and an optional
+    // `scanner` override — it never reads `imageId`. The old tool sent `{ imageId }`, which the
+    // real handler ignores entirely — every call 400ed with "Image name is required"
+    // (mcp-dockhand#167).
+    const block = extractToolBlock(imagesSource, 'scan_image');
+
+    expect(block).toMatch(/imageName:\s*z\.string\(\)(?!\.optional)/);
+    expect(block).not.toMatch(/imageId:\s*z\.string\(\)/);
+    expect(block).toMatch(/\{\s*imageName/);
+  });
+
+  it('request_git_preview_env sends composePath plus repositoryId/url, not an empty body', () => {
+    // Ground truth (Finsys/dockhand src/routes/api/git/preview-env/+server.ts, v1.0.41): `const
+    // data = await request.json(); if (!data.composePath || typeof data.composePath !==
+    // 'string') return json({ error: 'Compose path is required' }, { status: 400 }); ... if
+    // (data.repositoryId) { ... } else if (data.url) { ... } else { return json({ error:
+    // 'Either repositoryId or url is required' }, { status: 400 }); }`. `composePath` is always
+    // required, and either `repositoryId` (existing repo) or `url` (new repo) must be given;
+    // `branch`, `credentialId`, `envFilePath` are optional. The old tool's input schema was
+    // empty (`{}`) and sent no body at all — every call 400ed with "Compose path is required"
+    // (mcp-dockhand#167).
+    const block = extractToolBlock(gitStacksSource, 'request_git_preview_env');
+
+    expect(block).toMatch(/composePath:\s*z\.string\(\)(?!\.optional)/);
+    expect(block).toMatch(/repositoryId:\s*z\.number\(\)\.optional\(\)/);
+    expect(block).toMatch(/url:\s*z\.string\(\)\.optional\(\)/);
+    expect(block).toMatch(/client\.post\('\/api\/git\/preview-env',\s*body\)/);
+    expect(block).not.toMatch(/client\.post\('\/api\/git\/preview-env'\)/);
   });
 });


### PR DESCRIPTION
## Summary

Surfaced by the new body-contract validator (#166) and closes #167 — these 5 tools sent wrong or missing required body fields and 400ed on **every** invocation. Each verified directly against the real `Finsys/dockhand` `v1.0.41` handler code (never against `docs/dockhand-api-schema.json` or our own docs, per the `dockhand-mcp-dev` skill's ground-truth rule).

| Tool | Old shape | Real handler contract | Handler source |
|------|-----------|------------------------|-----------------|
| `clone_volume` | optional `body.newName` | required `body.name` | `src/routes/api/volumes/[name]/clone/+server.ts`: `const newName = body.name; if (!newName) return json({error:'New volume name is required'}, {status:400});` |
| `create_git_repository` | `name` not in schema at all | required `body.name` (+ required `url`) | `src/routes/api/git/repositories/+server.ts`: `if (!data.name ...) return json({error:'Name is required'},{status:400}); if (!data.url ...) return json({error:'Repository URL is required'},{status:400});` |
| `push_image` | `{ image }` (unread) | required `body.imageId` + `body.registryId` | `src/routes/api/images/push/+server.ts`: `const { imageId, imageName, registryId, newTag } = await request.json(); if (!imageId || !registryId) return json({error:'Image ID and registry ID are required'},{status:400});` |
| `scan_image` | `{ imageId }` (unread) | required `body.imageName` | `src/routes/api/images/scan/+server.ts`: `const { imageName, scanner } = body; if (!imageName) return json({error:'Image name is required'},{status:400});` |
| `request_git_preview_env` | no body at all | required `body.composePath` + one of `repositoryId`/`url` | `src/routes/api/git/preview-env/+server.ts`: `if (!data.composePath ...) return json({error:'Compose path is required'},{status:400}); if (data.repositoryId) {...} else if (data.url) {...} else return json({error:'Either repositoryId or url is required'},{status:400});` |

Also dropped `composePath`/`envFilePath`/`stackName`/`additionalConfig` from `create_git_repository` — the real handler never reads them (that config now lives on `git_stacks`, per an inline comment in the handler). This incidentally removes an `UNTYPED_PASSTHROUGH` finding too.

## Contract-test evidence (TDD)

Added 5 new source-scan contract tests to `tests/api-contracts.test.ts` (same `extractToolBlock` pattern as the existing 15), each with the real-handler citation inline as a comment. Confirmed RED against the pre-fix code, GREEN after.

## Validator gegenprobe

Regenerated `docs/body-contract-report.md` (`node scripts/validate-mcp-tools.mjs` + `node scripts/generate-body-contract-doc.mjs`, fully offline against the checked-in `docs/dockhand-openapi.json`):

- `BODY_PARAM_MISSING_REQUIRED`: **44 → 38** — all 5 tools' findings (6 rows, `push_image` had 2) are gone from the list.
- `BODY_PARAM_UNKNOWN`: 16 → 13 (the old wrong field names `newName`/`image`/`imageId` disappear).
- `UNTYPED_PASSTHROUGH`: 43 → 42 (`create_git_repository`'s `additionalConfig` removed).
- `ORPHANED_TOOL` / `PARAM_MISMATCH` / `MISSING_ENCODE` / `QUERY_PARAM_MISSING_REQUIRED` / `QUERY_PARAM_UNKNOWN`: unchanged at 0 — hard-gate categories untouched, `validate-mcp-tools.mjs` still exits 0.

## Test plan

- [x] `npx vitest run` — 35 files, 577 tests, all green (was 572 before the 5 new tests)
- [x] `npm run build` (`tsc`) — clean
- [x] `npm run typecheck` — clean
- [x] `node scripts/validate-mcp-tools.mjs` — exit 0, hard-gate categories unchanged
- [x] `node scripts/generate-body-contract-doc.mjs` — confirms the 5 tools' `BODY_PARAM_MISSING_REQUIRED` findings are gone (44 → 38)

Closes #167
Refs #57, #166