### PR TITLE
fix(api): correct shared-endpoint tool descriptions and lock in cross-ref parity

### DIFF
--- a/docs/adr/0002-description-override-map.md
+++ b/docs/adr/0002-description-override-map.md
@@ -1,0 +1,115 @@
+# ADR-0002: Description-override map for shared-endpoint tools
+
+**Status:** accepted
+**Date:** 2026-08-10
+**Refs:** #57 (P3 plan, "Final Fix Wave" review round), Findings 1 and 2
+
+## Context
+
+P3 (see commits `d37b986` "derive slim MCP tool descriptions from OpenAPI operations" and
+`80a24e9` "derive descriptions from the spec, drop hand-written text") replaced every
+hand-written MCP tool description with one derived at runtime from
+`docs/dockhand-openapi.json`: `describeTool(name)` resolves `name` to a `{method, path}` via
+`toolEndpoint()` (`src/openapi/tool-endpoint.ts`), looks up that endpoint's OpenAPI operation
+via `specOperation()` (`src/openapi/spec-loader.ts`), and hands it to
+`deriveToolDescription()` (`src/openapi/derive-description.ts`), which returns the
+operation's `summary` plus any resolved cross-references.
+
+This derivation is per-**endpoint**, not per-**tool**. When two MCP tools call the exact same
+`{method, path}` — four such pairs currently exist, see `tool-endpoint-map.ts` — both resolve
+to the identical spec operation and therefore receive the **identical** derived text. That
+text is accurate for whichever tool the spec operation was actually written to describe, and
+wrong for the other: it can name a request body field the other tool's Zod schema does not
+accept at all, or omit the behavior that is the other tool's entire purpose.
+
+Confirmed against the real handler code in `src/tools/*.ts` (not assumed) for all four pairs:
+
+| Shared endpoint | Spec text actually describes | Gets it wrong |
+|---|---|---|
+| `PUT /api/stacks/{name}/env/raw` | `update_stack_env_raw` (raw-file write, `content` field) | `remove_stack_env_vars` (takes `keys: string[]`, no `content` field at all) |
+| `GET /api/stacks/{name}/env` | `get_stack_env` (returns all variables) | `check_stack_env_collisions` (returns a collision report, not the variable list) |
+| `DELETE /api/users/{id}/roles` | `remove_user_role` (takes `roleId`, optional `environmentId`) | `clear_user_roles` (takes only `userId`, clears every role — no `roleId`/`environmentId` params) |
+| `GET /api/git/stacks/{id}/webhook` | `trigger_git_webhook` (takes and sends `secret`) | `get_git_stack_webhook` (takes only `stackId`, never sends a secret) |
+
+The first of these (`remove_stack_env_vars`) was already flagged as a known, unresolved gap
+at generation time — see the `EXPLICIT_OVERRIDES` comment in
+`scripts/generate-tool-endpoint-map.mjs`: "KNOWN REGRESSION either way: the disambiguation …
+has no surviving textual home at all". The P3 "Final Fix Wave" review round (this ADR) is
+that follow-up.
+
+A second, related problem: `endpointToTool()` (the reverse lookup other operations' cross-refs
+use) resolved a shared endpoint to whichever tool happened to sort first alphabetically in
+`TOOL_ENDPOINT_MAP`'s insertion order — an accident of naming, not a deliberate choice. For
+three of the four pairs above, the alphabetically-first tool is the WRONG one (the one the
+spec text does not describe).
+
+## Decision
+
+Two small, narrowly-scoped, fully-audited mechanisms — not a reintroduction of hand-written
+prose across the tool surface:
+
+1. **`TOOL_DESCRIPTION_OVERRIDES`** (`src/openapi/description-overrides.ts`): a
+   `Record<toolName, string>` consulted by `describeTool()` BEFORE any spec lookup. An
+   override wins outright when present. Currently four entries — exactly the four
+   "gets it wrong" tools in the table above. Each entry restores that tool's own pre-P3
+   hand-written description (from git history, the commit before `d37b986`) rather than
+   inventing new prose: that text was already reviewed and shipped, and is tool-specific by
+   construction.
+2. **Deterministic tiebreak in `endpointToTool()`** (`src/openapi/tool-endpoint.ts`): when
+   two tools share an endpoint, the one WITHOUT a `TOOL_DESCRIPTION_OVERRIDES` entry wins —
+   not alphabetical order. The reasoning connecting the two mechanisms: an override exists
+   *because* that tool's own derived description doesn't match its behavior, which means the
+   spec operation wasn't written with that tool in mind — so it should not "own" the endpoint
+   for cross-reference resolution either. The non-overridden sibling is, by construction, the
+   tool the spec operation actually describes.
+
+Both mechanisms are additive over the existing derivation path: a tool with no override and
+no endpoint-sharing conflict behaves exactly as before this ADR.
+
+### What was rejected
+
+**Adding more `EXPLICIT_OVERRIDES` entries in `scripts/generate-tool-endpoint-map.mjs`** to
+point the four affected tools at a *different*, less-shared endpoint. Rejected because no
+such endpoint exists for any of the four — each genuinely calls the exact same REST endpoint
+as its sibling; there is no dedicated `DELETE`/`PATCH` variant to redirect to. That map
+answers "which endpoint does this tool call", a question with only one honest answer per
+tool; it is not the right place to encode "how should this tool be described".
+
+**A fully general "primary tool per endpoint" inference** (e.g., picking whichever tool's own
+Zod parameter schema has the most overlap with the spec operation's declared parameters).
+Rejected as disproportionate: only four pairs exist today, each already individually
+confirmed by hand against the real handler code, and a heuristic inference risks being wrong
+in a way that is *harder* to notice than the current, fully-enumerated, tested override list.
+If a future shared endpoint appears, it is added to the table above and the override map
+following the same audited process — not silently absorbed into a guess.
+
+## Consequences
+
+- `describeTool('remove_stack_env_vars')`, `describeTool('check_stack_env_collisions')`,
+  `describeTool('clear_user_roles')`, and `describeTool('get_git_stack_webhook')` now return
+  their own, tool-specific description instead of their endpoint-sibling's.
+- `endpointToTool()` now resolves all four shared endpoints to the non-overridden sibling
+  (`update_stack_env_raw`, `get_stack_env`, `remove_user_role`, `trigger_git_webhook`) — so a
+  cross-reference embedded in some THIRD operation's spec text that happens to point at one of
+  these endpoints resolves to the tool the spec text actually describes.
+- A future new shared endpoint is safe by default (first-insertion tiebreak, unchanged
+  behavior) until someone confirms a mismatch and adds an override — at which point the
+  tiebreak redirects automatically, with no separate code change needed in
+  `tool-endpoint.ts`.
+- `tests/description-overrides.test.ts` guards the override map's structural invariants
+  (every key a real tool, no empty values, and — as a deliberate regression fence, not a
+  ceiling — exactly today's four entries); `tests/describe-tool.test.ts` and
+  `tests/tool-endpoint.test.ts` assert the specific wrong-text/wrong-tiebreak regressions
+  this ADR fixes stay fixed.
+
+## Linked
+
+- Overrides: `src/openapi/description-overrides.ts`
+- Tiebreak: `src/openapi/tool-endpoint.ts` (`getEndpointToToolIndex()`)
+- Tests: `tests/description-overrides.test.ts`, `tests/describe-tool.test.ts`
+  ("description overrides" block), `tests/tool-endpoint.test.ts` ("shared-endpoint tiebreak"
+  block)
+- Origin of the known gap: `scripts/generate-tool-endpoint-map.mjs` (`EXPLICIT_OVERRIDES`,
+  `remove_stack_env_vars`/`check_stack_env_collisions` comments)
+- Prior art: `docs/adr/0001-omission-registry.md` (same "make a known gap machine-readable
+  and tested, instead of leaving it as a comment" pattern)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,6 +8,7 @@ ADR nach dem Schema `NNNN-<slug>.md`.
 | Nr. | Titel | Status | Datum |
 |-----|-------|--------|-------|
 | [0001](0001-omission-registry.md) | Omission-Registry für bewusst nicht gespiegelte Dockhand-Endpunkte | accepted | 2026-08-10 |
+| [0002](0002-description-override-map.md) | Description-override map for shared-endpoint tools | accepted | 2026-08-10 |
 
 ## Wann ein ADR anlegen?
 

--- a/scripts/generate-tool-endpoint-map.mjs
+++ b/scripts/generate-tool-endpoint-map.mjs
@@ -110,7 +110,12 @@ export const EXPLICIT_OVERRIDES = {
   update_stack_env: { method: 'PUT', path: '/api/stacks/{name}/env' },
   // Composes client.get<StackEnv>(envPath, ...) + client.get<string>(envRawPath, ...) —
   // no single dedicated REST endpoint; anchored on the structured-read side as the
-  // closest available summary (secrets-masked variable listing).
+  // closest available summary (secrets-masked variable listing). This endpoint is also
+  // shared with `get_stack_env` — the spec summary this anchoring inherits ("Get all
+  // environment variables...") describes get_stack_env, not this tool; see
+  // src/openapi/description-overrides.ts for the follow-up fix (P3 Final Fix Wave,
+  // Finding 1/2, Refs #57) that gives this tool its own correct description AND makes
+  // endpointToTool() resolve this endpoint back to get_stack_env, not here.
   check_stack_env_collisions: { method: 'GET', path: '/api/stacks/{name}/env' },
   // client.get(...) is a CONDITIONAL performance shortcut ("Only fetch environment when
   // connectionType is not provided ... avoids performance regression from PR #21") —
@@ -125,11 +130,18 @@ export const EXPLICIT_OVERRIDES = {
   // the whole endpoint family that mentions "deletes" at all ("...empty content deletes
   // the .env file..."). PUT .../env (what first-wins previously picked, matching
   // update_stack_env) was rejected: its summary "Save environment variables..." directly
-  // contradicts a key-removal tool's purpose. KNOWN REGRESSION either way: the disambiguation
-  // from update_stack_env's merge-mode limitation ("safe way to delete variables —
-  // update_stack_env in merge mode cannot remove keys") has no surviving textual home at
-  // all (not the spec, not any .describe()) — see tests/stack-env-tools.test.ts and
-  // tests/stack-env-merge.test.ts, and the Task 5 fix-round report.
+  // contradicts a key-removal tool's purpose. KNOWN REGRESSION either way (at the time):
+  // the disambiguation from update_stack_env's merge-mode limitation ("safe way to delete
+  // variables — update_stack_env in merge mode cannot remove keys") had no surviving
+  // textual home at all (not the spec, not any .describe()) — see
+  // tests/stack-env-tools.test.ts and tests/stack-env-merge.test.ts, and the Task 5
+  // fix-round report. RESOLVED (P3 Final Fix Wave, Finding 1/2, Refs #57): this endpoint
+  // is ALSO shared with `update_stack_env_raw` — the derived description this anchoring
+  // produced was update_stack_env_raw's raw-file-write text, not this tool's own. See
+  // src/openapi/description-overrides.ts (restores the tool's own hand-written text,
+  // including the exact "update_stack_env in merge mode cannot remove keys" disambiguation
+  // above) and src/openapi/tool-endpoint.ts (makes endpointToTool() resolve this endpoint
+  // back to update_stack_env_raw, not here).
   remove_stack_env_vars: { method: 'PUT', path: '/api/stacks/{name}/env/raw' },
 };
 

--- a/scripts/lib/crossref-checks.mjs
+++ b/scripts/lib/crossref-checks.mjs
@@ -30,8 +30,10 @@
  * the existing (optional, gracefully-skippable) body-shape collector -- disproportionate for
  * two small, stable regexes that are themselves the documented, versioned contract, not an
  * implementation detail likely to drift silently. Should the two definitions ever diverge,
- * `tests/derive-description-crossref-parity.test.ts` is the intended regression guard (not
- * part of this task).
+ * `tests/derive-description-crossref-parity.test.ts` is the regression guard: it compares
+ * the regex source strings for byte-identity AND runs both extractors over a shared table
+ * of example operations to confirm they still agree on results (P3 Final Fix Wave,
+ * Finding 3, Refs #57).
  */
 
 const HTTP_METHODS = 'GET|POST|PUT|DELETE|PATCH';
@@ -150,4 +152,15 @@ function checkCrossRefs(entries, endpointToTool) {
   return findings;
 }
 
-export { checkCrossRefs, extractCrossRefsFromOperation, buildCrossRefEntries };
+// HTTP_METHODS/PROSE_CROSS_REF_SOURCE/PAREN_CROSS_REF_SOURCE are exported ONLY so
+// tests/derive-description-crossref-parity.test.ts can compare them against the
+// deliberately-duplicated TS copy in src/openapi/derive-description.ts (see this file's
+// header for why the duplication exists). No other caller should import these directly.
+export {
+  checkCrossRefs,
+  extractCrossRefsFromOperation,
+  buildCrossRefEntries,
+  HTTP_METHODS,
+  PROSE_CROSS_REF_SOURCE,
+  PAREN_CROSS_REF_SOURCE,
+};

--- a/src/openapi/derive-description.ts
+++ b/src/openapi/derive-description.ts
@@ -13,15 +13,22 @@
  *   - operation-wide `description` prose: `<field> from <METHOD> /api/<path>`
  * Different phrasing (`see GET /api/...`, `cf. .../...`) is not recognized —
  * that is a binding constraint of the upstream contract, not a gap here.
+ *
+ * `HTTP_METHODS`/`PROSE_CROSS_REF_SOURCE`/`PAREN_CROSS_REF_SOURCE` (and the two extraction
+ * functions built on them) are exported ONLY so `tests/derive-description-crossref-parity.
+ * test.ts` can compare them against the deliberately-duplicated copy in
+ * `scripts/lib/crossref-checks.mjs` (see that file's header for why the duplication itself
+ * exists — a TS/JS module-system boundary, not an oversight). No other caller should import
+ * these; use `deriveToolDescription()`.
  */
 
-const HTTP_METHODS = 'GET|POST|PUT|DELETE|PATCH';
+export const HTTP_METHODS = 'GET|POST|PUT|DELETE|PATCH';
 
 /** `<field> from <METHOD> /api/<path>` — used in operation-wide description prose. */
-const PROSE_CROSS_REF_SOURCE = `([A-Za-z_][A-Za-z0-9_]*) from (${HTTP_METHODS}) (\\/api\\/[^\\s.,;)]+)`;
+export const PROSE_CROSS_REF_SOURCE = `([A-Za-z_][A-Za-z0-9_]*) from (${HTTP_METHODS}) (\\/api\\/[^\\s.,;)]+)`;
 
 /** `(from <METHOD> /api/<path>)` — used in path/query parameter descriptions. */
-const PAREN_CROSS_REF_SOURCE = `\\(from (${HTTP_METHODS}) (\\/api\\/[^\\s)]+)\\)`;
+export const PAREN_CROSS_REF_SOURCE = `\\(from (${HTTP_METHODS}) (\\/api\\/[^\\s)]+)\\)`;
 
 const FALLBACK_DESCRIPTION = 'No description available.';
 
@@ -55,8 +62,12 @@ interface ParamCrossRef {
   path: string;
 }
 
-/** Extracts every `<field> from <METHOD> /api/<path>` reference from the operation's description prose. */
-function extractBodyCrossRefs(description: string | undefined): BodyCrossRef[] {
+/**
+ * Extracts every `<field> from <METHOD> /api/<path>` reference from the operation's
+ * description prose. Exported for `tests/derive-description-crossref-parity.test.ts` only
+ * — see the export note at the top of this file.
+ */
+export function extractBodyCrossRefs(description: string | undefined): BodyCrossRef[] {
   if (!description) return [];
   const refs: BodyCrossRef[] = [];
   const re = new RegExp(PROSE_CROSS_REF_SOURCE, 'g');
@@ -67,8 +78,12 @@ function extractBodyCrossRefs(description: string | undefined): BodyCrossRef[] {
   return refs;
 }
 
-/** Extracts the `(from <METHOD> /api/<path>)` reference from each path/query parameter's description. */
-function extractParamCrossRefs(parameters: OpenApiParameter[] | undefined): ParamCrossRef[] {
+/**
+ * Extracts the `(from <METHOD> /api/<path>)` reference from each path/query parameter's
+ * description. Exported for `tests/derive-description-crossref-parity.test.ts` only — see
+ * the export note at the top of this file.
+ */
+export function extractParamCrossRefs(parameters: OpenApiParameter[] | undefined): ParamCrossRef[] {
   if (!parameters) return [];
   const refs: ParamCrossRef[] = [];
   for (const param of parameters) {

--- a/src/openapi/describe-tool.ts
+++ b/src/openapi/describe-tool.ts
@@ -1,6 +1,9 @@
 /**
  * describeTool() — the single glue function `registerTool()` (src/utils/tool-helper.ts)
  * calls at registration time to derive a tool's MCP `description`. Ties together:
+ *   0. `TOOL_DESCRIPTION_OVERRIDES[name]` — a hand-written description WINS outright when
+ *      present, before any spec lookup (see description-overrides.ts for when/why this
+ *      escape hatch exists — a narrow, audited exception, not a general opt-out).
  *   1. `toolEndpoint(name)` — which Dockhand endpoint does this tool call?
  *   2. `specOperation(endpoint)` — what does docs/dockhand-openapi.json say about it?
  *   3. `deriveToolDescription(op, endpointToTool)` — summary + resolved cross-refs.
@@ -16,8 +19,12 @@
 import { deriveToolDescription } from './derive-description.js';
 import { toolEndpoint, endpointToTool } from './tool-endpoint.js';
 import { specOperation } from './spec-loader.js';
+import { TOOL_DESCRIPTION_OVERRIDES } from './description-overrides.js';
 
 export function describeTool(name: string): string {
+  const override = TOOL_DESCRIPTION_OVERRIDES[name];
+  if (override) return override;
+
   const endpoint = toolEndpoint(name);
   if (!endpoint) {
     console.error(

--- a/src/openapi/description-overrides.ts
+++ b/src/openapi/description-overrides.ts
@@ -1,0 +1,80 @@
+/**
+ * Manual description overrides for MCP tools whose DERIVED description
+ * (`deriveToolDescription()`, derive-description.ts, fed from `docs/dockhand-openapi.json`
+ * via spec-loader.ts) is demonstrably wrong or misleading — checked by `describeTool()`
+ * (describe-tool.ts) BEFORE spec-derivation runs.
+ *
+ * Derivation is a per-ENDPOINT lookup (`toolEndpoint(name)` -> `specOperation(endpoint)`),
+ * not a per-TOOL one. When two tools call the SAME `{method, path}`, both resolve to the
+ * SAME spec operation and therefore get the IDENTICAL derived text — correct for whichever
+ * tool the spec operation was actually written to describe, wrong (field/behavior
+ * mismatch) for the other. `endpointToTool()` (tool-endpoint.ts) additionally picks exactly
+ * ONE of the two as the "owning" tool for CROSS-REFERENCE resolution (first match in
+ * `TOOL_ENDPOINT_MAP`'s alphabetically-sorted insertion order) — that same tool is also the
+ * one whose OWN description this ambiguity affects, since a caller has no way to ask for
+ * "the other tool's" operation.
+ *
+ * This is a narrow, audited exception to "derive everything from the spec" (P3, Refs #57)
+ * — NOT a reintroduction of hand-written prose across the board. Every entry below:
+ *   1. Is added ONLY after confirming the derived text actually references a field/behavior
+ *      the tool does not have (checked against the tool's own Zod schema + handler body in
+ *      `src/tools/*.ts` — never assumed).
+ *   2. Carries a code comment explaining WHY derivation fails for this specific pair.
+ *   3. Reuses the tool's own pre-P3 hand-written description where one existed (git history,
+ *      commit before d37b986) rather than inventing new prose — that text was already
+ *      reviewed, shipped, and tool-specific.
+ *
+ * `tests/description-overrides.test.ts` guards two invariants: every key here is a real,
+ * registered tool name (typo-proofing against `TOOL_ENDPOINT_MAP`), and every value is
+ * non-empty. `tests/describe-tool.test.ts` additionally asserts the overridden text does
+ * NOT contain the specific wrong field/behavior references that motivated each entry.
+ */
+
+export const TOOL_DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = {
+  // Shares PUT /api/stacks/{name}/env/raw with `update_stack_env_raw`. The spec operation
+  // describes the raw-file-write semantics of THAT tool (`content` body field, "Write raw
+  // .env file content to disk", "empty content deletes the .env file"). `remove_stack_env_vars`
+  // takes `keys: string[]` and has no `content` field at all — the derived text names a
+  // field the tool does not accept. Restored the tool's own pre-P3 description (introduced
+  // in c5e2e2f, "add remove_stack_env_vars for safe two-store key removal").
+  remove_stack_env_vars:
+    'Remove environment variables from a stack across BOTH stores. Secret keys are dropped ' +
+    'from the encrypted database set (remaining secrets are preserved via masked "***" ' +
+    'values); non-secret keys are removed from the .env file. Keys present in neither are ' +
+    'returned in not_found. This is the safe way to delete variables — update_stack_env in ' +
+    'the default merge mode cannot remove keys.',
+
+  // Shares GET /api/stacks/{name}/env with `get_stack_env`. The spec operation describes
+  // "Get all environment variables for a stack (secrets masked)" — accurate for
+  // `get_stack_env`, but `check_stack_env_collisions` does not return the variable list at
+  // all; it returns a collision report (keys present as BOTH a DB secret and a .env entry).
+  // Restored the tool's own pre-P3 description.
+  check_stack_env_collisions:
+    'Read-only check reporting variable keys defined BOTH as a database-backed secret and ' +
+    'in the plain .env file. Such duplicates are ambiguous: at deploy the secret (shell ' +
+    'environment) wins over the .env value. Remove the duplicate copy with ' +
+    '`remove_stack_env_vars`.',
+
+  // Shares DELETE /api/users/{id}/roles with `remove_user_role`. The spec operation
+  // describes "Remove a role assignment from a user, optionally scoped to an environment"
+  // with cross-refs for `roleId` and `environmentId` — accurate for `remove_user_role`
+  // (which takes both), but `clear_user_roles` takes ONLY `userId` (no roleId, no
+  // environmentId) and clears EVERY role assignment, not one. The derived text's
+  // cross-refs point at fields this tool's schema does not have. Restored the tool's own
+  // pre-P3 description.
+  clear_user_roles:
+    'Permanently remove every role assignment from a user (the user remains, but loses all ' +
+    'permissions until reassigned); pair with `get_user_roles` to inspect first, or ' +
+    '`add_user_role` to re-assign roles afterwards.',
+
+  // Shares GET /api/git/stacks/{id}/webhook with `trigger_git_webhook`. The spec operation
+  // describes "GET webhook trigger ... with the secret passed as the `secret` query
+  // parameter" — accurate for `trigger_git_webhook` (which takes and sends `secret`), but
+  // `get_git_stack_webhook` takes only `stackId` and never sends a secret. Restored the
+  // tool's own pre-P3 description.
+  get_git_stack_webhook:
+    'Retrieve the inbound webhook URL and secret configured on a Git-based stack (used by ' +
+    'GitHub/GitLab/etc. to POST deploy notifications); use `trigger_git_webhook` to fire the ' +
+    'webhook manually, or `get_git_webhook` for the equivalent on the generic webhook ' +
+    'endpoint.',
+};

--- a/src/openapi/tool-endpoint.ts
+++ b/src/openapi/tool-endpoint.ts
@@ -14,6 +14,7 @@
  */
 
 import { TOOL_ENDPOINT_MAP, type ToolEndpointEntry } from './tool-endpoint-map.js';
+import { TOOL_DESCRIPTION_OVERRIDES } from './description-overrides.js';
 
 /**
  * Resolves a registered MCP tool name to the {method, path} of the Dockhand endpoint
@@ -34,9 +35,21 @@ function endpointIndexKey(method: string, path: string): string {
  * Lazily-built, memoized inverse of TOOL_ENDPOINT_MAP: `"METHOD /api/path" -> toolName`.
  * Built once from the same static map `toolEndpoint()` reads — there is no separate
  * generated file to keep in sync, so forward and reverse lookups can never drift from
- * each other. If two tools happen to share an endpoint, the one that appears first when
- * iterating TOOL_ENDPOINT_MAP's insertion order (the generator emits entries sorted
- * alphabetically by tool name) wins; both still resolve correctly via `toolEndpoint()`.
+ * each other. Both tools of a shared endpoint still resolve correctly via `toolEndpoint()`
+ * regardless of which one wins here.
+ *
+ * Tiebreak (Finding 2, P3 Final Fix Wave, Refs #57): when two tools share an endpoint, the
+ * one WITHOUT a `TOOL_DESCRIPTION_OVERRIDES` entry wins — deterministically, not by
+ * insertion/alphabetical order. An override exists precisely because that tool's own
+ * derived description (spec summary + cross-refs) does NOT match its actual
+ * fields/behavior (see description-overrides.ts for the four currently-known cases and
+ * why each mismatch was confirmed against the real handler code, not assumed). The
+ * non-overridden sibling is therefore the tool the spec operation actually describes —
+ * exactly the tool a cross-reference to this endpoint should resolve to. When neither or
+ * both share the same override status, the first-seen (insertion-order) entry still wins,
+ * unchanged from the previous behavior — this rule only ever REDIRECTS an endpoint away
+ * from a tool that is independently known to be mismatched, never introduces a new
+ * ambiguity.
  */
 let endpointToToolIndex: Map<string, string> | undefined;
 
@@ -45,7 +58,16 @@ function getEndpointToToolIndex(): Map<string, string> {
     const index = new Map<string, string>();
     for (const [name, entry] of Object.entries(TOOL_ENDPOINT_MAP)) {
       const key = endpointIndexKey(entry.method, entry.path);
-      if (!index.has(key)) index.set(key, name);
+      const existing = index.get(key);
+      if (!existing) {
+        index.set(key, name);
+        continue;
+      }
+      const existingIsOverridden = existing in TOOL_DESCRIPTION_OVERRIDES;
+      const currentIsOverridden = name in TOOL_DESCRIPTION_OVERRIDES;
+      if (existingIsOverridden && !currentIsOverridden) {
+        index.set(key, name);
+      }
     }
     endpointToToolIndex = index;
   }

--- a/tests/derive-description-crossref-parity.test.ts
+++ b/tests/derive-description-crossref-parity.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression guard promised (but not yet delivered) by the header comment in
+ * scripts/lib/crossref-checks.mjs: that module deliberately RE-IMPLEMENTS the same two
+ * cross-reference regexes as src/openapi/derive-description.ts, rather than importing
+ * them, because it lives in scripts/ (plain JS, run directly via `node`, no build/tsx
+ * step) while derive-description.ts lives in src/ (TypeScript). Should the two
+ * definitions ever diverge — someone edits one copy without the other — this test is
+ * the thing that is supposed to notice (P3 Final Fix Wave, Finding 3, Refs #57).
+ *
+ * Two independent checks, because either one alone would miss a real divergence:
+ *   1. The regex SOURCE STRINGS must be byte-identical. This alone would already catch
+ *      almost any edit, but a source-string diff can be hard to read at a glance.
+ *   2. The two sides' EXTRACTION BEHAVIOR must agree on a shared table of example
+ *      operations (including edge cases: multiple refs, ignored header params, no refs
+ *      at all) — a behavioral check that stays meaningful even if a future refactor
+ *      changes how either side is built internally, as long as the two extractors still
+ *      agree on results.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  HTTP_METHODS as TS_HTTP_METHODS,
+  PROSE_CROSS_REF_SOURCE as TS_PROSE_CROSS_REF_SOURCE,
+  PAREN_CROSS_REF_SOURCE as TS_PAREN_CROSS_REF_SOURCE,
+  extractParamCrossRefs,
+  extractBodyCrossRefs,
+  type OpenApiOperation,
+} from '../src/openapi/derive-description.js';
+import {
+  HTTP_METHODS as JS_HTTP_METHODS,
+  PROSE_CROSS_REF_SOURCE as JS_PROSE_CROSS_REF_SOURCE,
+  PAREN_CROSS_REF_SOURCE as JS_PAREN_CROSS_REF_SOURCE,
+  extractCrossRefsFromOperation,
+} from '../scripts/lib/crossref-checks.mjs';
+
+/** TS-side combined extraction, matching the JS side's own documented order: param refs (declaration order), then prose refs (regex match order). */
+function extractAllRefsTs(op: OpenApiOperation): Array<{ method: string; path: string }> {
+  const paramRefs = extractParamCrossRefs(op.parameters).map((r) => ({ method: r.method, path: r.path }));
+  const bodyRefs = extractBodyCrossRefs(op.description).map((r) => ({ method: r.method, path: r.path }));
+  return [...paramRefs, ...bodyRefs];
+}
+
+describe('derive-description.ts vs scripts/lib/crossref-checks.mjs: cross-ref regex parity', () => {
+  it('regex source strings are byte-identical between the TS and JS copies', () => {
+    expect(TS_HTTP_METHODS).toBe(JS_HTTP_METHODS);
+    expect(TS_PROSE_CROSS_REF_SOURCE).toBe(JS_PROSE_CROSS_REF_SOURCE);
+    expect(TS_PAREN_CROSS_REF_SOURCE).toBe(JS_PAREN_CROSS_REF_SOURCE);
+  });
+
+  const cases: Array<{ name: string; op: OpenApiOperation }> = [
+    {
+      name: 'single param cross-ref',
+      op: {
+        parameters: [
+          { in: 'path', name: 'environmentId', description: 'The environment (from GET /api/environments)' },
+        ],
+      },
+    },
+    {
+      name: 'single prose cross-ref',
+      op: { description: 'containerId from GET /api/containers.' },
+    },
+    {
+      name: 'multiple prose cross-refs in the same description',
+      op: {
+        description:
+          'containerId from GET /api/containers, environmentId from GET /api/environments.',
+      },
+    },
+    {
+      name: 'combined param + prose cross-refs',
+      op: {
+        parameters: [
+          { in: 'query', name: 'environmentId', description: 'Env (from GET /api/environments)' },
+        ],
+        description: 'containerId from GET /api/containers.',
+      },
+    },
+    {
+      name: 'header parameter cross-ref is ignored (only path/query count)',
+      op: {
+        parameters: [
+          { in: 'header', name: 'X-Foo', description: 'Something (from GET /api/environments)' },
+        ],
+      },
+    },
+    {
+      name: 'parameter without a cross-ref annotation is ignored',
+      op: { parameters: [{ in: 'path', name: 'id', description: 'Just a plain id' }] },
+    },
+    {
+      name: 'a PUT/DELETE/PATCH method is recognized, not just GET/POST',
+      op: { description: 'roleId from DELETE /api/roles/{id}.' },
+    },
+    {
+      name: 'operation with neither parameters nor description',
+      op: {},
+    },
+  ];
+
+  it.each(cases)('extraction behavior agrees for: $name', ({ op }) => {
+    const tsRefs = extractAllRefsTs(op);
+    const jsRefs = extractCrossRefsFromOperation(op);
+    expect(tsRefs).toEqual(jsRefs);
+  });
+});

--- a/tests/describe-tool.test.ts
+++ b/tests/describe-tool.test.ts
@@ -40,4 +40,51 @@ describe('describeTool', () => {
     expect(description.length).toBeGreaterThan(0);
     expect(errorSpy).toHaveBeenCalled();
   });
+
+  describe('description overrides (P3 Final Fix Wave, Finding 1, Refs #57)', () => {
+    // Four tool pairs share a single Dockhand endpoint (see tool-endpoint-map.ts). The
+    // spec operation for a shared endpoint describes only ONE of the two tools correctly;
+    // `endpointToTool()`'s alphabetical tiebreak picks the other as the endpoint's "owner"
+    // for the wrong reason, so its OWN derived description also inherits the mismatch.
+    // `TOOL_DESCRIPTION_OVERRIDES` (description-overrides.ts) replaces exactly those four.
+
+    it('remove_stack_env_vars: no longer suggests a "content" field or raw-file-write semantics', () => {
+      const description = describeTool('remove_stack_env_vars');
+      expect(description).not.toMatch(/\bcontent\b/i);
+      expect(description).not.toMatch(/write raw \.env file/i);
+      expect(description).toMatch(/remove environment variables/i);
+      expect(description).toMatch(/keys/i);
+    });
+
+    it('check_stack_env_collisions: no longer claims to return the full variable list', () => {
+      const description = describeTool('check_stack_env_collisions');
+      expect(description).not.toMatch(/get all environment variables/i);
+      expect(description).toMatch(/collision|duplicate/i);
+    });
+
+    it('clear_user_roles: no longer references roleId/environmentId cross-refs it does not accept', () => {
+      const description = describeTool('clear_user_roles');
+      expect(description).not.toMatch(/roleId/);
+      expect(description).not.toMatch(/environmentId/);
+      expect(description).toMatch(/every role assignment/i);
+    });
+
+    it('get_git_stack_webhook: no longer claims it sends the secret query parameter', () => {
+      const description = describeTool('get_git_stack_webhook');
+      expect(description).not.toMatch(/secret passed as the `secret` query parameter/i);
+      expect(description).toMatch(/retrieve the inbound webhook/i);
+    });
+
+    it('leaves the OTHER tool in each shared-endpoint pair on the normal spec-derived path', () => {
+      // update_stack_env_raw, get_stack_env, remove_user_role, trigger_git_webhook are the
+      // tools the spec operation's summary actually describes — they must keep getting the
+      // plain derived text (no override entry for them).
+      expect(describeTool('update_stack_env_raw')).toMatch(/write raw \.env file/i);
+      expect(describeTool('get_stack_env')).toMatch(/get all environment variables/i);
+      expect(describeTool('remove_user_role')).toMatch(/remove a role assignment/i);
+      expect(describeTool('trigger_git_webhook')).toMatch(
+        /secret passed as the `secret` query parameter/i,
+      );
+    });
+  });
 });

--- a/tests/description-overrides.test.ts
+++ b/tests/description-overrides.test.ts
@@ -1,0 +1,38 @@
+/**
+ * TOOL_DESCRIPTION_OVERRIDES (description-overrides.ts) — two structural invariants that
+ * do not depend on the current wording of any individual entry:
+ *   1. Every key is a real, registered MCP tool name (typo-proofing — an override for a
+ *      tool that does not exist would silently do nothing, forever).
+ *   2. Every value is non-empty prose (an empty override would defeat `describeTool()`'s
+ *      "never return an empty string" contract — see describe-tool.ts).
+ * Wording-specific assertions (does the override text avoid the exact wrong field/behavior
+ * it was added to fix) live in tests/describe-tool.test.ts, next to the `describeTool()`
+ * call that surfaces them.
+ */
+import { describe, it, expect } from 'vitest';
+import { TOOL_DESCRIPTION_OVERRIDES } from '../src/openapi/description-overrides.js';
+import { TOOL_ENDPOINT_MAP } from '../src/openapi/tool-endpoint-map.js';
+
+describe('TOOL_DESCRIPTION_OVERRIDES', () => {
+  it('every override key is a registered tool name in TOOL_ENDPOINT_MAP', () => {
+    for (const name of Object.keys(TOOL_DESCRIPTION_OVERRIDES)) {
+      expect(TOOL_ENDPOINT_MAP, `override key "${name}" is not a registered tool`).toHaveProperty(
+        name,
+      );
+    }
+  });
+
+  it('every override value is non-empty prose', () => {
+    for (const [name, text] of Object.entries(TOOL_DESCRIPTION_OVERRIDES)) {
+      expect(text.trim().length, `override for "${name}" is empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers exactly the four known shared-endpoint mismatches (P3 Final Fix Wave, Refs #57)', () => {
+    // Not a hard ceiling on future overrides — a regression guard so a new entry is a
+    // deliberate, reviewed addition rather than an accidental duplicate/typo key.
+    expect(Object.keys(TOOL_DESCRIPTION_OVERRIDES).sort()).toEqual(
+      ['check_stack_env_collisions', 'clear_user_roles', 'get_git_stack_webhook', 'remove_stack_env_vars'].sort(),
+    );
+  });
+});

--- a/tests/tool-endpoint.test.ts
+++ b/tests/tool-endpoint.test.ts
@@ -53,6 +53,32 @@ describe('endpointToTool', () => {
       expect(toolEndpoint(resolved!)).toEqual(entry);
     }
   });
+
+  describe('shared-endpoint tiebreak is deterministic, not alphabetical (Finding 2, P3 Final Fix Wave, Refs #57)', () => {
+    // All four currently-known shared endpoints (see tool-endpoint-map-multi-call.test.ts
+    // for how "shared" here differs from that file's "multi-endpoint tool" concept -- this
+    // is the reverse case: ONE endpoint, MULTIPLE tools). Before the fix, alphabetical
+    // insertion order picked the WRONG tool as the endpoint's owner for three of these four
+    // (the one WITH a description override -- see description-overrides.ts) purely because
+    // its name sorted first. The fix: prefer whichever tool has NO description override --
+    // an override exists precisely because the spec text does not describe that tool.
+
+    it('PUT /api/stacks/{name}/env/raw resolves to update_stack_env_raw, not remove_stack_env_vars', () => {
+      expect(endpointToTool('PUT', '/api/stacks/{name}/env/raw')).toBe('update_stack_env_raw');
+    });
+
+    it('GET /api/stacks/{name}/env resolves to get_stack_env, not check_stack_env_collisions', () => {
+      expect(endpointToTool('GET', '/api/stacks/{name}/env')).toBe('get_stack_env');
+    });
+
+    it('DELETE /api/users/{id}/roles resolves to remove_user_role, not clear_user_roles', () => {
+      expect(endpointToTool('DELETE', '/api/users/{id}/roles')).toBe('remove_user_role');
+    });
+
+    it('GET /api/git/stacks/{id}/webhook resolves to trigger_git_webhook, not get_git_stack_webhook', () => {
+      expect(endpointToTool('GET', '/api/git/stacks/{id}/webhook')).toBe('trigger_git_webhook');
+    });
+  });
 });
 
 describe('tool-endpoint-map completeness', () => {


### PR DESCRIPTION
## Summary

Three findings from the P3 "Final Fix Wave" whole-branch review (Refs #57), all fixed in one PR as requested.

- **Finding 1 (critical):** `describeTool('remove_stack_env_vars')` derived a wrong, misleading description — it inherited `PUT /api/stacks/{name}/env/raw`'s spec summary, which actually describes `update_stack_env_raw` (a `content`-field raw-file write). `remove_stack_env_vars` takes `keys: string[]` and has no `content` field at all. Audited **all four** tool pairs that share a single Dockhand endpoint (`tool-endpoint-map.ts`) and confirmed the same mismatch pattern in three more: `check_stack_env_collisions`, `clear_user_roles`, `get_git_stack_webhook`. Added `TOOL_DESCRIPTION_OVERRIDES` (`src/openapi/description-overrides.ts`) — checked by `describeTool()` before any spec lookup — restoring each tool's own pre-P3 hand-written description from git history (reviewed, shipped text, not invented).
- **Finding 2:** `endpointToTool()`'s reverse lookup picked the alphabetically-first tool name for a shared endpoint — the *wrong* one in three of the four pairs above. Made the tiebreak deterministic: the tool **without** a description override wins (an override exists precisely because the spec text doesn't describe that tool, so it shouldn't "own" the endpoint for cross-reference resolution either).
- **Finding 3:** the parity test promised by `scripts/lib/crossref-checks.mjs`'s own header comment (guarding its deliberately-duplicated cross-ref regexes against drifting from `derive-description.ts`) did not exist. Exported the regex sources + extraction helpers on both the TS and JS side and added `tests/derive-description-crossref-parity.test.ts`: regex source-string identity, plus both extractors run over a shared table of example operations.

Design rationale (including alternatives considered and rejected) documented in `docs/adr/0002-description-override-map.md`.

## Test plan

- [x] `npx vitest run` — 650/650 passing (21 new tests: description-overrides map invariants, describeTool override behavior for all 4 pairs + the non-overridden sibling, endpointToTool deterministic tiebreak for all 4 pairs, cross-ref regex parity)
- [x] TDD: confirmed RED before wiring each fix (override lookup in `describe-tool.ts`, tiebreak in `tool-endpoint.ts`), GREEN after
- [x] Sanity-checked the parity guard actually catches divergence (temporarily diverged one regex copy, confirmed the test fails, reverted)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `node scripts/validate-mcp-tools.mjs` → exit 0, `ORPHANED_TOOL: 0`, `BODY_PARAM_MISSING_REQUIRED: 0` (unchanged from before this PR)
- [x] `describeTool('remove_stack_env_vars')` (and the other 3 overridden tools) verified live against the real `docs/dockhand-openapi.json`, not just against a mock spec

Refs #57