### PR TITLE
feat(api): add advisory CROSSREF_UNRESOLVED check to the MCP tool validator

### DIFF
--- a/scripts/lib/crossref-checks.mjs
+++ b/scripts/lib/crossref-checks.mjs
@@ -1,0 +1,153 @@
+/**
+ * Cross-Ref-Unresolved-Check (advisory, Task P3.6, Refs #57).
+ *
+ * `derive-description.ts` (src/openapi/derive-description.ts) already parses the two-form
+ * cross-reference contract embedded in `docs/dockhand-openapi.json`'s own text -- see that
+ * file's header for the exact grammar:
+ *   - path/query parameter description: `<desc> (from <METHOD> /api/<path>)`
+ *   - operation-wide `description` prose: `<field> from <METHOD> /api/<path>`
+ * -- and resolves each reference to the MCP tool name that serves the REFERENCED endpoint,
+ * via `endpointToTool()` (src/openapi/tool-endpoint.ts). That resolution is best-effort by
+ * design: `formatCrossRef()`/`formatParamCrossRef()` fall back to the raw `METHOD /api/path`
+ * string when no tool covers it, so a typo'd or deliberately-omitted target endpoint never
+ * breaks description generation.
+ *
+ * This module answers a DIFFERENT question with the SAME extraction grammar: not "what
+ * should the description text say", but "does every cross-ref actually point at SOMETHING
+ * WE EXPOSE" -- i.e. is `endpointToTool()`'s fallback ever silently hit in practice? Each
+ * unresolved case is either a typo in the annotation (the referenced `/api/...` path does
+ * not exist, or exists under a different method) or a deliberate reference to an endpoint we
+ * have not wrapped yet -- both worth surfacing, neither worth failing CI over (see
+ * `checkCrossRefs()` below and its caller in `scripts/validate-mcp-tools.mjs`, where the
+ * resulting findings never influence `hasCriticalErrors()`/the exit code).
+ *
+ * Deliberately re-implements the SAME two regexes as derive-description.ts rather than
+ * importing it: this module lives in `scripts/` (plain JS, run directly via `node`, no
+ * build/tsx step -- see the "tsx-free" convention documented at the top of
+ * `scripts/validate-mcp-tools.mjs`), `derive-description.ts` lives in `src/` (TypeScript,
+ * compiled/run via tsc/tsx). Importing across that boundary would either require a build
+ * step before every `node scripts/validate-mcp-tools.mjs` run, or a `tsx` subprocess like
+ * the existing (optional, gracefully-skippable) body-shape collector -- disproportionate for
+ * two small, stable regexes that are themselves the documented, versioned contract, not an
+ * implementation detail likely to drift silently. Should the two definitions ever diverge,
+ * `tests/derive-description-crossref-parity.test.ts` is the intended regression guard (not
+ * part of this task).
+ */
+
+const HTTP_METHODS = 'GET|POST|PUT|DELETE|PATCH';
+
+/** `<field> from <METHOD> /api/<path>` — used in operation-wide description prose. */
+const PROSE_CROSS_REF_SOURCE = `([A-Za-z_][A-Za-z0-9_]*) from (${HTTP_METHODS}) (\\/api\\/[^\\s.,;)]+)`;
+
+/** `(from <METHOD> /api/<path>)` — used in path/query parameter descriptions. */
+const PAREN_CROSS_REF_SOURCE = `\\(from (${HTTP_METHODS}) (\\/api\\/[^\\s)]+)\\)`;
+
+/**
+ * @typedef {{ method: string, path: string }} CrossRefTarget
+ * @typedef {{ tool: string, refs: CrossRefTarget[] }} CrossRefEntry
+ *   One OpenAPI operation's cross-refs, labeled with the tool that OWNS the operation
+ *   (i.e. the tool a caller would use to reach the endpoint carrying the annotation --
+ *   NOT the referenced target). See `buildCrossRefEntries()` below for how the real spec
+ *   is turned into a list of these.
+ * @typedef {{ type: 'CROSSREF_UNRESOLVED', tool: string, method: string, path: string }} CrossRefFinding
+ */
+
+/**
+ * Extracts every cross-ref (both forms) from a single OpenAPI operation object
+ * (`spec.paths[path][method]`, or any object shaped like one -- tests pass plain
+ * literals). Order: parameter refs first (in declaration order), then prose refs (in
+ * regex match order) -- matches `deriveToolDescription()`'s own ordering in
+ * derive-description.ts, though nothing here depends on that order.
+ * @param {{ description?: string, parameters?: Array<{in?: string, name?: string, description?: string}> }} op
+ * @returns {CrossRefTarget[]}
+ */
+function extractCrossRefsFromOperation(op) {
+  const refs = [];
+
+  for (const param of op?.parameters ?? []) {
+    if (param?.in !== 'path' && param?.in !== 'query') continue;
+    if (!param?.description) continue;
+    const match = new RegExp(PAREN_CROSS_REF_SOURCE).exec(param.description);
+    if (match) refs.push({ method: match[1], path: match[2] });
+  }
+
+  const description = op?.description;
+  if (description) {
+    const re = new RegExp(PROSE_CROSS_REF_SOURCE, 'g');
+    let match;
+    while ((match = re.exec(description)) !== null) {
+      refs.push({ method: match[2], path: match[3] });
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Builds the `entries` input `checkCrossRefs()` expects, from a real loaded OpenAPI spec
+ * (`loadOpenApiSpec()`, scripts/lib/openapi-contract-source.mjs) and an `endpointToTool`
+ * resolver for the OWNING side (same function signature `checkCrossRefs` itself takes for
+ * the referenced side -- callers typically pass the identical resolver to both).
+ *
+ * Operations with zero extracted refs are skipped entirely (nothing to check). An
+ * operation whose OWN endpoint has no covering tool still contributes its entry --
+ * `entry.tool` falls back to `"METHOD /api/path"` (mirrors `formatCrossRef()`'s own
+ * fallback in derive-description.ts) so the finding remains attributable even though no
+ * MCP tool exposes the annotation's source.
+ * @param {object} spec Parsed `docs/dockhand-openapi.json` (or an equivalent fixture)
+ * @param {(method: string, path: string) => string | undefined} endpointToTool
+ * @returns {CrossRefEntry[]}
+ */
+function buildCrossRefEntries(spec, endpointToTool) {
+  const entries = [];
+  const methodPattern = new RegExp(`^(${HTTP_METHODS.toLowerCase()})$`);
+
+  for (const [path, operations] of Object.entries(spec?.paths ?? {})) {
+    for (const [method, op] of Object.entries(operations ?? {})) {
+      if (!methodPattern.test(method)) continue; // skip non-HTTP keys (e.g. "parameters")
+
+      const refs = extractCrossRefsFromOperation(op);
+      if (refs.length === 0) continue;
+
+      const upperMethod = method.toUpperCase();
+      const owningTool = endpointToTool(upperMethod, path) ?? `${upperMethod} ${path}`;
+      entries.push({ tool: owningTool, refs });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Checks every cross-ref target against `endpointToTool` and reports every one that does
+ * NOT resolve to a covering tool. Pure function, no I/O -- `entries` and `endpointToTool`
+ * are both caller-supplied (see `buildCrossRefEntries()` for the real-spec wiring used by
+ * `scripts/validate-mcp-tools.mjs`).
+ *
+ * Advisory by design (Task P3.6 scope, Refs #57): the caller is responsible for NOT
+ * folding `CROSSREF_UNRESOLVED` into `hasCriticalErrors()` -- this function itself has no
+ * opinion on exit codes, it only reports.
+ * @param {CrossRefEntry[]} entries
+ * @param {(method: string, path: string) => string | undefined} endpointToTool
+ * @returns {CrossRefFinding[]}
+ */
+function checkCrossRefs(entries, endpointToTool) {
+  const findings = [];
+
+  for (const entry of entries ?? []) {
+    for (const ref of entry?.refs ?? []) {
+      const resolved = endpointToTool(ref.method, ref.path);
+      if (resolved) continue;
+      findings.push({
+        type: 'CROSSREF_UNRESOLVED',
+        tool: entry.tool,
+        method: ref.method,
+        path: ref.path,
+      });
+    }
+  }
+
+  return findings;
+}
+
+export { checkCrossRefs, extractCrossRefsFromOperation, buildCrossRefEntries };

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -21,6 +21,10 @@
  *   P2.1-Voll-Sweep + #171)
  * - BODY_PARAM_UNKNOWN / UNTYPED_PASSTHROUGH / BODY_CONTRACT_UNRESOLVED: weiterhin advisory
  *   (siehe scripts/lib/body-checks.mjs, docs/body-contract-report.md)
+ * - CROSSREF_UNRESOLVED: eine `(from METHOD /api/path)`- bzw. `<feld> from METHOD /api/path`-
+ *   Cross-Ref-Annotation in docs/dockhand-openapi.json zeigt auf einen Endpunkt, den kein
+ *   MCP-Tool bedient (Tippfehler in der Annotation oder bewusst ausgelassener Endpunkt) --
+ *   advisory, Task P3.6 (siehe scripts/lib/crossref-checks.mjs)
  *
  * Required vs. optional kommt aus dem Schema (von extract-dockhand-api.mjs anhand des
  * echten `if (!x) { ... status: 4xx ... }`-Guards im Handler klassifiziert) — es gibt
@@ -44,6 +48,7 @@ import { findMatchingClose, splitTopLevel, extractObjectKey } from './lib/js-sca
 import { resolveQueryParamKeys } from './lib/query-params.mjs';
 import { getBodyContract, getOperationParamNames, loadOpenApiSpec } from './lib/openapi-contract-source.mjs';
 import { computeBodyFindings } from './lib/body-checks.mjs';
+import { checkCrossRefs, buildCrossRefEntries } from './lib/crossref-checks.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -390,6 +395,64 @@ function buildOpenApiPathIndex() {
   return index;
 }
 
+// --- Cross-Ref-Unresolved-Check (Task P3.6, advisory) ---
+//
+// Same "own resolver, no cross-stack import" reasoning as scripts/generate-tool-endpoint-map.mjs's
+// buildMap(): rather than importing src/openapi/tool-endpoint.ts's endpointToTool() (TypeScript,
+// would need a tsx subprocess like loadToolBodyShapes() below), this builds an equivalent
+// method+path -> toolName index directly from the SAME toolCalls + openApiPathIndex this file
+// already extracts for the body-contract checks -- no new I/O, no tsx dependency.
+
+/**
+ * Builds a `endpointKey(realOpenApiPath, METHOD) -> toolName` index from `toolCalls`, by
+ * resolving each call's own path form to the OpenAPI spec's path form via `openApiPathIndex`
+ * (same normalizePath()-based matching `buildOpenApiPathIndex()`'s callers already rely on).
+ * First tool call to reach a given real endpoint wins (mirrors generate-tool-endpoint-map.mjs's
+ * `buildMap()` "first call wins" rule) -- acceptable here because this index is advisory-only
+ * (CROSSREF_UNRESOLVED never gates the exit code, see computeCrossRefFindings() below): a
+ * cross-ref resolving to the "wrong" of two tools sharing an endpoint is still correctly
+ * reported as RESOLVED, which is all this check cares about.
+ * @param {Array} toolCalls Rückgabe von extractToolCalls()
+ * @param {Map<string, string>} openApiPathIndex Rückgabe von buildOpenApiPathIndex()
+ * @returns {Map<string, string>}
+ */
+function buildEndpointToToolIndex(toolCalls, openApiPathIndex) {
+  const index = new Map();
+  for (const call of toolCalls) {
+    const realPath = openApiPathIndex.get(endpointKey(call.path, call.httpMethod));
+    if (!realPath) continue; // endpoint not (yet) in the OpenAPI spec -- same skip as computeBodyFindingsForCalls()
+    const key = endpointKey(realPath, call.httpMethod);
+    if (!index.has(key)) index.set(key, call.toolName);
+  }
+  return index;
+}
+
+/**
+ * Computes CROSSREF_UNRESOLVED findings (Task P3.6) for every cross-ref annotation in
+ * `docs/dockhand-openapi.json` whose target endpoint no registered MCP tool serves.
+ * Advisory: the caller MUST NOT fold the result into hasCriticalErrors() (see that
+ * function's own doc comment for the full list of what IS critical).
+ * @param {Array} toolCalls Rückgabe von extractToolCalls()
+ * @param {Map<string, string>|null} openApiPathIndex Rückgabe von buildOpenApiPathIndex()
+ * @returns {import('./lib/crossref-checks.mjs').CrossRefFinding[]}
+ */
+function computeCrossRefFindings(toolCalls, openApiPathIndex) {
+  if (!openApiPathIndex) return [];
+
+  let spec;
+  try {
+    spec = loadOpenApiSpec();
+  } catch {
+    return [];
+  }
+
+  const endpointToToolIndex = buildEndpointToToolIndex(toolCalls, openApiPathIndex);
+  const endpointToTool = (method, path) => endpointToToolIndex.get(endpointKey(path, method));
+
+  const entries = buildCrossRefEntries(spec, endpointToTool);
+  return checkCrossRefs(entries, endpointToTool);
+}
+
 /**
  * Sammelt die Body-Shapes ALLER registrierten MCP-Tools, indem der eigenständige
  * `tsx`-Collector (scripts/collect-tool-shapes.mjs) als Subprozess ausgeführt wird — siehe
@@ -511,7 +574,7 @@ function computeBodyFindingsForCalls(toolCalls, toolBodyShapes, openApiPathIndex
  * @returns {{
  *   covered: Array, missingTool: Array, orphanedTool: Array, paramMismatch: Array,
  *   missingEncode: Array, queryParamMissingRequired: Array, queryParamUnknown: Array,
- *   bodyFindings: Array, excludedCount: number
+ *   bodyFindings: Array, crossRefFindings: Array, excludedCount: number
  * }}
  */
 function computeValidation(schema, toolCalls, toolBodyShapes = null) {
@@ -635,13 +698,23 @@ function computeValidation(schema, toolCalls, toolBodyShapes = null) {
   // covered/missingTool/.../queryParamUnknown -- eigener Bucket. Seit Task P2.2 ist
   // BODY_PARAM_MISSING_REQUIRED darin selbst kritisch (siehe hasCriticalErrors() unten);
   // die übrigen drei Finding-Typen bleiben advisory.
+  //
+  // openApiPathIndex wird UNABHÄNGIG von toolBodyShapes gebaut (anders als vorher) --
+  // computeCrossRefFindings() (Task P3.6, Schritt 7 unten) braucht ihn genauso, hat aber
+  // KEINE Abhängigkeit vom tsx-Body-Shape-Collector (der einzige Grund, warum Body-Checks
+  // an toolBodyShapes gekoppelt sind). `null`, wenn docs/dockhand-openapi.json (noch) nicht
+  // existiert -- beide Checks überspringen sich dann selbst (siehe buildOpenApiPathIndex()
+  // JSDoc).
+  const openApiPathIndex = buildOpenApiPathIndex();
+
   let bodyFindings = [];
-  if (toolBodyShapes) {
-    const openApiPathIndex = buildOpenApiPathIndex();
-    if (openApiPathIndex) {
-      bodyFindings = computeBodyFindingsForCalls(toolCalls, toolBodyShapes, openApiPathIndex);
-    }
+  if (toolBodyShapes && openApiPathIndex) {
+    bodyFindings = computeBodyFindingsForCalls(toolCalls, toolBodyShapes, openApiPathIndex);
   }
+
+  // 7. Cross-Ref-Unresolved-Check (Task P3.6, advisory) -- unabhängig von toolBodyShapes,
+  // siehe computeCrossRefFindings() JSDoc.
+  const crossRefFindings = computeCrossRefFindings(toolCalls, openApiPathIndex);
 
   return {
     covered,
@@ -652,6 +725,7 @@ function computeValidation(schema, toolCalls, toolBodyShapes = null) {
     queryParamMissingRequired,
     queryParamUnknown,
     bodyFindings,
+    crossRefFindings,
     excludedCount,
   };
 }
@@ -751,6 +825,7 @@ function validate() {
     queryParamMissingRequired,
     queryParamUnknown,
     bodyFindings,
+    crossRefFindings,
   } = computeValidation(schema, toolCalls, toolBodyShapes);
 
   // Report generieren
@@ -764,6 +839,7 @@ function validate() {
     queryParamMissingRequired,
     queryParamUnknown,
     bodyFindings,
+    crossRefFindings,
   });
 
   writeFileSync(REPORT_FILE, report, 'utf8');
@@ -781,6 +857,7 @@ function validate() {
   const { critical: bodyFindingsCritical, advisory: bodyFindingsAdvisory } = partitionBodyFindings(bodyFindings);
   console.error(`  BODY_PARAM_MISSING_REQUIRED: ${bodyFindingsCritical.length} laut Contract required Body-Felder, die das Tool nicht sendet`);
   console.error(`  BODY_FINDINGS (informativ, kein Exit-Code-Effekt): ${bodyFindingsAdvisory.length}`);
+  console.error(`  CROSSREF_UNRESOLVED (informativ, kein Exit-Code-Effekt): ${crossRefFindings.length} Cross-Ref-Annotationen ohne bedienenden Tool`);
 
   // Exit-Code: Fehler bei kritischen Problemen.
   // QUERY_PARAM_UNKNOWN ist wie ORPHANED_TOOL/PARAM_MISMATCH eindeutig ein Bug (das
@@ -820,7 +897,7 @@ function validate() {
 /**
  * Generiert den Markdown-Report
  */
-function generateReport({ schema, covered, missingTool, orphanedTool, paramMismatch, missingEncode, queryParamMissingRequired, queryParamUnknown, bodyFindings = [] }) {
+function generateReport({ schema, covered, missingTool, orphanedTool, paramMismatch, missingEncode, queryParamMissingRequired, queryParamUnknown, bodyFindings = [], crossRefFindings = [] }) {
   const lines = [];
   const now = new Date().toISOString();
   // Task P2.2: BODY_PARAM_MISSING_REQUIRED bekommt eine eigene Kritisch-Section (analog zu
@@ -850,6 +927,7 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
   lines.push(`| QUERY_PARAM_UNKNOWN | ${queryParamUnknown.length} |`);
   lines.push(`| BODY_PARAM_MISSING_REQUIRED | ${bodyFindingsCritical.length} |`);
   lines.push(`| BODY_FINDINGS (informativ, übrige Body-Typen) | ${bodyFindingsAdvisory.length} |`);
+  lines.push(`| CROSSREF_UNRESOLVED (informativ) | ${crossRefFindings.length} |`);
   lines.push('');
 
   // Kritische Probleme
@@ -967,6 +1045,31 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
     lines.push('');
   }
 
+  // CROSSREF_UNRESOLVED (Task P3.6, informativ/advisory -- KEIN Exit-Code-Effekt). Eine
+  // `(from METHOD /api/path)`- bzw. `<feld> from METHOD /api/path`-Annotation in
+  // docs/dockhand-openapi.json zeigt auf einen Endpunkt, den kein MCP-Tool bedient --
+  // entweder ein Tippfehler in der Annotation, oder ein bewusst (noch) nicht bewrappter
+  // Endpunkt. `tool` ist der ANFRAGENDE Tool-Name (dessen Beschreibung die Annotation
+  // trägt), `method`/`path` sind das unaufgelöste ZIEL der Annotation -- siehe
+  // scripts/lib/crossref-checks.mjs.
+  if (crossRefFindings.length > 0) {
+    lines.push('## CROSSREF_UNRESOLVED (Informativ / Advisory)');
+    lines.push('');
+    lines.push(
+      'Cross-Ref-Annotationen in `docs/dockhand-openapi.json` (`(from METHOD /api/path)` ' +
+        'bzw. `<feld> from METHOD /api/path`), deren Ziel-Endpunkt kein registriertes ' +
+        'MCP-Tool bedient. **Kein Gate** -- Kandidaten für Tippfehler in der Annotation ODER ' +
+        'für die Omission-Registry (bewusst ausgelassene Endpunkte).'
+    );
+    lines.push('');
+    lines.push('| Anfragendes Tool/Endpunkt | Ziel-HTTP | Ziel-Pfad |');
+    lines.push('|---------------------------|-----------|-----------|');
+    for (const f of crossRefFindings) {
+      lines.push(`| \`${f.tool}\` | ${f.method} | \`${f.path}\` |`);
+    }
+    lines.push('');
+  }
+
   // Fehlende Tools (informativ)
   if (missingTool.length > 0) {
     lines.push('## MISSING_TOOL (Informativ)');
@@ -1020,6 +1123,8 @@ export {
   isIgnored,
   buildOpenApiPathIndex,
   computeBodyFindingsForCalls,
+  buildEndpointToToolIndex,
+  computeCrossRefFindings,
   computeValidation,
   loadSchema,
   CRITICAL_BODY_FINDING_TYPES,

--- a/tests/crossref-unresolved.test.ts
+++ b/tests/crossref-unresolved.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { checkCrossRefs, extractCrossRefsFromOperation } from '../scripts/lib/crossref-checks.mjs';
+
+describe('checkCrossRefs (P3 Task 6, advisory)', () => {
+  it('meldet CROSSREF_UNRESOLVED fuer einen Verweis ohne Tool', () => {
+    const findings = checkCrossRefs(
+      [{ tool: 'create_git_stack', refs: [{ method: 'GET', path: '/api/nonexistent' }] }],
+      () => undefined
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].type).toBe('CROSSREF_UNRESOLVED');
+  });
+
+  it('meldet NICHTS fuer aufloesbare Verweise', () => {
+    const findings = checkCrossRefs(
+      [{ tool: 'create_git_stack', refs: [{ method: 'GET', path: '/api/environments' }] }],
+      (m, p) => (p === '/api/environments' ? 'list_environments' : undefined)
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  it('traegt den anfragenden Tool-Namen sowie Ziel-Methode/-Pfad in das Finding ein', () => {
+    const findings = checkCrossRefs(
+      [{ tool: 'create_git_stack', refs: [{ method: 'GET', path: '/api/nonexistent' }] }],
+      () => undefined
+    );
+    expect(findings[0]).toMatchObject({
+      type: 'CROSSREF_UNRESOLVED',
+      tool: 'create_git_stack',
+      method: 'GET',
+      path: '/api/nonexistent',
+    });
+  });
+
+  it('prueft mehrere Refs pro Eintrag unabhaengig voneinander', () => {
+    const findings = checkCrossRefs(
+      [
+        {
+          tool: 'create_git_stack',
+          refs: [
+            { method: 'GET', path: '/api/environments' },
+            { method: 'GET', path: '/api/typo' },
+          ],
+        },
+      ],
+      (m, p) => (p === '/api/environments' ? 'list_environments' : undefined)
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('/api/typo');
+  });
+
+  it('behandelt einen Eintrag ohne Refs als Nicht-Fund', () => {
+    const findings = checkCrossRefs([{ tool: 'create_git_stack', refs: [] }], () => undefined);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('behandelt eine leere Eintragsliste als Nicht-Fund', () => {
+    expect(checkCrossRefs([], () => undefined)).toEqual([]);
+  });
+});
+
+describe('extractCrossRefsFromOperation (P3 Task 6)', () => {
+  it('extrahiert einen Parameter-Cross-Ref der Form "(from METHOD /api/path)"', () => {
+    const op = {
+      parameters: [
+        { in: 'path', name: 'environmentId', description: 'The environment (from GET /api/environments)' },
+      ],
+    };
+    const refs = extractCrossRefsFromOperation(op);
+    expect(refs).toContainEqual({ method: 'GET', path: '/api/environments' });
+  });
+
+  it('ignoriert Parameter ohne Cross-Ref-Anmerkung', () => {
+    const op = {
+      parameters: [{ in: 'path', name: 'id', description: 'Just a plain id' }],
+    };
+    expect(extractCrossRefsFromOperation(op)).toEqual([]);
+  });
+
+  it('ignoriert body-/header-Parameter (nur path/query zaehlen)', () => {
+    const op = {
+      parameters: [
+        { in: 'header', name: 'X-Foo', description: 'Something (from GET /api/environments)' },
+      ],
+    };
+    expect(extractCrossRefsFromOperation(op)).toEqual([]);
+  });
+
+  it('extrahiert einen Prosa-Cross-Ref der Form "<field> from METHOD /api/path" aus der description', () => {
+    const op = {
+      description: 'containerId from GET /api/containers.',
+    };
+    const refs = extractCrossRefsFromOperation(op);
+    expect(refs).toContainEqual({ method: 'GET', path: '/api/containers' });
+  });
+
+  it('extrahiert mehrere Prosa-Cross-Refs aus derselben description', () => {
+    const op = {
+      description: 'containerId from GET /api/containers, environmentId from GET /api/environments.',
+    };
+    const refs = extractCrossRefsFromOperation(op);
+    expect(refs).toContainEqual({ method: 'GET', path: '/api/containers' });
+    expect(refs).toContainEqual({ method: 'GET', path: '/api/environments' });
+  });
+
+  it('kombiniert Parameter- und Prosa-Cross-Refs derselben Operation', () => {
+    const op = {
+      parameters: [
+        { in: 'query', name: 'environmentId', description: 'Env (from GET /api/environments)' },
+      ],
+      description: 'containerId from GET /api/containers.',
+    };
+    const refs = extractCrossRefsFromOperation(op);
+    expect(refs).toHaveLength(2);
+  });
+
+  it('liefert ein leeres Array fuer eine Operation ohne parameters/description', () => {
+    expect(extractCrossRefsFromOperation({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

P3 Task 6 (Refs #57): adds a new, purely **advisory** validator check —
`CROSSREF_UNRESOLVED`.

- `docs/dockhand-openapi.json` carries `(from METHOD /api/path)` (param
  descriptions) and `<field> from METHOD /api/path` (operation description
  prose) cross-ref annotations — the same two-form grammar
  `src/openapi/derive-description.ts` already parses to resolve tool names
  inside slim MCP tool descriptions.
- New `scripts/lib/crossref-checks.mjs` re-extracts those refs (kept
  `scripts/`-local/tsx-free rather than importing across the `src/`
  TypeScript boundary, same reasoning as the existing tsx-free
  `validate-mcp-tools.mjs`) and reports every ref whose **target** endpoint
  is not served by any registered MCP tool.
- Wired into `computeValidation()`/`generateReport()` as a new, independent
  bucket with its own report section — **never** folded into
  `hasCriticalErrors()`, exit code unaffected.
- `endpointToTool` resolution reuses the exact same `toolCalls` +
  `buildOpenApiPathIndex()` data the body-contract checks already extract
  (first-call-wins, mirrors `generate-tool-endpoint-map.mjs`'s `buildMap()`)
  — no new I/O, no new subprocess.

## Real run against the current spec

```
CROSSREF_UNRESOLVED (informativ, kein Exit-Code-Effekt): 33 Cross-Ref-Annotationen ohne bedienenden Tool
```

All 33 are attributable to a single root cause, not annotation typos: an
entire feature area — the Backup API (`/api/backup/configs`,
`/api/backup/destinations`, `/api/backup/snapshots`, 29 endpoints total) plus
`GET /api/self-update/progress` — has **zero** MCP tool coverage today (same
endpoints also show up in `MISSING_TOOL`). Every unresolved target path is a
real, valid endpoint per the spec; none of the 33 point at a nonexistent
path. These are candidates for the omission registry (P3 Task 7), not bugs
to fix in this task.

Exit code confirmed `0` on a full run (`node
scripts/validate-mcp-tools.mjs`), i.e. the check is genuinely advisory.

## Test plan

- [x] TDD: failing tests first (`Cannot find module
      '../scripts/lib/crossref-checks.mjs'`), then implementation, then
      green — `tests/crossref-unresolved.test.ts` (13 tests: `checkCrossRefs`
      unresolved/resolved/multi-ref/empty-input, plus
      `extractCrossRefsFromOperation` param-form/prose-form/combined/none)
- [x] `npx vitest run` — 46 files, 623 tests, all passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Real validator run against `docs/dockhand-openapi.json` — 33
      `CROSSREF_UNRESOLVED` findings, all triaged, exit code `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
