### PR TITLE
feat(docs): add omission registry for deliberately un-mirrored endpoints

### DIFF
--- a/docs/adr/0001-omission-registry.md
+++ b/docs/adr/0001-omission-registry.md
@@ -1,0 +1,112 @@
+# ADR-0001: Omission-Registry für bewusst nicht gespiegelte Dockhand-Endpunkte
+
+**Status:** accepted
+**Datum:** 2026-08-10
+**Refs:** #57 (P3-Plan), #171 (env-files-Removal), #164 (Backup-API — echte Lücke, KEINE Omission)
+
+## Kontext
+
+`scripts/validate-mcp-tools.mjs` vergleicht bei jedem Lauf die Endpunkte im generierten
+Dockhand-API-Schema (`docs/dockhand-api-schema.json`) mit den tatsächlich registrierten
+MCP-Tools (`src/tools/*.ts`). Jeder Endpunkt ohne Tool erzeugt einen `MISSING_TOOL`-Fund
+(informativ, kein CI-Gate) — sichtbar in `validation-report.md` und in der eingecheckten
+`docs/coverage.md`.
+
+Zwei grundverschiedene Situationen erzeugen denselben `MISSING_TOOL`-Fund:
+
+1. **Echte Lücke** — der Endpunkt existiert, ein Tool dafür ist geplant, aber (noch) nicht
+   gebaut. Beispiel: die komplette Backup-API (`/api/backup/*`), 29 Endpunkte, Tracking-Issue
+   #164.
+2. **Bewusste Auslassung** — wir werden NIE ein Tool dafür bauen, aus einem dokumentierten
+   Grund (Sicherheit, Redundanz, technische Eignung). Beispiel: `POST
+   /api/git/stacks/{id}/env-files` wurde in #171 als eigenes Tool entfernt, weil es
+   read-only-redundant zu `get_git_stack_env_files` (GET) plus `update_git_stack`/
+   `update_stack_env` für Schreib-Operationen war.
+
+Vor diesem ADR gab es dafür zwei getrennte, unvollständige Mechanismen:
+
+- `IGNORED_PATTERNS` in `validate-mcp-tools.mjs` — ein Array von Pfad-Substrings (Streams,
+  Debug, Self-Update, ...), das betroffene Endpunkte VOR der `MISSING_TOOL`-Berechnung
+  herausfiltert und nur als aggregierte Zahl (`excludedCount`) zählt. Kein Grund, kein
+  Zeitstempel, keine Nachvollziehbarkeit pro Endpunkt — nur ein Musterausdruck im Code.
+- Für endpunkt-genaue Einzelfälle wie `POST /api/git/stacks/{id}/env-files` gab es GAR
+  KEINEN Mechanismus — der Endpunkt tauchte schlicht als `MISSING_TOOL` auf, ununterscheidbar
+  von einer echten Lücke wie der Backup-API.
+
+Das Problem: ohne Unterscheidung sieht ein Betrachter von `docs/coverage.md` 37
+`MISSING_TOOL`-Einträge und kann nicht erkennen, welche davon tatsächlich noch zu bauen
+sind (#164, priorisierbar) und welche für immer offen bleiben werden (kein Backlog-Posten).
+
+## Entscheidung
+
+Wir führen eine maschinenlesbare **Omission-Registry** (`docs/omitted-endpoints.json`) ein:
+ein JSON-Array von Einträgen `{ method, path, reason, adr, date }`, je einer pro bewusst
+NICHT gespiegeltem Endpunkt.
+
+`scripts/lib/omission-registry.mjs` (`partitionMissingTools()`) trennt die rohen
+`MISSING_TOOL`-Funde aus `computeValidation()` anhand dieser Registry in:
+
+- **`realGaps`** — kein Registry-Treffer. Verhält sich exakt wie das bisherige
+  `MISSING_TOOL` (feuert in derselben Stelle, gleiches Exit-Code-Verhalten — `MISSING_TOOL`
+  war nie Teil von `hasCriticalErrors()` und bleibt es nicht).
+- **`deliberatelyOmitted`** — Registry-Treffer, angereichert mit `reason`/`adr`. Erscheint
+  in `docs/coverage.md` UNTER EINEM EIGENEN, SICHTBAREN Abschnitt ("Deliberately omitted
+  (with reason)") — kein stilles Verschwinden, sondern eine dokumentierte, nachvollziehbare
+  Entscheidung.
+
+### Verhältnis zu `IGNORED_PATTERNS`
+
+`IGNORED_PATTERNS` bleibt für **breite, musterbasierte** Ausschlüsse bestehen (z.B. `/stream`
+matcht alle vier SSE-Stream-Endpunkte, `/api/debug/` würde jeden künftigen Debug-Endpunkt
+mitausschließen, ohne dass jemand die Registry pflegen muss). Diese Endpunkte werden bereits
+VOR der `MISSING_TOOL`-Berechnung herausgefiltert (`excludedCount`) — sie erreichen
+`partitionMissingTools()` nie und werden dort folglich auch nicht doppelt unterdrückt.
+
+Die Omission-Registry ist trotzdem die **Single Source of Truth für die Begründung**: alle
+22 aktuell über `IGNORED_PATTERNS` ausgeschlossenen Endpunkte (Stand 2026-08-10, siehe
+`docs/omitted-endpoints.json`) sind zusätzlich als Registry-Eintrag dokumentiert — mit
+individueller Begründung statt nur einem Kommentar neben einem Pfad-Substring im Code. Für
+diese 22 wirkt der Ausschluss weiterhin über `IGNORED_PATTERNS` (technischer Mechanismus,
+unverändert); die Registry liefert nur die für Menschen lesbare Begründung UND die
+`docs/coverage.md`-Sichtbarkeit. Für endpunkt-genaue Einzelfälle wie `POST
+/api/git/stacks/{id}/env-files`, die NICHT über ein Pfad-Muster erfasst werden (der Pfad ist
+nicht Teil einer größeren, ebenfalls auszuschließenden Familie), ist die Registry über
+`partitionMissingTools()` der EINZIGE Unterdrückungsmechanismus.
+
+**Faustregel für neue Einträge:** eine ganze Endpunkt-FAMILIE (Streams, Debug, Self-Update,
+...) → `IGNORED_PATTERNS`-Pattern ergänzen UND Registry-Einträge für die betroffenen
+Endpunkte anlegen (Begründung). Ein EINZELNER Endpunkt ohne verwandte Geschwister → nur
+Registry-Eintrag, kein neues `IGNORED_PATTERNS`-Pattern nötig.
+
+### Was NIEMALS in die Registry gehört
+
+Eine geplante, aber noch nicht gebaute API-Fläche — auch wenn sie groß ist (Backup-API #164,
+29 Endpunkte). Ein Registry-Eintrag bedeutet "wir bauen das NIE", nicht "wir haben es noch
+nicht gebaut". Eine versehentliche Registrierung würde `MISSING_TOOL` für einen echten
+Rückstand fälschlich zum Schweigen bringen — genau das Risiko, das `#164` in Task P3.7
+(dieses ADR) explizit als Gegenbeispiel benannt hat.
+
+## Konsequenz
+
+- `docs/coverage.md` zeigt ab sofort einen eigenen Abschnitt "Deliberately omitted (with
+  reason)" für Registry-Treffer — getrennt vom "MISSING_TOOL — nach Bereich"-Abschnitt, der
+  nur noch `realGaps` enthält.
+- `MISSING_TOOL`-Zahl in `docs/coverage.md`/`validation-report.md` sinkt entsprechend um die
+  Anzahl der Registry-Treffer unter den aktuellen `MISSING_TOOL`-Funden (aktuell: 1 —
+  `POST /api/git/stacks/{id}/env-files`; die übrigen 22 Registry-Einträge waren bereits über
+  `IGNORED_PATTERNS` ausgeschlossen und tauchten nie als `MISSING_TOOL` auf).
+- Ein neuer bewusster Ausschluss braucht ab jetzt IMMER einen Registry-Eintrag mit
+  Begründung — kein stiller Codepfad mehr, der einen Endpunkt einfach verschwinden lässt.
+- Dieses ADR etabliert zugleich die ADR-Praxis in diesem Repo (`docs/adr/`, Registry unter
+  `docs/adr/README.md`) für künftige Architektur-Entscheidungen.
+
+## Verlinkung
+
+- Registry: `docs/omitted-endpoints.json`
+- Implementierung: `scripts/lib/omission-registry.mjs` (`partitionMissingTools()`)
+- Wiring: `scripts/validate-mcp-tools.mjs` (`computeValidation()`, 4. Parameter `registry`)
+- Sichtbarkeit: `scripts/lib/coverage-report.mjs` (`buildCoverageDoc()`, Abschnitt
+  "Deliberately omitted (with reason)")
+- Tests: `tests/omission-registry.test.ts`
+- Tracking-Issue echte Lücke (KEINE Omission): #164 (Backup-API, 29 fehlende Tools)
+- Auslöser-Removal: #171 (`POST /api/git/stacks/{id}/env-files`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records (ADR)
+
+Dieses Verzeichnis dokumentiert Architektur-Entscheidungen für mcp-dockhand — jede Datei ein
+ADR nach dem Schema `NNNN-<slug>.md`.
+
+## Registry
+
+| Nr. | Titel | Status | Datum |
+|-----|-------|--------|-------|
+| [0001](0001-omission-registry.md) | Omission-Registry für bewusst nicht gespiegelte Dockhand-Endpunkte | accepted | 2026-08-10 |
+
+## Wann ein ADR anlegen?
+
+Bei jeder Entscheidung, die künftige Beiträge nachhaltig prägt und deren Begründung sonst nur
+im Kopf einer einzelnen Person oder verstreut in Commit-Messages existieren würde — z.B.
+neue Governance-Mechanismen (wie die Omission-Registry), bewusste Architektur-Abweichungen
+vom naheliegenden Standardweg, oder Entscheidungen, die später leicht falsch nachgeahmt
+werden könnten, wenn der Grund dafür nicht dokumentiert ist.
+
+## Format
+
+Jedes ADR trägt einen Status (`accepted`, `superseded`, ...), Datum, Kontext, Entscheidung und
+Konsequenz — siehe [0001](0001-omission-registry.md) als Vorlage.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,18 +4,19 @@
 > Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
 > Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
 
-**Erzeugt:** 2026-08-10T09:28:04.886Z
+**Erzeugt:** 2026-08-10T19:48:41.982Z
 **Dockhand-Upstream-Commit:** `905c4a004dafe1cbad4ed2babc2c532d7f4018b8`
 **Schema-Endpunkte gesamt:** 235
 
 ## Coverage
 
-**88.7%** (282/318 in-Scope-Endpunkte haben ein MCP-Tool)
+**88.6%** (281/317 in-Scope-Endpunkte haben ein MCP-Tool)
 
 | Status | Anzahl |
 |--------|--------|
-| COVERED | 282 |
+| COVERED | 281 |
 | MISSING_TOOL | 36 |
+| Deliberately omitted (Registry, siehe unten) | 1 |
 | ORPHANED_TOOL | 0 |
 | Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |
 
@@ -89,6 +90,16 @@ ersten Pfad-Segment nach `/api/`:
 | HTTP | Pfad | Path-Parameter |
 |------|------|----------------|
 | GET | `/api/stacks/{name}/delete-preview` | name |
+
+## Deliberately omitted (with reason)
+
+Endpunkte, die laut Schema existieren, aber laut `docs/omitted-endpoints.json` bewusst
+NIE ein MCP-Tool bekommen sollen. Unterscheidet sich von MISSING_TOOL oben: dort stehen
+echte, noch offene Lücken (z.B. die Backup-API, siehe #164).
+
+| HTTP | Pfad | Begründung | ADR |
+|------|------|------------|-----|
+| POST | `/api/git/stacks/{id}/env-files` | Entfernt in #171 — read-only Aufgabe, redundant zu get_git_stack_env_files (GET) plus update_git_stack/update_stack_env für Änderungen. Kein zusätzliches Tool nötig. | docs/adr/0001-omission-registry.md |
 
 ## Details
 

--- a/docs/omitted-endpoints.json
+++ b/docs/omitted-endpoints.json
@@ -1,0 +1,163 @@
+[
+  {
+    "method": "POST",
+    "path": "/api/git/stacks/{id}/env-files",
+    "reason": "Entfernt in #171 — read-only Aufgabe, redundant zu get_git_stack_env_files (GET) plus update_git_stack/update_stack_env für Änderungen. Kein zusätzliches Tool nötig.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/self-update",
+    "reason": "Self-Update-Trigger ist gefährlich über MCP auszulösen — kann den laufenden Dockhand-Prozess ersetzen/neu starten und damit alle aktiven MCP-Verbindungen kappen. Bewusst nie als Tool exponiert.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/self-update/check",
+    "reason": "Gehört zur Self-Update-Familie (siehe POST /api/self-update) — bewusst konsistent mitausgelassen, kein eigenständiger MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/self-update/progress",
+    "reason": "Gehört zur Self-Update-Familie (siehe POST /api/self-update) — bewusst konsistent mitausgelassen, kein eigenständiger MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/auth/login",
+    "reason": "Login läuft über die Dockhand-UI/Session-Cookie, nicht über MCP — ein Tool würde Zugangsdaten durch die Tool-Aufruf-Kette reichen.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/auth/oidc/callback",
+    "reason": "OAuth-Redirect-Callback, wird vom Browser während des Login-Flows aufgerufen — kein sinnvoller eigenständiger MCP-Aufruf.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/containers/{id}/logs/stream",
+    "reason": "SSE-Stream-Endpunkt — wird über die postSSE-Client-Methode der Basis-Operation (get_container_logs) abgedeckt, kein eigenständiges Tool nötig.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/containers/stats/stream",
+    "reason": "SSE-Stream-Endpunkt — wird über die postSSE-Client-Methode der Basis-Operation (get_containers_stats) abgedeckt, kein eigenständiges Tool nötig.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/dashboard/stats/stream",
+    "reason": "SSE-Stream-Endpunkt — wird über die postSSE-Client-Methode der Basis-Operation (get_dashboard_stats) abgedeckt, kein eigenständiges Tool nötig.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/schedules/stream",
+    "reason": "SSE-Stream-Endpunkt — wird über die postSSE-Client-Methode der Basis-Operation (list_schedules) abgedeckt, kein eigenständiges Tool nötig.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/debug/memory",
+    "reason": "Interner Debug-Endpunkt für die Dockhand-Entwicklung, keine für MCP-Nutzer relevante Operation.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/events",
+    "reason": "Globaler SSE-Event-Stream (Server-Sent-Events) — kein für MCP sinnvoller Request/Response-Aufruf.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/jobs/{id}",
+    "reason": "Interne Job-Verwaltung (Dockhand-eigene Hintergrundprozesse), nicht für MCP-Nutzer gedacht.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/jobs/{id}",
+    "reason": "Interne Job-Verwaltung (Dockhand-eigene Hintergrundprozesse), nicht für MCP-Nutzer gedacht.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/hawser/connect",
+    "reason": "Hawser-Agent-WebSocket-Verbindungsaufbau (Node zu Dockhand), kein MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/hawser/connect",
+    "reason": "Hawser-Agent-WebSocket-Verbindungsaufbau (Node zu Dockhand), kein MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/environments/{id}/icon",
+    "reason": "Binäres Icon-Upload/-Download — MCP-Tools transportieren aktuell keine Binärdaten in diesem Format.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/environments/{id}/icon",
+    "reason": "Binäres Icon-Upload/-Download — MCP-Tools transportieren aktuell keine Binärdaten in diesem Format.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/environments/{id}/icon",
+    "reason": "Binäres Icon-Upload/-Download — MCP-Tools transportieren aktuell keine Binärdaten in diesem Format.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "GET",
+    "path": "/api/environments/{id}/disk-warning",
+    "reason": "Interner Health-Warnschwellenwert, wird von Dockhand selbst gesetzt und gelesen — kein MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/environments/{id}/disk-warning",
+    "reason": "Interner Health-Warnschwellenwert, wird von Dockhand selbst gesetzt und gelesen — kein MCP-Anwendungsfall.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/profile/avatar",
+    "reason": "Binäres Avatar-Upload — gleiche Einschränkung wie das Environment-Icon-Upload.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  },
+  {
+    "method": "DELETE",
+    "path": "/api/profile/avatar",
+    "reason": "Binäres Avatar-Upload — gleiche Einschränkung wie das Environment-Icon-Upload.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-10"
+  }
+]

--- a/scripts/generate-coverage-doc.mjs
+++ b/scripts/generate-coverage-doc.mjs
@@ -11,6 +11,11 @@
  * kritische Mismatches findet und mit Exit 1 abbricht) — Coverage-Sichtbarkeit soll nicht
  * an einem unabhängigen Fehler (z.B. ORPHANED_TOOL) hängen.
  *
+ * Lädt seit Task P3.7 (ADR docs/adr/0001-omission-registry.md) zusätzlich die
+ * Omission-Registry (docs/omitted-endpoints.json) und reicht sie an computeValidation()
+ * weiter -- MISSING_TOOL enthält dadurch nur noch echte Lücken, bewusst ausgelassene
+ * Endpunkte erscheinen sichtbar (mit Begründung) im eigenen "Deliberately omitted"-Abschnitt.
+ *
  * Verwendung:
  *   node scripts/generate-coverage-doc.mjs
  */
@@ -18,7 +23,7 @@
 import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadSchema, extractToolCalls, computeValidation } from './validate-mcp-tools.mjs';
+import { loadSchema, extractToolCalls, computeValidation, loadOmissionRegistry } from './validate-mcp-tools.mjs';
 import { buildCoverageDoc } from './lib/coverage-report.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -39,7 +44,13 @@ function stripTimestamp(content) {
 function main() {
   const schema = loadSchema();
   const toolCalls = extractToolCalls();
-  const { covered, missingTool, orphanedTool, excludedCount } = computeValidation(schema, toolCalls);
+  const registry = loadOmissionRegistry();
+  const { covered, missingTool, deliberatelyOmitted, orphanedTool, excludedCount } = computeValidation(
+    schema,
+    toolCalls,
+    null,
+    registry
+  );
 
   const doc = buildCoverageDoc({
     generatedAt: new Date().toISOString(),
@@ -47,6 +58,7 @@ function main() {
     schemaEndpointCount: schema.endpointCount,
     covered,
     missingTool,
+    deliberatelyOmitted,
     orphanedTool,
     excludedCount,
   });

--- a/scripts/lib/coverage-report.mjs
+++ b/scripts/lib/coverage-report.mjs
@@ -52,6 +52,11 @@ function groupMissingByArea(missingTool) {
  * @param {number} input.schemaEndpointCount Gesamtzahl der Endpunkte im Schema (inkl. ausgeschlossener)
  * @param {Array<{path: string, method: string, tools: string[]}>} input.covered
  * @param {Array<{path: string, method: string, pathParams?: string[]}>} input.missingTool
+ * @param {Array<{path: string, method: string, reason: string, adr?: string}>} [input.deliberatelyOmitted]
+ *   Registry-Treffer aus `partitionMissingTools()` (Task P3.7, ADR
+ *   docs/adr/0001-omission-registry.md) -- Endpunkte, die WIR BEWUSST NIE als Tool
+ *   aufnehmen. `[]` (Default) rendert keinen zusätzlichen Abschnitt -- Aufrufer ohne
+ *   Registry (z.B. bestehende Tests) bleiben unverändert kompatibel.
  * @param {Array<{toolName: string, httpMethod: string, path: string, file: string, line: number}>} input.orphanedTool
  * @param {number} input.excludedCount Anzahl bewusst ausgeschlossener Endpunkte (IGNORED_PATTERNS)
  * @returns {string}
@@ -62,6 +67,7 @@ function buildCoverageDoc({
   schemaEndpointCount,
   covered,
   missingTool,
+  deliberatelyOmitted = [],
   orphanedTool,
   excludedCount,
 }) {
@@ -94,6 +100,7 @@ function buildCoverageDoc({
   lines.push('|--------|--------|');
   lines.push(`| COVERED | ${covered.length} |`);
   lines.push(`| MISSING_TOOL | ${missingTool.length} |`);
+  lines.push(`| Deliberately omitted (Registry, siehe unten) | ${deliberatelyOmitted.length} |`);
   lines.push(`| ORPHANED_TOOL | ${orphanedTool.length} |`);
   lines.push(`| Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | ${excludedCount} |`);
   lines.push('');
@@ -122,6 +129,33 @@ function buildCoverageDoc({
     lines.push('## MISSING_TOOL');
     lines.push('');
     lines.push('Keine — alle in-Scope-Endpunkte haben ein MCP-Tool.');
+    lines.push('');
+  }
+
+  // Deliberately omitted (Task P3.7, ADR docs/adr/0001-omission-registry.md) --
+  // Registry-Treffer, die NICHT unter MISSING_TOOL oben auftauchen (Endpunkte, die WIR
+  // BEWUSST NIE als Tool exponieren, z.B. das in #171 entfernte
+  // POST /api/git/stacks/{id}/env-files). Sichtbar mit Begründung + ADR-Verweis statt
+  // kommentarlos zu verschwinden — unterscheidet sich damit von "Bewusst ausgeschlossen"
+  // oben (IGNORED_PATTERNS, aggregierte Zahl ohne Einzel-Begründung).
+  if (deliberatelyOmitted.length > 0) {
+    lines.push('## Deliberately omitted (with reason)');
+    lines.push('');
+    lines.push(
+      'Endpunkte, die laut Schema existieren, aber laut `docs/omitted-endpoints.json` bewusst'
+    );
+    lines.push(
+      'NIE ein MCP-Tool bekommen sollen. Unterscheidet sich von MISSING_TOOL oben: dort stehen'
+    );
+    lines.push('echte, noch offene Lücken (z.B. die Backup-API, siehe #164).');
+    lines.push('');
+    lines.push('| HTTP | Pfad | Begründung | ADR |');
+    lines.push('|------|------|------------|-----|');
+    for (const e of deliberatelyOmitted
+      .slice()
+      .sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method))) {
+      lines.push(`| ${e.method} | \`${e.path}\` | ${e.reason} | ${e.adr ?? '-'} |`);
+    }
     lines.push('');
   }
 

--- a/scripts/lib/omission-registry.mjs
+++ b/scripts/lib/omission-registry.mjs
@@ -1,0 +1,103 @@
+/**
+ * Omission-Governance (P3 Task 7, ADR docs/adr/0001-omission-registry.md, Refs #57).
+ *
+ * `docs/omitted-endpoints.json` listet Dockhand-Endpunkte, die WIR bewusst NIE als
+ * MCP-Tool aufnehmen (z.B. das in #171 entfernte `POST /api/git/stacks/{id}/env-files`,
+ * oder `POST /api/self-update` — gefährlich über MCP). Das ist etwas ANDERES als eine
+ * echte Lücke: die Backup-API (`/api/backup/*`, #164, 29 fehlende Tools) ist geplant,
+ * nur noch nicht implementiert -- sie gehört NIE in diese Registry, sonst würde
+ * `MISSING_TOOL` sie fälschlich unterdrücken.
+ *
+ * `partitionMissingTools()` ist die reine Trenn-Funktion: sie bekommt die rohen
+ * MISSING_TOOL-Funde von `computeValidation()` (scripts/validate-mcp-tools.mjs) und die
+ * geladene Registry, und liefert zwei Eimer zurück -- `realGaps` (bleibt MISSING_TOOL,
+ * feuert wie bisher) und `deliberatelyOmitted` (wird sichtbar in `docs/coverage.md`
+ * unter "Deliberately omitted", aber nicht mehr als Lücke gemeldet).
+ *
+ * WARUM ein eigenes, dupliziertes normalizePath() statt Import aus
+ * validate-mcp-tools.mjs: validate-mcp-tools.mjs importiert seinerseits
+ * partitionMissingTools() aus diesem Modul (für die MISSING_TOOL-Berechnung in
+ * computeValidation()) -- ein Re-Import von dort würde einen ES-Modul-Zirkelbezug
+ * erzeugen. Die Normalisierung selbst ist eine reine, zustandslose Ein-Zeilen-Regel
+ * (Platzhalter `{name}` -> `{*}`, identisch zu normalizePath() dort), die Duplizierung
+ * ist risikofrei und macht dieses Modul unabhängig importierbar/testbar.
+ */
+
+/**
+ * Normalisiert einen API-Pfad für den Vergleich: ersetzt jeden `{name}`-Platzhalter
+ * durch den generischen Platzhalter `{*}`, damit unterschiedliche Parameter-Namen
+ * (Schema `{id}` vs. Tool-Aufruf `{stackId}`) denselben Match ergeben -- exakt dieselbe
+ * Regel wie `normalizePath()` in scripts/validate-mcp-tools.mjs (siehe Datei-Kopf-Kommentar
+ * für das WARUM der Duplizierung statt Import).
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizePath(path) {
+  return path.replace(/\{[^}]+\}/g, '{*}');
+}
+
+/**
+ * Baut den Lookup-Key aus HTTP-Methode + normalisiertem Pfad.
+ * @param {string} method
+ * @param {string} path
+ * @returns {string}
+ */
+function registryKey(method, path) {
+  return `${method.toUpperCase()} ${normalizePath(path)}`;
+}
+
+/**
+ * Baut einen `registryKey() -> Registry-Eintrag`-Lookup aus der geladenen Registry
+ * (Array aus `docs/omitted-endpoints.json`).
+ * @param {Array<{method: string, path: string, reason: string, adr?: string, date?: string}>} registry
+ * @returns {Map<string, object>}
+ */
+function buildRegistryIndex(registry) {
+  const index = new Map();
+  for (const entry of registry ?? []) {
+    index.set(registryKey(entry.method, entry.path), entry);
+  }
+  return index;
+}
+
+/**
+ * Trennt die rohen MISSING_TOOL-Funde in `realGaps` (kein Registry-Eintrag -- bleibt
+ * eine echte Lücke, z.B. die Backup-API #164) und `deliberatelyOmitted` (Registry-Treffer
+ * -- bewusste Auslassung, mit `reason`/`adr` aus dem Registry-Eintrag angereichert, damit
+ * `docs/coverage.md` sie SICHTBAR unter "Deliberately omitted" auflisten kann statt sie
+ * kommentarlos verschwinden zu lassen).
+ *
+ * Reine Funktion, kein I/O -- `missingToolEntries` und `registry` sind beide
+ * caller-supplied (siehe `scripts/validate-mcp-tools.mjs` für das Laden von
+ * `docs/omitted-endpoints.json` und die Verdrahtung in `computeValidation()`).
+ * @param {Array<{method: string, path: string, [key: string]: any}>} missingToolEntries
+ *   Rückgabeform von `computeValidation()`s bisherigem `missingTool`-Bucket -- Achtung,
+ *   DORT heißt das Feld `method`, nicht `httpMethod` (siehe dessen `missingTool.push({
+ *   path: ep.path, method, pathParams: ep.pathParams })`).
+ * @param {Array<{method: string, path: string, reason: string, adr?: string, date?: string}>} registry
+ *   Rückgabe von `docs/omitted-endpoints.json` (bzw. `[]`, wenn die Datei fehlt).
+ * @returns {{ realGaps: Array, deliberatelyOmitted: Array }}
+ */
+function partitionMissingTools(missingToolEntries, registry) {
+  const registryIndex = buildRegistryIndex(registry);
+
+  const realGaps = [];
+  const deliberatelyOmitted = [];
+
+  for (const finding of missingToolEntries ?? []) {
+    const registryEntry = registryIndex.get(registryKey(finding.method, finding.path));
+    if (registryEntry) {
+      deliberatelyOmitted.push({
+        ...finding,
+        reason: registryEntry.reason,
+        adr: registryEntry.adr,
+      });
+    } else {
+      realGaps.push(finding);
+    }
+  }
+
+  return { realGaps, deliberatelyOmitted };
+}
+
+export { normalizePath, registryKey, buildRegistryIndex, partitionMissingTools };

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -26,6 +26,15 @@
  *   MCP-Tool bedient (Tippfehler in der Annotation oder bewusst ausgelassener Endpunkt) --
  *   advisory, Task P3.6 (siehe scripts/lib/crossref-checks.mjs)
  *
+ * MISSING_TOOL wird seit Task P3.7 (ADR docs/adr/0001-omission-registry.md, Refs #57) weiter
+ * unterteilt: ein Treffer in der Omission-Registry (docs/omitted-endpoints.json -- Endpunkte,
+ * die WIR BEWUSST NIE als Tool aufnehmen, z.B. das in #171 entfernte
+ * `POST /api/git/stacks/{id}/env-files`) wandert nach `deliberatelyOmitted` statt
+ * `missingTool` -- sichtbar in docs/coverage.md unter "Deliberately omitted", aber nicht
+ * mehr als offene Lücke gemeldet. Eine ECHTE Lücke (z.B. die Backup-API, #164, 29 fehlende
+ * Tools -- geplant, nur noch nicht gebaut) bleibt unverändert `missingTool`. Siehe
+ * scripts/lib/omission-registry.mjs (`partitionMissingTools()`).
+ *
  * Required vs. optional kommt aus dem Schema (von extract-dockhand-api.mjs anhand des
  * echten `if (!x) { ... status: 4xx ... }`-Guards im Handler klassifiziert) — es gibt
  * KEINEN manuellen Re-Check mehr. Ein fehlender REQUIRED Query-Param ist ein harter
@@ -49,6 +58,7 @@ import { resolveQueryParamKeys } from './lib/query-params.mjs';
 import { getBodyContract, getOperationParamNames, loadOpenApiSpec } from './lib/openapi-contract-source.mjs';
 import { computeBodyFindings } from './lib/body-checks.mjs';
 import { checkCrossRefs, buildCrossRefEntries } from './lib/crossref-checks.mjs';
+import { partitionMissingTools } from './lib/omission-registry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -58,6 +68,7 @@ const SCHEMA_FILE = join(PROJECT_ROOT, 'docs', 'dockhand-api-schema.json');
 const TOOLS_DIR = join(PROJECT_ROOT, 'src', 'tools');
 const REPORT_FILE = join(PROJECT_ROOT, 'validation-report.md');
 const COLLECT_SHAPES_SCRIPT = join(__dirname, 'collect-tool-shapes.mjs');
+const OMITTED_ENDPOINTS_FILE = join(PROJECT_ROOT, 'docs', 'omitted-endpoints.json');
 
 /**
  * HTTP-Methoden, für die die Body-Contract-Checks (Task P1.4) überhaupt sinnvoll sind --
@@ -110,6 +121,20 @@ function loadSchema() {
     process.exit(2);
   }
   return JSON.parse(readFileSync(SCHEMA_FILE, 'utf8'));
+}
+
+/**
+ * Lädt die Omission-Registry (docs/omitted-endpoints.json, ADR
+ * docs/adr/0001-omission-registry.md, Task P3.7). Anders als loadSchema() bricht ein
+ * fehlendes File hier NICHT ab -- die Registry ist eine bewusst optionale Verfeinerung von
+ * MISSING_TOOL, kein Pflicht-Artefakt wie das API-Schema. Fehlt die Datei (z.B. in einem
+ * Kontext, der nur das Repo teilweise auscheckt), verhält sich partitionMissingTools() mit
+ * `[]` identisch zum Vor-P3.7-Verhalten: alles bleibt `realGaps`.
+ * @returns {Array<{method: string, path: string, reason: string, adr?: string, date?: string}>}
+ */
+function loadOmissionRegistry() {
+  if (!existsSync(OMITTED_ENDPOINTS_FILE)) return [];
+  return JSON.parse(readFileSync(OMITTED_ENDPOINTS_FILE, 'utf8'));
 }
 
 // --- Query-Param-Key-Extraktion für Aufruf-Argumente ---
@@ -571,13 +596,20 @@ function computeBodyFindingsForCalls(toolCalls, toolBodyShapes, openApiPathIndex
  *   immer `[]`, alle bestehenden Buckets/Exit-Code-Verhalten bleiben UNVERÄNDERT. Damit
  *   bleiben bestehende Aufrufer wie generate-coverage-doc.mjs (2 Argumente) unverändert
  *   kompatibel.
+ * @param {Array<{method: string, path: string, reason: string, adr?: string, date?: string}>} [registry]
+ *   Rückgabe von loadOmissionRegistry() (Task P3.7, ADR docs/adr/0001-omission-registry.md).
+ *   `[]` (Default) lässt `missingTool` unverändert (alles bleibt in diesem Bucket, wie vor
+ *   P3.7) -- bestehende Aufrufer mit 2/3 Argumenten bleiben kompatibel. Ein Registry-Treffer
+ *   wandert aus `missingTool` nach `deliberatelyOmitted`, siehe partitionMissingTools()
+ *   (scripts/lib/omission-registry.mjs).
  * @returns {{
- *   covered: Array, missingTool: Array, orphanedTool: Array, paramMismatch: Array,
- *   missingEncode: Array, queryParamMissingRequired: Array, queryParamUnknown: Array,
- *   bodyFindings: Array, crossRefFindings: Array, excludedCount: number
+ *   covered: Array, missingTool: Array, deliberatelyOmitted: Array, orphanedTool: Array,
+ *   paramMismatch: Array, missingEncode: Array, queryParamMissingRequired: Array,
+ *   queryParamUnknown: Array, bodyFindings: Array, crossRefFindings: Array,
+ *   excludedCount: number
  * }}
  */
-function computeValidation(schema, toolCalls, toolBodyShapes = null) {
+function computeValidation(schema, toolCalls, toolBodyShapes = null, registry = []) {
   // Baue Lookup-Maps
   const schemaEndpoints = new Map();
   for (const ep of schema.endpoints) {
@@ -716,9 +748,19 @@ function computeValidation(schema, toolCalls, toolBodyShapes = null) {
   // siehe computeCrossRefFindings() JSDoc.
   const crossRefFindings = computeCrossRefFindings(toolCalls, openApiPathIndex);
 
+  // 8. Omission-Governance (Task P3.7, ADR docs/adr/0001-omission-registry.md) -- trennt die
+  // rohen MISSING_TOOL-Funde aus Schritt 1 in `realGaps` (kein Registry-Treffer, bleibt
+  // MISSING_TOOL wie bisher -- war nie Teil von hasCriticalErrors(), Exit-Code-Verhalten
+  // also unverändert) und `deliberatelyOmitted` (Registry-Treffer, mit reason/adr
+  // angereichert -- sichtbar in docs/coverage.md, aber nicht mehr als Lücke gemeldet). Mit
+  // `registry = []` (Default) ist `realGaps` identisch zum rohen `missingTool` von vor
+  // P3.7 -- bestehende 2-/3-Argument-Aufrufer bleiben unverändert.
+  const { realGaps, deliberatelyOmitted } = partitionMissingTools(missingTool, registry);
+
   return {
     covered,
-    missingTool,
+    missingTool: realGaps,
+    deliberatelyOmitted,
     orphanedTool,
     paramMismatch,
     missingEncode,
@@ -816,9 +858,16 @@ function validate() {
     console.error(`[validate] Body-Shapes: ${Object.keys(toolBodyShapes).length} Tools erfasst (tsx-Collector)`);
   }
 
+  // Omission-Registry (Task P3.7) -- optional, siehe loadOmissionRegistry() JSDoc.
+  const registry = loadOmissionRegistry();
+  if (registry.length > 0) {
+    console.error(`[validate] Omission-Registry: ${registry.length} bewusst ausgelassene Endpunkte (docs/omitted-endpoints.json)`);
+  }
+
   const {
     covered,
     missingTool,
+    deliberatelyOmitted,
     orphanedTool,
     paramMismatch,
     missingEncode,
@@ -826,13 +875,14 @@ function validate() {
     queryParamUnknown,
     bodyFindings,
     crossRefFindings,
-  } = computeValidation(schema, toolCalls, toolBodyShapes);
+  } = computeValidation(schema, toolCalls, toolBodyShapes, registry);
 
   // Report generieren
   const report = generateReport({
     schema,
     covered,
     missingTool,
+    deliberatelyOmitted,
     orphanedTool,
     paramMismatch,
     missingEncode,
@@ -848,7 +898,8 @@ function validate() {
   // Zusammenfassung
   console.error('\n--- Validierungs-Ergebnis ---');
   console.error(`  COVERED:            ${covered.length} Endpunkte haben MCP-Tools`);
-  console.error(`  MISSING_TOOL:       ${missingTool.length} Endpunkte ohne MCP-Tool`);
+  console.error(`  MISSING_TOOL:       ${missingTool.length} Endpunkte ohne MCP-Tool (echte Lücken)`);
+  console.error(`  DELIBERATELY_OMITTED (informativ, kein Exit-Code-Effekt): ${deliberatelyOmitted.length} bewusst ausgelassene Endpunkte (Registry-Treffer)`);
   console.error(`  ORPHANED_TOOL:      ${orphanedTool.length} MCP-Tools referenzieren nicht-existente Endpunkte`);
   console.error(`  PARAM_MISMATCH:     ${paramMismatch.length} Path-Parameter-Inkonsistenzen`);
   console.error(`  MISSING_ENCODE:     ${missingEncode.length} fehlende encodePath()-Aufrufe`);
@@ -897,7 +948,7 @@ function validate() {
 /**
  * Generiert den Markdown-Report
  */
-function generateReport({ schema, covered, missingTool, orphanedTool, paramMismatch, missingEncode, queryParamMissingRequired, queryParamUnknown, bodyFindings = [], crossRefFindings = [] }) {
+function generateReport({ schema, covered, missingTool, deliberatelyOmitted = [], orphanedTool, paramMismatch, missingEncode, queryParamMissingRequired, queryParamUnknown, bodyFindings = [], crossRefFindings = [] }) {
   const lines = [];
   const now = new Date().toISOString();
   // Task P2.2: BODY_PARAM_MISSING_REQUIRED bekommt eine eigene Kritisch-Section (analog zu
@@ -920,6 +971,7 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
   lines.push('|--------|--------|');
   lines.push(`| COVERED | ${covered.length} |`);
   lines.push(`| MISSING_TOOL | ${missingTool.length} |`);
+  lines.push(`| DELIBERATELY_OMITTED (informativ) | ${deliberatelyOmitted.length} |`);
   lines.push(`| ORPHANED_TOOL | ${orphanedTool.length} |`);
   lines.push(`| PARAM_MISMATCH | ${paramMismatch.length} |`);
   lines.push(`| MISSING_ENCODE | ${missingEncode.length} |`);
@@ -1084,6 +1136,26 @@ function generateReport({ schema, covered, missingTool, orphanedTool, paramMisma
     lines.push('');
   }
 
+  // Deliberately omitted (Task P3.7, ADR docs/adr/0001-omission-registry.md) -- Registry-
+  // Treffer aus MISSING_TOOL, SICHTBAR mit Begründung statt kommentarlos zu verschwinden.
+  // Kein Gate -- beeinflusst den Exit-Code nicht (MISSING_TOOL tat das schon vorher nicht).
+  if (deliberatelyOmitted.length > 0) {
+    lines.push('## Deliberately omitted (with reason)');
+    lines.push('');
+    lines.push(
+      'Endpunkte, die laut Schema existieren, aber laut `docs/omitted-endpoints.json` bewusst ' +
+        'NIE ein MCP-Tool bekommen sollen (siehe `docs/adr/0001-omission-registry.md`) -- ' +
+        'unterscheidet sich von MISSING_TOOL oben: das dort sind echte, noch offene Lücken.'
+    );
+    lines.push('');
+    lines.push('| HTTP | Pfad | Begründung | ADR |');
+    lines.push('|------|------|------------|-----|');
+    for (const t of deliberatelyOmitted) {
+      lines.push(`| ${t.method} | \`${t.path}\` | ${t.reason} | ${t.adr ?? '-'} |`);
+    }
+    lines.push('');
+  }
+
   // Coverage
   if (covered.length > 0) {
     lines.push('<details>');
@@ -1127,6 +1199,7 @@ export {
   computeCrossRefFindings,
   computeValidation,
   loadSchema,
+  loadOmissionRegistry,
   CRITICAL_BODY_FINDING_TYPES,
   partitionBodyFindings,
   hasCriticalErrors,

--- a/tests/omission-registry.test.ts
+++ b/tests/omission-registry.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { partitionMissingTools } from '../scripts/lib/omission-registry.mjs';
+
+/**
+ * Omission-Governance (P3 Task 7, ADR docs/adr/0001-omission-registry.md, Refs #57).
+ *
+ * `partitionMissingTools()` trennt die rohen MISSING_TOOL-Funde von
+ * `computeValidation()` (scripts/validate-mcp-tools.mjs) in zwei Eimer:
+ * - `realGaps` — Endpunkte ohne Tool, die NICHT in der Registry stehen (echte Lücke,
+ *   z.B. die Backup-API #164 — geplant, nur noch nicht implementiert)
+ * - `deliberatelyOmitted` — Endpunkte, die bewusst nie ein MCP-Tool bekommen sollen
+ *   (docs/omitted-endpoints.json), inkl. der Begründung aus dem Registry-Eintrag
+ */
+
+describe('partitionMissingTools', () => {
+  it('unterdrückt MISSING_TOOL für registrierte Auslassungen', () => {
+    const registry = [
+      {
+        method: 'POST',
+        path: '/api/git/stacks/{id}/env-files',
+        reason: 'Entfernt in #171 — redundant zu get_git_stack_env_files + update_stack_env.',
+        adr: 'docs/adr/0001-omission-registry.md',
+        date: '2026-08-10',
+      },
+    ];
+    const missing = partitionMissingTools(
+      [
+        { method: 'POST', path: '/api/git/stacks/{id}/env-files' },
+        { method: 'POST', path: '/api/really/missing' },
+      ],
+      registry
+    );
+
+    expect(missing.realGaps.map((g) => g.path)).toEqual(['/api/really/missing']);
+    expect(missing.deliberatelyOmitted).toHaveLength(1);
+  });
+
+  it('lässt einen Backup-Endpunkt (echte Lücke, nicht in der Registry) in realGaps', () => {
+    const registry = [
+      {
+        method: 'POST',
+        path: '/api/self-update',
+        reason: 'Self-Update ist gefährlich über MCP auszulösen.',
+        adr: 'docs/adr/0001-omission-registry.md',
+        date: '2026-08-10',
+      },
+    ];
+    const missing = partitionMissingTools(
+      [{ method: 'GET', path: '/api/backup/configs' }],
+      registry
+    );
+
+    expect(missing.realGaps).toHaveLength(1);
+    expect(missing.realGaps[0].path).toBe('/api/backup/configs');
+    expect(missing.deliberatelyOmitted).toHaveLength(0);
+  });
+
+  it('behandelt eine leere Registry als Nicht-Fund (alles bleibt realGaps)', () => {
+    const missing = partitionMissingTools(
+      [
+        { method: 'GET', path: '/api/backup/configs' },
+        { method: 'POST', path: '/api/backup/configs' },
+      ],
+      []
+    );
+
+    expect(missing.realGaps).toHaveLength(2);
+    expect(missing.deliberatelyOmitted).toHaveLength(0);
+  });
+
+  it('behandelt eine leere Missing-Liste als Nicht-Fund', () => {
+    expect(partitionMissingTools([], [{ method: 'GET', path: '/api/x' }])).toEqual({
+      realGaps: [],
+      deliberatelyOmitted: [],
+    });
+  });
+
+  it('matcht Methode case-insensitiv, Pfad aber exakt (nach Normalisierung)', () => {
+    const registry = [
+      {
+        method: 'post',
+        path: '/api/git/stacks/{id}/env-files',
+        reason: 'x',
+        adr: 'docs/adr/0001-omission-registry.md',
+        date: '2026-08-10',
+      },
+    ];
+    const missing = partitionMissingTools(
+      [{ method: 'POST', path: '/api/git/stacks/{stackId}/env-files' }],
+      registry
+    );
+
+    // Unterschiedlicher Platzhaltername (stackId vs. id) darf den Match nicht verhindern —
+    // dieselbe {*}-Normalisierung wie endpointKey()/normalizePath() in validate-mcp-tools.mjs.
+    expect(missing.deliberatelyOmitted).toHaveLength(1);
+    expect(missing.realGaps).toHaveLength(0);
+  });
+
+  it('reichert deliberatelyOmitted-Einträge mit reason und adr aus der Registry an', () => {
+    const registry = [
+      {
+        method: 'POST',
+        path: '/api/self-update',
+        reason: 'Self-Update ist gefährlich über MCP auszulösen.',
+        adr: 'docs/adr/0001-omission-registry.md',
+        date: '2026-08-10',
+      },
+    ];
+    const missing = partitionMissingTools(
+      [{ method: 'POST', path: '/api/self-update', pathParams: [] }],
+      registry
+    );
+
+    expect(missing.deliberatelyOmitted[0]).toMatchObject({
+      path: '/api/self-update',
+      method: 'POST',
+      reason: 'Self-Update ist gefährlich über MCP auszulösen.',
+      adr: 'docs/adr/0001-omission-registry.md',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `docs/omitted-endpoints.json` — a machine-readable registry of Dockhand endpoints we deliberately never wrap as an MCP tool, each with a `reason` + `adr` + `date`.
- Adds `docs/adr/0001-omission-registry.md` (and `docs/adr/README.md` as the registry index) — establishes the ADR practice in this repo, documents the decision, and explicitly explains the relationship to the existing `IGNORED_PATTERNS` mechanism (broad, pattern-based exclusions stay there; the registry is authoritative for endpoint-exact omissions and for the human-readable reason behind every exclusion, including the ones already covered by `IGNORED_PATTERNS`).
- Adds `scripts/lib/omission-registry.mjs` (`partitionMissingTools()`) — pure function that splits the raw `MISSING_TOOL` findings into `realGaps` (no registry match — stays `MISSING_TOOL`, same exit-code behavior as before) and `deliberatelyOmitted` (registry match, enriched with `reason`/`adr`).
- Wires the registry into `computeValidation()` (`scripts/validate-mcp-tools.mjs`, new optional 4th param `registry`) and into `docs/coverage.md` generation (`scripts/generate-coverage-doc.mjs` / `scripts/lib/coverage-report.mjs`) — a new "Deliberately omitted (with reason)" section now shows these endpoints instead of letting them silently disappear.

## Why

Before this change, `IGNORED_PATTERNS` silently subtracted endpoints from `MISSING_TOOL` into an aggregate `excludedCount` with no per-endpoint reason, and endpoint-exact omissions (like `POST /api/git/stacks/{id}/env-files`, removed in #171) had **no** suppression mechanism at all — they just showed up as `MISSING_TOOL`, indistinguishable from a real, still-open gap like the Backup API (#164, 29 endpoints, tracked separately and deliberately **excluded** from this registry).

## Real gap vs. deliberate omission (verified)

- `POST /api/git/stacks/{id}/env-files` — was in `MISSING_TOOL` (37 raw) before this change, now correctly appears only under "Deliberately omitted" (`MISSING_TOOL` → 36).
- The Backup API (`GET/POST /api/backup/*`) stays in `MISSING_TOOL` untouched — confirmed by the `docs/coverage.md` diff (still 29 entries under `### backup`).
- The 22 endpoints already excluded via `IGNORED_PATTERNS` (self-update family, streams, debug, auth/login, hawser/connect, icon/avatar uploads, disk-warning) never reach `partitionMissingTools()` in the first place (excluded earlier via `excludedCount`) — they are additionally documented in the registry purely for the human-readable reason, with no double suppression.

## Test plan

- [x] `npx vitest run tests/omission-registry.test.ts` — new test written first (red), confirmed failing on missing module, then green after implementation (6/6 passing)
- [x] `npx vitest run` — full suite, 47 files / 629 tests, all passing (no regressions)
- [x] `npx tsc --noEmit` / `npm run build` — clean
- [x] `node scripts/validate-mcp-tools.mjs` — `MISSING_TOOL: 36` (was 37), `DELIBERATELY_OMITTED: 1`, exit 0 (unchanged — `MISSING_TOOL` was never part of `hasCriticalErrors()`)
- [x] `node scripts/generate-coverage-doc.mjs` — regenerated `docs/coverage.md`, new "Deliberately omitted (with reason)" section renders correctly, `### backup (29)` untouched

Refs #57, #164, #171