### PR TITLE
fix(tools): stop false-positive BODY_PARAM_MISSING_REQUIRED for passthrough+computed bodies

### DIFF
--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -9,60 +9,30 @@
 > Body-Contract-Validierungs-Plans ist bewusst informativ; die Beförderung ins Gate (mindestens
 > `BODY_PARAM_MISSING_REQUIRED`) ist Phase P2, nach einer FP-freien Voll-Sweep-Triage.
 
-**Erzeugt:** 2026-08-10T13:22:38.678Z
+**Erzeugt:** 2026-08-10T13:53:41.577Z
 
 ## Zusammenfassung
 
 | Typ | Anzahl | Bedeutung |
 |-----|--------|-----------|
-| BODY_PARAM_MISSING_REQUIRED | 38 | Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142). |
+| BODY_PARAM_MISSING_REQUIRED | 8 | Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142). |
 | BODY_PARAM_UNKNOWN | 13 | Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Ausschluss der Query-/Path-Parameter der Operation). |
 | UNTYPED_PASSTHROUGH | 42 | Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl der Endpunkt einen aufgelösten Contract hat — statisch nicht vollständig prüfbar. |
 | BODY_CONTRACT_UNRESOLVED | 35 | Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehlende `@openapi`-JSDoc-Annotation im Dockhand-Fork). |
 
-## BODY_PARAM_MISSING_REQUIRED (38)
+## BODY_PARAM_MISSING_REQUIRED (8)
 
 Ein laut OpenAPI-Contract required Body-Feld wird vom Tool nicht als required gesendet — der Aufruf kann am echten Endpunkt fehlschlagen (siehe #142).
 
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `activate_license` | POST | `/api/license` | `name` | system.ts:138 |
-| `activate_license` | POST | `/api/license` | `key` | system.ts:138 |
-| `add_label` | POST | `/api/labels` | `action` | labels.ts:25 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `stacks` | stacks.ts:465 |
-| `create_config_set` | POST | `/api/config-sets` | `name` | users.ts:250 |
 | `create_container_file` | POST | `/api/containers/{containerId}/files/create` | `type` | containers.ts:337 |
-| `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | `notificationId` | environments.ts:236 |
-| `create_git_stack` | POST | `/api/git/stacks` | `stackName` | git-stacks.ts:231 |
-| `create_ldap_provider` | POST | `/api/auth/ldap` | `name` | auth.ts:65 |
-| `create_ldap_provider` | POST | `/api/auth/ldap` | `serverUrl` | auth.ts:65 |
-| `create_ldap_provider` | POST | `/api/auth/ldap` | `baseDn` | auth.ts:65 |
-| `create_notification` | POST | `/api/notifications` | `type` | notifications.ts:25 |
-| `create_notification` | POST | `/api/notifications` | `name` | notifications.ts:25 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | `name` | auth.ts:37 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | `issuerUrl` | auth.ts:37 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | `clientId` | auth.ts:37 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | `clientSecret` | auth.ts:37 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | `redirectUri` | auth.ts:37 |
-| `create_registry` | POST | `/api/registries` | `name` | registries.ts:25 |
-| `create_registry` | POST | `/api/registries` | `url` | registries.ts:25 |
 | `create_role` | POST | `/api/roles` | `permissions` | users.ts:114 |
-| `create_template_source` | POST | `/api/templates/sources` | `name` | templates.ts:41 |
-| `create_template_source` | POST | `/api/templates/sources` | `url` | templates.ts:41 |
-| `create_volume` | POST | `/api/volumes` | `name` | volumes.ts:116 |
 | `list_batch_operations` | POST | `/api/batch` | `operation` | system.ts:193 |
 | `list_batch_operations` | POST | `/api/batch` | `entityType` | system.ts:193 |
 | `list_batch_operations` | POST | `/api/batch` | `items` | system.ts:193 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `variables` | stacks.ts:389 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `content` | stacks.ts:397 |
-| `set_favorite_groups` | POST | `/api/preferences/favorite-groups` | `action` | users.ts:212 |
-| `set_favorites` | POST | `/api/preferences/favorites` | `action` | users.ts:191 |
-| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | `path` | git-stacks.ts:265 |
-| `set_grid_preferences` | POST | `/api/preferences/grid` | `gridId` | users.ts:232 |
-| `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `order` | preferences.ts:24 |
-| `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `hidden` | preferences.ts:24 |
 | `set_user_roles` | POST | `/api/users/{userId}/roles` | `roleId` | users.ts:93 |
-| `test_notification_config` | POST | `/api/notifications/test` | `type` | notifications.ts:65 |
 | `trigger_test_notification` | POST | `/api/notifications/trigger-test` | `eventType` | notifications.ts:72 |
 
 ## BODY_PARAM_UNKNOWN (13)
@@ -91,26 +61,26 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
-| `create_config_set` | POST | `/api/config-sets` | - | users.ts:250 |
-| `create_container` | POST | `/api/containers` | - | containers.ts:284 |
-| `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | - | environments.ts:236 |
-| `create_git_credential` | POST | `/api/git/credentials` | - | git-stacks.ts:98 |
-| `create_git_stack` | POST | `/api/git/stacks` | - | git-stacks.ts:231 |
-| `create_ldap_provider` | POST | `/api/auth/ldap` | - | auth.ts:65 |
-| `create_network` | POST | `/api/networks` | - | networks.ts:60 |
-| `create_notification` | POST | `/api/notifications` | - | notifications.ts:25 |
-| `create_oidc_provider` | POST | `/api/auth/oidc` | - | auth.ts:37 |
-| `create_registry` | POST | `/api/registries` | - | registries.ts:25 |
-| `create_template_compose` | POST | `/api/templates/compose` | - | templates.ts:25 |
-| `create_template_source` | POST | `/api/templates/sources` | - | templates.ts:41 |
-| `create_volume` | POST | `/api/volumes` | - | volumes.ts:116 |
+| `create_config_set` | POST | `/api/config-sets` | `name` | users.ts:250 |
+| `create_container` | POST | `/api/containers` | `name`, `image` | containers.ts:284 |
+| `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | `notificationId` | environments.ts:236 |
+| `create_git_credential` | POST | `/api/git/credentials` | `name` | git-stacks.ts:98 |
+| `create_git_stack` | POST | `/api/git/stacks` | `stackName` | git-stacks.ts:231 |
+| `create_ldap_provider` | POST | `/api/auth/ldap` | `name`, `serverUrl`, `baseDn` | auth.ts:65 |
+| `create_network` | POST | `/api/networks` | `name` | networks.ts:60 |
+| `create_notification` | POST | `/api/notifications` | `type`, `name` | notifications.ts:25 |
+| `create_oidc_provider` | POST | `/api/auth/oidc` | `name`, `issuerUrl`, `clientId`, `clientSecret`, `redirectUri` | auth.ts:37 |
+| `create_registry` | POST | `/api/registries` | `name`, `url` | registries.ts:25 |
+| `create_template_compose` | POST | `/api/templates/compose` | `template` | templates.ts:25 |
+| `create_template_source` | POST | `/api/templates/sources` | `name`, `url` | templates.ts:41 |
+| `create_volume` | POST | `/api/volumes` | `name` | volumes.ts:116 |
 | `set_dashboard_preferences` | POST | `/api/dashboard/preferences` | - | dashboard.ts:29 |
 | `set_environment_image_prune` | POST | `/api/environments/{environmentId}/image-prune` | - | environments.ts:219 |
 | `set_environment_update_check` | POST | `/api/environments/{environmentId}/update-check` | - | environments.ts:202 |
-| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | - | git-stacks.ts:265 |
-| `set_grid_preferences` | POST | `/api/preferences/grid` | - | users.ts:232 |
-| `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | - | preferences.ts:24 |
-| `test_notification_config` | POST | `/api/notifications/test` | - | notifications.ts:65 |
+| `set_git_stack_env_files` | POST | `/api/git/stacks/{stackId}/env-files` | `path` | git-stacks.ts:265 |
+| `set_grid_preferences` | POST | `/api/preferences/grid` | `gridId` | users.ts:232 |
+| `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `order`, `hidden` | preferences.ts:24 |
+| `test_notification_config` | POST | `/api/notifications/test` | `type` | notifications.ts:65 |
 | `test_registry` | POST | `/api/registries/test` | - | registries.ts:113 |
 | `update_auth_settings` | PUT | `/api/auth/settings` | - | auth.ts:202 |
 | `update_config_set` | PUT | `/api/config-sets/{configSetId}` | - | users.ts:267 |
@@ -131,7 +101,7 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `update_role` | PUT | `/api/roles/{roleId}` | - | users.ts:131 |
 | `update_scanner_settings` | POST | `/api/settings/scanner` | - | system.ts:120 |
 | `update_schedule_settings` | PUT | `/api/schedules/settings` | - | schedules.ts:32 |
-| `update_template_source` | PUT | `/api/templates/sources` | - | templates.ts:52 |
+| `update_template_source` | PUT | `/api/templates/sources` | `id` | templates.ts:52 |
 | `update_user` | PUT | `/api/users/{userId}` | - | users.ts:50 |
 
 ## BODY_CONTRACT_UNRESOLVED (35)

--- a/scripts/lib/body-checks.mjs
+++ b/scripts/lib/body-checks.mjs
@@ -22,8 +22,55 @@
  *   Rückgabeform von getBodyContract() (openapi-contract-source.mjs).
  * @typedef {{ sentFields: string[], requiredSent: string[], passthrough: boolean }} ToolBodyShape
  *   Rückgabeform von computeBodyShape()/getToolBodyShape() (tool-body-shape.mjs).
- * @typedef {{ type: string, field?: string }} BodyFinding
+ * @typedef {{ type: string, field?: string, expectedRequired?: string[] }} BodyFinding
  */
+
+/**
+ * FP_COMPUTED_BODY-Whitelist (Task P2.1 Fix 2, `tool:field`-Keys).
+ *
+ * Diese Tools sind NICHT `z.record(...)`-Ganzkörper-Passthrough (das behandelt Fix 1 unten
+ * strukturell/self-maintaining) -- ihr Zod-Input-Shape ist vollständig getypt, aber der
+ * TATSÄCHLICH gesendete Wire-Body weicht davon ab, weil der Callback ein Feld umbenennt,
+ * hartcodiert oder aus anderen Eingabefeldern berechnet, BEVOR er sendet. Der Collector
+ * (tool-body-shape.mjs) sieht ausschließlich das deklarierte Zod-Input-Schema, nie den
+ * tatsächlich konstruierten Request-Body -- diese Fälle sind daher statisch NICHT
+ * erkennbar und brauchen eine echte, einzeln verifizierte Ausnahme statt einer
+ * strukturellen Regel. Jeder Eintrag ist gegen den echten Tool-Callback UND den echten
+ * OpenAPI-Contract verifiziert (siehe tests/body-checks-whitelist-anti-orphan.test.ts).
+ *
+ * Name bewusst "…PASSTHROUGH" (konsistent mit `WHITELISTED_QUERY_PARAMS` in
+ * validate-mcp-tools.mjs), obwohl es hier nicht um z.record(...)-Passthrough geht, sondern
+ * um einen im Callback abweichend konstruierten Body -- die Kategorie heißt im P2.1-Plan
+ * FP_COMPUTED_BODY.
+ */
+const WHITELISTED_BODY_PASSTHROUGH = new Set([
+  // system.ts:138 -- Callback sendet { key: licenseKey }; Zod-Feld heißt `licenseKey`, der
+  // Contract kennt nur `key`. Reine Umbenennung, kein fehlendes Feld.
+  'activate_license:key',
+  // labels.ts:25 -- Callback sendet immer { action: 'add', label, environmentIds };
+  // `action` ist im Zod-Shape gar nicht deklariert, weil add_label EINE feste Aktion ist.
+  'add_label:action',
+  // stacks.ts:467 -- Callback baut `stacks: [{ name, composePath, ... }]` aus den
+  // Einzelfeldern `name`/`composePath`/`envPath`/`sourceDir`; das Zod-Shape kennt kein
+  // eigenes `stacks`-Feld.
+  'adopt_stack:stacks',
+  // stacks.ts:390 -- Callback berechnet einen Diff (verbleibende DB-Variablen nach Entfernen
+  // der Ziel-Keys) und sendet das Ergebnis als `variables`; das Zod-Shape kennt nur `keys`
+  // (die zu entfernenden Namen), nie den fertig berechneten Rest-Zustand.
+  'remove_stack_env_vars:variables',
+  // stacks.ts:398 -- derselbe Diff-Mechanismus für die .env-Datei, gesendet als `content`
+  // (neu zusammengesetzter Dateiinhalt); ebenfalls nicht im Zod-Shape (nur `keys`).
+  'remove_stack_env_vars:content',
+  // users.ts:214 -- Callback sendet immer { environmentId, action: 'reorder', groups };
+  // `action` ist im Zod-Shape (`environmentId`, `groups`) nicht deklariert, weil
+  // set_favorite_groups den Voll-Replace-Pfad IMMER mit `action:"reorder"` fährt (siehe
+  // dockhand-mcp-dev-Skill, Abschnitt "favorites/favorite-groups action-Enum").
+  'set_favorite_groups:action',
+  // users.ts:193 -- derselbe Mechanismus für set_favorites: { environmentId, action:
+  // 'reorder', favorites }; `action` ist im Zod-Shape (`environmentId`, `favorites`) nicht
+  // deklariert.
+  'set_favorites:action',
+]);
 
 /**
  * Berechnet die Body-Contract-Findings für EINEN Endpunkt/Tool-Paar.
@@ -33,50 +80,74 @@
  *     weiteren Vergleiche (missing/unknown) würden nur Rauschen erzeugen (jedes gesendete
  *     Feld wäre trivial "unknown" gegen eine leere knownFields-Liste). Deshalb NUR
  *     BODY_CONTRACT_UNRESOLVED und sofortiger Rückgabe.
- *   - BODY_PARAM_UNKNOWN wird bei `passthrough:true` komplett übersprungen (nicht nur für
- *     das Passthrough-Feld selbst): computeBodyShape() liefert keine Information darüber,
- *     WELCHES sentFields-Element der Record-Typ ist, und der Feld-NAME eines
- *     Passthrough-Containers (z.B. `settings`) hat ohnehin keine Entsprechung unter den
- *     echten API-Property-Namen -- ein Per-Feld-Vergleich würde bei jedem
- *     Passthrough-Tool einen garantierten Fehlalarm auf den Container-Feldnamen selbst
- *     erzeugen. Stattdessen macht UNTYPED_PASSTHROUGH sichtbar, dass dieses Tool
- *     statisch nicht vollständig prüfbar ist.
+ *   - BODY_PARAM_MISSING_REQUIRED und BODY_PARAM_UNKNOWN werden BEIDE bei
+ *     `passthrough:true` komplett übersprungen (Task P2.1 Fix 1, Collector-Bug-Korrektur):
+ *     computeBodyShape() liefert keine Information darüber, WELCHE Feldnamen innerhalb
+ *     eines `z.record(...)`-Ganzkörper-Bodys tatsächlich auf die Leitung gehen -- weder für
+ *     den Unknown- noch für den Required-Vergleich. Vor diesem Fix wurde
+ *     `missingRequired` VOR der passthrough-Weiche berechnet und dadurch bei jedem
+ *     Ganzkörper-Passthrough-Tool (z.B. `create_oidc_provider`, `{ config:
+ *     z.record(...) }`) JEDES contract-required Feld fälschlich als "fehlt" gemeldet --
+ *     der Collector sieht die verschachtelten Feldnamen innerhalb des Records schlicht
+ *     nicht, unabhängig davon, ob sie zur Laufzeit tatsächlich gesendet werden (P2.1-Sweep:
+ *     22 von 38 BODY_PARAM_MISSING_REQUIRED-Funden waren genau dieser strukturelle
+ *     Fehlalarm). Stattdessen macht UNTYPED_PASSTHROUGH sichtbar, dass dieses Tool statisch
+ *     nicht vollständig prüfbar ist -- ergänzt um `expectedRequired`, damit der Report
+ *     weiterhin zeigt, WELCHE Felder beim manuellen Gegenlesen zu prüfen sind, ohne die
+ *     Fehlalarme zurückzubringen.
+ *   - `WHITELISTED_BODY_PASSTHROUGH` (Task P2.1 Fix 2, FP_COMPUTED_BODY) greift NUR im
+ *     Nicht-Passthrough-Zweig, auf einzelne `tool:field`-Paare -- diese Tools sind
+ *     vollständig getypt (kein `z.record`), aber ihr Callback verändert den Body vor dem
+ *     Senden (Umbenennung/Hardcoding/Berechnung), was der Collector strukturell nicht
+ *     sehen kann. Siehe die Set-Definition oben für den Beleg je Eintrag.
  *
  * @param {BodyContract} contract
  * @param {ToolBodyShape} toolShape
  * @param {string[]} [opParams] Namen der Query-/Path-Parameter dieser Operation (aus dem
  *   OpenAPI `parameters`-Abschnitt, siehe getOperationParamNames()) -- werden von der
  *   BODY_PARAM_UNKNOWN-Prüfung ausgenommen.
+ * @param {string} [toolName] Name des MCP-Tools (z.B. `call.toolName` in
+ *   validate-mcp-tools.mjs) -- nötig, um `WHITELISTED_BODY_PASSTHROUGH`-Einträge korrekt
+ *   als `tool:field` zu matchen. Ohne Angabe (Default `''`) matcht kein Whitelist-Eintrag
+ *   (kein Key beginnt mit `:`), das Verhalten ist damit rückwärtskompatibel zu Aufrufern,
+ *   die noch keinen Tool-Namen mitgeben.
  * @returns {BodyFinding[]}
  */
-function computeBodyFindings(contract, toolShape, opParams = []) {
+function computeBodyFindings(contract, toolShape, opParams = [], toolName = '') {
   if (!contract.hasSchema) {
     return [{ type: 'BODY_CONTRACT_UNRESOLVED' }];
   }
 
   const findings = [];
 
+  if (toolShape.passthrough) {
+    const finding = { type: 'UNTYPED_PASSTHROUGH' };
+    if (contract.requiredFields.length > 0) {
+      finding.expectedRequired = contract.requiredFields;
+    }
+    findings.push(finding);
+    return findings;
+  }
+
   const missingRequired = contract.requiredFields.filter(
-    (field) => !toolShape.requiredSent.includes(field)
+    (field) =>
+      !toolShape.requiredSent.includes(field) &&
+      !WHITELISTED_BODY_PASSTHROUGH.has(`${toolName}:${field}`)
   );
   for (const field of missingRequired) {
     findings.push({ type: 'BODY_PARAM_MISSING_REQUIRED', field });
   }
 
-  if (toolShape.passthrough) {
-    findings.push({ type: 'UNTYPED_PASSTHROUGH' });
-  } else {
-    const known = new Set(contract.knownFields);
-    const params = new Set(opParams);
-    const unknown = toolShape.sentFields.filter(
-      (field) => !known.has(field) && !params.has(field)
-    );
-    for (const field of unknown) {
-      findings.push({ type: 'BODY_PARAM_UNKNOWN', field });
-    }
+  const known = new Set(contract.knownFields);
+  const params = new Set(opParams);
+  const unknown = toolShape.sentFields.filter(
+    (field) => !known.has(field) && !params.has(field)
+  );
+  for (const field of unknown) {
+    findings.push({ type: 'BODY_PARAM_UNKNOWN', field });
   }
 
   return findings;
 }
 
-export { computeBodyFindings };
+export { computeBodyFindings, WHITELISTED_BODY_PASSTHROUGH };

--- a/scripts/lib/body-contract-report.mjs
+++ b/scripts/lib/body-contract-report.mjs
@@ -28,6 +28,23 @@ const FINDING_DESCRIPTIONS = {
 };
 
 /**
+ * Rendert die "Feld"-Zelle einer Finding-Tabellenzeile. Ein `field` (die meisten
+ * Finding-Typen) hat Vorrang; ein `UNTYPED_PASSTHROUGH`-Finding hat stattdessen (optional)
+ * `expectedRequired` -- die Liste der laut Contract required Felder, die der Collector wegen
+ * des `z.record(...)`-Ganzkörper-Bodys nicht einzeln prüfen konnte (Task P2.1 Fix 1). Ohne
+ * eines von beidem bleibt es beim Platzhalter-Strich.
+ * @param {{field?: string, expectedRequired?: string[]}} finding
+ * @returns {string}
+ */
+function renderFieldCell(finding) {
+  if (finding.field) return `\`${finding.field}\``;
+  if (finding.expectedRequired?.length) {
+    return finding.expectedRequired.map((f) => `\`${f}\``).join(', ');
+  }
+  return '-';
+}
+
+/**
  * Gruppiert die Findings nach Typ, in der festen FINDING_ORDER-Reihenfolge (kritischste
  * zuerst), jede Gruppe intern nach Tool-Name sortiert.
  * @param {Array<{type: string, field?: string, toolName: string, httpMethod: string, path: string, file: string, line: number}>} bodyFindings
@@ -114,7 +131,7 @@ function buildBodyContractDoc({ generatedAt, bodyFindings }) {
     lines.push('| Tool | HTTP | Pfad | Feld | Datei |');
     lines.push('|------|------|------|------|-------|');
     for (const e of entries) {
-      lines.push(`| \`${e.toolName}\` | ${e.httpMethod} | \`${e.path}\` | ${e.field ? `\`${e.field}\`` : '-'} | ${e.file}:${e.line} |`);
+      lines.push(`| \`${e.toolName}\` | ${e.httpMethod} | \`${e.path}\` | ${renderFieldCell(e)} | ${e.file}:${e.line} |`);
     }
     lines.push('');
   }

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -471,7 +471,7 @@ function computeBodyFindingsForCalls(toolCalls, toolBodyShapes, openApiPathIndex
       ...ENVIRONMENT_SCOPING_FIELD_NAMES,
       ...getOperationParamNames(call.httpMethod, realPath),
     ];
-    const findings = computeBodyFindings(contract, shape, opParams);
+    const findings = computeBodyFindings(contract, shape, opParams, call.toolName);
 
     for (const finding of findings) {
       results.push({

--- a/tests/body-checks-whitelist-anti-orphan.test.ts
+++ b/tests/body-checks-whitelist-anti-orphan.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { getBodyContract } from '../scripts/lib/openapi-contract-source.mjs';
+import { createCapturingServer, getToolBodyShape } from '../scripts/lib/tool-body-shape.mjs';
+import { computeBodyFindings, WHITELISTED_BODY_PASSTHROUGH } from '../scripts/lib/body-checks.mjs';
+import { registerSystemTools } from '../src/tools/system.js';
+import { registerLabelTools } from '../src/tools/labels.js';
+import { registerStackTools } from '../src/tools/stacks.js';
+import { registerUserTools } from '../src/tools/users.js';
+
+/**
+ * Task P2.1 Fix 2 -- anti-orphaning proof for WHITELISTED_BODY_PASSTHROUGH.
+ *
+ * A whitelist entry is only justified while it actually suppresses a real, currently-firing
+ * BODY_PARAM_MISSING_REQUIRED candidate. If a future tool refactor makes the underlying Zod
+ * shape send the field under its real name (or the endpoint contract drops the requirement),
+ * the whitelist entry becomes a silent no-op -- nobody would notice, because "nothing fires"
+ * looks identical to "a stale entry masks nothing". This file proves, against the REAL
+ * registered tool shapes (via createCapturingServer(), the same fixture the P1.5 regression
+ * test already established) and the REAL committed docs/dockhand-openapi.json (no fixture
+ * spec), that every entry:
+ *
+ *   1. targets a field the real contract genuinely lists as required for that endpoint,
+ *   2. would fire BODY_PARAM_MISSING_REQUIRED WITHOUT the whitelist (toolName omitted --
+ *      proves there is still something real to suppress), and
+ *   3. is actually suppressed WITH the whitelist active (toolName passed).
+ *
+ * If any of the 7 entries stops satisfying (1)+(2), this test fails loudly instead of the
+ * whitelist quietly rotting into dead weight.
+ */
+
+const { server, shapes } = createCapturingServer();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerSystemTools(server as any, {} as any);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerLabelTools(server as any, {} as any);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerStackTools(server as any, {} as any);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+registerUserTools(server as any, {} as any);
+
+/** One row per WHITELISTED_BODY_PASSTHROUGH entry -- the real endpoint each targets. */
+const CASES = [
+  { toolName: 'activate_license', field: 'key', method: 'POST', path: '/api/license' },
+  { toolName: 'add_label', field: 'action', method: 'POST', path: '/api/labels' },
+  { toolName: 'adopt_stack', field: 'stacks', method: 'POST', path: '/api/stacks/adopt' },
+  { toolName: 'remove_stack_env_vars', field: 'variables', method: 'PUT', path: '/api/stacks/{name}/env' },
+  { toolName: 'remove_stack_env_vars', field: 'content', method: 'PUT', path: '/api/stacks/{name}/env/raw' },
+  { toolName: 'set_favorite_groups', field: 'action', method: 'POST', path: '/api/preferences/favorite-groups' },
+  { toolName: 'set_favorites', field: 'action', method: 'POST', path: '/api/preferences/favorites' },
+];
+
+describe('WHITELISTED_BODY_PASSTHROUGH — every entry has a key in the set', () => {
+  it.each(CASES)('$toolName:$field is present in WHITELISTED_BODY_PASSTHROUGH', ({ toolName, field }) => {
+    expect(WHITELISTED_BODY_PASSTHROUGH.has(`${toolName}:${field}`)).toBe(true);
+  });
+});
+
+describe('WHITELISTED_BODY_PASSTHROUGH — anti-orphaning proof (real contract + real tool shapes)', () => {
+  it.each(CASES)(
+    '$toolName:$field targets a genuinely required field, fires unfiltered, and is suppressed with the whitelist active',
+    ({ toolName, field, method, path }) => {
+      const contract = getBodyContract(method, path);
+      expect(contract.hasSchema).toBe(true);
+      expect(contract.requiredFields).toContain(field);
+
+      const shape = getToolBodyShape(toolName, shapes);
+
+      // (2) Without the whitelist (toolName omitted), the real shape genuinely does NOT
+      // send this field under its contract name -- the candidate is real, not hypothetical.
+      const unfiltered = computeBodyFindings(contract, shape, []);
+      expect(unfiltered).toContainEqual({ type: 'BODY_PARAM_MISSING_REQUIRED', field });
+
+      // (3) With the whitelist active (real toolName passed), this specific field is
+      // suppressed -- proves the filter actually reaches this tool:field pair end-to-end.
+      const filtered = computeBodyFindings(contract, shape, [], toolName);
+      expect(filtered).not.toContainEqual({ type: 'BODY_PARAM_MISSING_REQUIRED', field });
+    }
+  );
+});

--- a/tests/body-checks.test.ts
+++ b/tests/body-checks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeBodyFindings } from '../scripts/lib/body-checks.mjs';
+import { computeBodyFindings, WHITELISTED_BODY_PASSTHROUGH } from '../scripts/lib/body-checks.mjs';
 
 /**
  * computeBodyFindings() korreliert die Soll-Seite (getBodyContract()) mit der Ist-Seite
@@ -89,16 +89,32 @@ describe('computeBodyFindings — UNTYPED_PASSTHROUGH', () => {
     expect(findings).toEqual([{ type: 'UNTYPED_PASSTHROUGH' }]);
   });
 
-  it('still flags BODY_PARAM_MISSING_REQUIRED alongside UNTYPED_PASSTHROUGH -- passthrough does not excuse a missing explicit required field', () => {
+  it('does NOT flag BODY_PARAM_MISSING_REQUIRED for a whole-body z.record(...) passthrough tool (Collector-Fix, P2.1) -- the collector cannot see field names nested inside the record, so every contract-required field would otherwise be a guaranteed false positive', () => {
     const contract = { hasSchema: true, requiredFields: ['name'], knownFields: ['name'] };
     const toolShape = { sentFields: ['settings'], requiredSent: [], passthrough: true };
 
     const findings = computeBodyFindings(contract, toolShape);
 
-    expect(findings).toEqual([
-      { type: 'BODY_PARAM_MISSING_REQUIRED', field: 'name' },
-      { type: 'UNTYPED_PASSTHROUGH' },
-    ]);
+    expect(findings).toEqual([{ type: 'UNTYPED_PASSTHROUGH', expectedRequired: ['name'] }]);
+  });
+
+  it('attaches expectedRequired with ALL contract-required fields to the UNTYPED_PASSTHROUGH finding, so the report still shows what to watch for', () => {
+    const contract = { hasSchema: true, requiredFields: ['name', 'compose'], knownFields: ['name', 'compose'] };
+    const toolShape = { sentFields: ['config'], requiredSent: ['config'], passthrough: true };
+
+    const findings = computeBodyFindings(contract, toolShape);
+
+    expect(findings).toEqual([{ type: 'UNTYPED_PASSTHROUGH', expectedRequired: ['name', 'compose'] }]);
+  });
+
+  it('omits expectedRequired entirely when the contract has no required fields at all (nothing to watch for)', () => {
+    const contract = { hasSchema: true, requiredFields: [], knownFields: ['name'] };
+    const toolShape = { sentFields: ['settings'], requiredSent: [], passthrough: true };
+
+    const findings = computeBodyFindings(contract, toolShape);
+
+    expect(findings).toEqual([{ type: 'UNTYPED_PASSTHROUGH' }]);
+    expect(findings[0]).not.toHaveProperty('expectedRequired');
   });
 });
 
@@ -136,5 +152,61 @@ describe('computeBodyFindings — happy path', () => {
     const toolShape = { sentFields: ['name'], requiredSent: ['name'], passthrough: false };
 
     expect(computeBodyFindings(contract, toolShape)).toEqual([]);
+  });
+});
+
+describe('computeBodyFindings — WHITELISTED_BODY_PASSTHROUGH (Task P2.1 Fix 2, FP_COMPUTED_BODY)', () => {
+  /**
+   * These fixtures model tools whose Zod input shape does NOT match the wire body 1:1
+   * because the callback computes/renames/hardcodes a field before sending it (e.g.
+   * `add_label` never declares `action` in its Zod shape, but its callback always sends
+   * `{ action: 'add', ... }` on the wire) -- NOT the z.record(...) Ganzkörper-passthrough
+   * case covered above (toolShape.passthrough stays false here). The collector can only
+   * see the declared Zod shape, so these are statically unprovable and need a real,
+   * per-tool:field whitelist instead of a structural fix.
+   */
+
+  it('suppresses BODY_PARAM_MISSING_REQUIRED for a whitelisted tool:field pair (activate_license sends the required "key" field, just renamed from its Zod field "licenseKey")', () => {
+    const contract = { hasSchema: true, requiredFields: ['name', 'key'], knownFields: ['name', 'key', 'licenseKey'] };
+    const toolShape = { sentFields: ['licenseKey'], requiredSent: ['licenseKey'], passthrough: false };
+
+    const findings = computeBodyFindings(contract, toolShape, [], 'activate_license');
+
+    // "key" is whitelisted (renamed on the wire) and must NOT appear; "name" is a genuine
+    // gap (activate_license never sends it at all, under any name) and must still fire.
+    expect(findings.filter((f) => f.type === 'BODY_PARAM_MISSING_REQUIRED')).toEqual([
+      { type: 'BODY_PARAM_MISSING_REQUIRED', field: 'name' },
+    ]);
+  });
+
+  it('does NOT suppress the same field name for a DIFFERENT, non-whitelisted tool -- the filter is a tool:field pair, not a bare field name', () => {
+    const contract = { hasSchema: true, requiredFields: ['key'], knownFields: ['key'] };
+    const toolShape = { sentFields: [], requiredSent: [], passthrough: false };
+
+    const findings = computeBodyFindings(contract, toolShape, [], 'some_other_tool');
+
+    expect(findings).toEqual([{ type: 'BODY_PARAM_MISSING_REQUIRED', field: 'key' }]);
+  });
+
+  it('does not suppress anything when toolName is omitted (backward-compatible default)', () => {
+    const contract = { hasSchema: true, requiredFields: ['action'], knownFields: ['action', 'label', 'environmentIds'] };
+    const toolShape = { sentFields: ['label', 'environmentIds'], requiredSent: ['label', 'environmentIds'], passthrough: false };
+
+    expect(computeBodyFindings(contract, toolShape)).toEqual([{ type: 'BODY_PARAM_MISSING_REQUIRED', field: 'action' }]);
+  });
+
+  it('exposes exactly the 7 verified tool:field pairs documented in the P2.1 triage', () => {
+    // Guards against silent drift of the whitelist set itself (accidental additions/
+    // removals) -- the anti-orphaning proof against the REAL contract + REAL tool shapes
+    // lives in tests/body-checks-whitelist-anti-orphan.test.ts.
+    expect([...WHITELISTED_BODY_PASSTHROUGH].sort()).toEqual([
+      'activate_license:key',
+      'add_label:action',
+      'adopt_stack:stacks',
+      'remove_stack_env_vars:content',
+      'remove_stack_env_vars:variables',
+      'set_favorite_groups:action',
+      'set_favorites:action',
+    ]);
   });
 });

--- a/tests/body-contract-report.test.ts
+++ b/tests/body-contract-report.test.ts
@@ -59,6 +59,25 @@ describe('buildBodyContractDoc', () => {
     expect(doc).toMatch(/\| `update_container` \| POST \| `\/api\/containers\/\{containerId\}\/update` \| - \| containers\.ts:209 \|/);
   });
 
+  it('renders expectedRequired (Task P2.1 Fix 1) in the field cell of a passthrough finding instead of a dash, so the report keeps showing what to check manually', () => {
+    const withExpected = [
+      ...findings,
+      {
+        type: 'UNTYPED_PASSTHROUGH',
+        expectedRequired: ['name', 'url'],
+        toolName: 'create_registry',
+        httpMethod: 'POST',
+        path: '/api/registries',
+        file: 'registries.ts',
+        line: 25,
+      },
+    ];
+
+    const doc = buildBodyContractDoc({ generatedAt: '2026-08-10T12:00:00.000Z', bodyFindings: withExpected });
+
+    expect(doc).toContain('| `create_registry` | POST | `/api/registries` | `name`, `url` | registries.ts:25 |');
+  });
+
   it('reports "no findings" clearly instead of an empty/confusing table for a clean run', () => {
     const doc = buildBodyContractDoc({ generatedAt: '2026-08-10T12:00:00.000Z', bodyFindings: [] });
 


### PR DESCRIPTION
## Summary

Task P2.1 follow-up (see `docs/body-contract-report.md`'s ~38 `BODY_PARAM_MISSING_REQUIRED` findings from the P1 full sweep): triages down to the real bugs by fixing two distinct false-positive sources.

- **Collector bug (structural fix, self-maintaining):** `computeBodyFindings()` computed `missingRequired` **before** the `passthrough` branch, so any whole-body `z.record(...)` tool (e.g. `create_oidc_provider`'s `{ config: z.record(...) }`) flagged every contract-required field as missing — the collector cannot see field names nested inside the record, regardless of whether they're actually sent at runtime. Moved the `missingRequired`/`BODY_PARAM_UNKNOWN` computation into the non-passthrough branch (mirrors the pattern `BODY_PARAM_UNKNOWN` already used). The `UNTYPED_PASSTHROUGH` finding is now enriched with `expectedRequired` (the contract's required-field list), so the report still shows what to check manually without bringing the false positives back.
- **FP_COMPUTED_BODY whitelist (7 verified entries):** tools whose Zod input shape is fully typed (no `z.record`), but whose callback renames/hardcodes/computes the actual wire body before sending — statically invisible to the collector. Each entry is verified against the real callback code and the real OpenAPI contract:
  - `activate_license:key` — callback sends `{ key: licenseKey }`, Zod field is `licenseKey`
  - `add_label:action` — callback always sends `action: 'add'`, not in the Zod shape
  - `adopt_stack:stacks` — callback builds `stacks: [{ name, composePath, ... }]` from individual fields
  - `remove_stack_env_vars:variables` / `:content` — callback computes a diff and sends the result under names not in the Zod shape (`keys` only)
  - `set_favorite_groups:action` / `set_favorites:action` — callback always sends `action: 'reorder'`

## Result

`docs/body-contract-report.md` regenerated: `BODY_PARAM_MISSING_REQUIRED` drops from **38 to 8**. The remaining 8 are real gaps (e.g. `list_batch_operations` and `trigger_test_notification` send no body at all, `create_role`'s `permissions` is Zod-optional but backend-required, `set_user_roles` sends `roles` instead of `roleId`) — a follow-up issue for those is tracked separately, **not** touched here.

Exit-code-critical buckets (`ORPHANED_TOOL`, `PARAM_MISMATCH`, `MISSING_ENCODE`, `QUERY_PARAM_*`) are unchanged; `validate-mcp-tools.mjs` still exits 0 (body findings remain advisory, no CI-gate effect — confirmed by diffing full validator output before/after this change).

Refs #57.

## Test plan

- [x] New/updated unit tests in `tests/body-checks.test.ts` (passthrough suppression, `expectedRequired` enrichment, whitelist filtering by `tool:field`, whitelist-set content pin)
- [x] New `tests/body-checks-whitelist-anti-orphan.test.ts` — proves each of the 7 whitelist entries still suppresses a genuinely-firing candidate against the **real** contract + **real** registered tool shapes (not fixtures), so a future refactor that fixes the underlying rename/hardcode makes this test fail loudly instead of leaving a dead whitelist entry
- [x] `tests/body-contract-report.test.ts` — `expectedRequired` rendering in the report table
- [x] `npx vitest run` — 598/598 passing
- [x] `npm run build` (`tsc`) — clean
- [x] `node scripts/generate-body-contract-doc.mjs` — `BODY_PARAM_MISSING_REQUIRED` 38 → 8, `docs/body-contract-report.md` committed
- [x] `node scripts/validate-mcp-tools.mjs` exit code diffed before/after this change — unchanged (0), only the advisory `BODY_FINDINGS` count moved (128 → 98)