### PR TITLE
fix: hard-fail body-contract collector crash, drop unrunnable lint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,16 @@ DOCKHAND_PASSWORD=secret \
 npm run dev
 ```
 
+### Linting
+
+There is currently no `npm run lint` script. `typescript-eslint` (the only maintained
+ESLint/TypeScript integration) does not yet support the pinned `typescript@^7.0.2`
+devDependency — it refuses to run at all against TS 7.0 (hard runtime error, not just a
+peer-dependency warning): see
+[typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940).
+Re-add `eslint` + `typescript-eslint` as devDependencies once that's resolved upstream —
+`tsc --noEmit` (via `npm run typecheck`) is the only static check enforced today.
+
 ## License
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -479,30 +479,65 @@ function computeCrossRefFindings(toolCalls, openApiPathIndex) {
 }
 
 /**
+ * Thrown by loadToolBodyShapes() when the `tsx` subprocess collector fails for ANY reason
+ * (the `npx tsx` invocation itself errors/exits non-zero, or its stdout is not valid JSON).
+ *
+ * Ground truth for WHY this is now a dedicated error type instead of a swallowed `null`
+ * (Refs #173, follow-up to #172's hard BODY_PARAM_MISSING_REQUIRED gate): the OLD
+ * loadToolBodyShapes() caught every failure and returned `null`, which computeValidation()
+ * treats as "body-checks intentionally skipped" -- the EXACT same signal a caller sends by
+ * never calling loadToolBodyShapes() at all (e.g. generate-coverage-doc.mjs's 2-arg
+ * computeValidation() call). That made "the collector crashed" indistinguishable from "body
+ * checks were never requested", so the hard gate went silently fail-open on a broken
+ * collector: CI stayed green even though the check never ran. `tsx` is a committed
+ * devDependency and every CI job runs `npm ci` before `validate-mcp-tools.mjs` (see
+ * .github/workflows/ci.yml, api-schema-sync.yml) -- there is no longer a legitimate
+ * "tsx isn't installed" case to stay silent for.
+ */
+class BodyShapeCollectorError extends Error {
+  constructor(message, options) {
+    super(message, options);
+    this.name = 'BodyShapeCollectorError';
+  }
+}
+
+/**
  * Sammelt die Body-Shapes ALLER registrierten MCP-Tools, indem der eigenständige
  * `tsx`-Collector (scripts/collect-tool-shapes.mjs) als Subprozess ausgeführt wird — siehe
  * dessen Datei-Kopf-Kommentar für das WARUM (plain `node` kann `.ts`-Tool-Dateien nicht
  * importieren, `validate-mcp-tools.mjs` selbst bleibt bewusst `tsx`-frei).
  *
- * Body-Checks sind komplett advisory (Global Constraint des P1-Plans): schlägt der
- * Collector aus IRGENDEINEM Grund fehl (kein `tsx` installiert, ein Tool-File das nicht
- * importierbar ist, ...), gibt diese Funktion `null` zurück und computeValidation()
- * überspringt die Body-Checks komplett — der bestehende `node scripts/validate-mcp-tools.mjs`
- * Aufruf und sein Exit-Code bleiben davon unberührt.
- * @returns {Record<string, { sentFields: string[], requiredSent: string[], passthrough: boolean }>|null}
+ * Fail-CLOSED seit #173 (vorher fail-open, siehe BodyShapeCollectorError-JSDoc oben):
+ * schlägt der Collector-Subprozess fehl ODER liefert kein valides JSON auf stdout, wirft
+ * diese Funktion eine BodyShapeCollectorError -- der einzige Aufrufer (validate(), unten)
+ * fängt sie ab und bricht mit Exit 1 und einer klaren "body-contract collector failed"-
+ * Meldung ab, BEVOR computeValidation() überhaupt läuft. Ein Collector-Lauf, der sauber
+ * durchläuft und (legitim) 0 Tool-Shapes meldet, ist davon unterschieden: `JSON.parse('{}')`
+ * wirft NICHT, liefert nur ein leeres Objekt -- computeValidation() sieht dann ganz normal
+ * 0 Body-Findings und der Exit-Code bleibt 0 (kein anderer Bucket betroffen).
+ * @param {string} [scriptPath] Pfad zum Collector-Script (Default COLLECT_SHAPES_SCRIPT).
+ *   Nur für Tests parametrisierbar (siehe tests/body-shape-collector.test.ts), damit ein
+ *   Collector-Crash ohne echten Bug in collect-tool-shapes.mjs simuliert werden kann.
+ * @returns {Record<string, { sentFields: string[], requiredSent: string[], passthrough: boolean }>}
+ * @throws {BodyShapeCollectorError}
  */
-function loadToolBodyShapes() {
+function loadToolBodyShapes(scriptPath = COLLECT_SHAPES_SCRIPT) {
+  let output;
   try {
-    const output = execFileSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['tsx', COLLECT_SHAPES_SCRIPT], {
+    output = execFileSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['tsx', scriptPath], {
       cwd: PROJECT_ROOT,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'inherit'],
       maxBuffer: 10 * 1024 * 1024,
     });
+  } catch (err) {
+    throw new BodyShapeCollectorError(`body-contract collector failed: ${err.message}`, { cause: err });
+  }
+
+  try {
     return JSON.parse(output);
   } catch (err) {
-    console.error(`[validate] Body-Contract-Checks übersprungen (tsx-Collector fehlgeschlagen): ${err.message}`);
-    return null;
+    throw new BodyShapeCollectorError(`body-contract collector failed: collector output is not valid JSON (${err.message})`, { cause: err });
   }
 }
 
@@ -849,14 +884,20 @@ function validate() {
   console.error(`[validate] Schema: ${schema.endpointCount} Endpunkte (Commit: ${schema.sourceCommit.substring(0, 8)})`);
   console.error(`[validate] MCP Tools: ${toolCalls.length} API-Aufrufe gefunden`);
 
-  // Body-Contract-Checks (Task P1.4/P1.6) sind advisory und optional: loadToolBodyShapes()
-  // gibt `null` zurück, wenn der tsx-Collector aus irgendeinem Grund fehlschlägt (z.B. tsx
-  // fehlt) -- computeValidation() überspringt die Checks dann komplett, alle bestehenden
-  // Buckets und der Exit-Code bleiben unangetastet.
-  const toolBodyShapes = loadToolBodyShapes();
-  if (toolBodyShapes) {
-    console.error(`[validate] Body-Shapes: ${Object.keys(toolBodyShapes).length} Tools erfasst (tsx-Collector)`);
+  // Body-Contract-Checks (Task P1.4/P1.6) sind fail-CLOSED seit #173: schlägt der
+  // tsx-Collector fehl (BodyShapeCollectorError, siehe loadToolBodyShapes()-JSDoc), bricht
+  // dieser CLI-Lauf HART ab -- kein stiller Rückfall mehr auf "Body-Checks übersprungen".
+  let toolBodyShapes;
+  try {
+    toolBodyShapes = loadToolBodyShapes();
+  } catch (err) {
+    if (err instanceof BodyShapeCollectorError) {
+      console.error(`\n[validate] KRITISCH: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
   }
+  console.error(`[validate] Body-Shapes: ${Object.keys(toolBodyShapes).length} Tools erfasst (tsx-Collector)`);
 
   // Omission-Registry (Task P3.7) -- optional, siehe loadOmissionRegistry() JSDoc.
   const registry = loadOmissionRegistry();
@@ -1204,4 +1245,6 @@ export {
   partitionBodyFindings,
   hasCriticalErrors,
   generateReport,
+  loadToolBodyShapes,
+  BodyShapeCollectorError,
 };

--- a/tests/body-shape-collector.test.ts
+++ b/tests/body-shape-collector.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { loadToolBodyShapes, BodyShapeCollectorError } from '../scripts/validate-mcp-tools.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Refs #173 -- follow-up to #172's hard BODY_PARAM_MISSING_REQUIRED gate.
+ *
+ * Ground truth for "why this test exists": the OLD loadToolBodyShapes() caught EVERY
+ * failure of the `tsx` collector subprocess (crash, missing binary, bad JSON) and
+ * returned `null`. computeValidation() treats `null` as "body-checks intentionally
+ * skipped" -- the exact same signal a caller sends by never calling loadToolBodyShapes()
+ * at all (see generate-coverage-doc.mjs's 2-arg computeValidation() call). That made a
+ * genuine collector CRASH indistinguishable from "checks were never requested", so the
+ * hard gate (#172) went silently fail-open on a broken collector: CI stayed green even
+ * though the body-contract check never ran.
+ *
+ * These are unit tests against loadToolBodyShapes() itself (now parametrized by
+ * `scriptPath` purely so a crash can be simulated without touching the real
+ * collect-tool-shapes.mjs) -- no vitest mocking of child_process, matching the existing
+ * convention in this file's siblings (body-contract-gate.test.ts) of testing the real
+ * exported function directly. The companion "successful run, 0 findings, exit 0" case is
+ * already covered by hasCriticalErrors(emptyResult()) in body-contract-gate.test.ts, and
+ * is additionally proven live by actually running `node scripts/validate-mcp-tools.mjs`
+ * against the real repo (see PR description / task report) -- not re-implemented as a
+ * slow end-to-end vitest case here.
+ */
+
+describe('loadToolBodyShapes — fail-CLOSED on collector crash (#173)', () => {
+  it('throws a BodyShapeCollectorError (not a silent null) when the tsx subprocess itself fails', () => {
+    // A script path that does not exist makes the `npx tsx <path>` subprocess fail fast
+    // with a non-zero exit — the same failure class ("tsx-Collector-Subprozess scheitert")
+    // #173 is about (build/import errors inside collect-tool-shapes.mjs surface the same
+    // way: execFileSync throws because the child process exited non-zero).
+    const missingScript = join(__dirname, 'fixtures', 'does-not-exist-collector.mjs');
+
+    expect(() => loadToolBodyShapes(missingScript)).toThrow(BodyShapeCollectorError);
+  });
+
+  it('the thrown error carries the "body-contract collector failed" marker validate() greps for', () => {
+    const missingScript = join(__dirname, 'fixtures', 'does-not-exist-collector.mjs');
+
+    try {
+      loadToolBodyShapes(missingScript);
+      expect.unreachable('loadToolBodyShapes() should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BodyShapeCollectorError);
+      expect((err as Error).message).toContain('body-contract collector failed');
+    }
+  });
+
+  it('throws a BodyShapeCollectorError when the collector prints invalid JSON to stdout', () => {
+    // Fixture script runs to completion (exit 0) but its stdout is not JSON at all —
+    // exercises the second failure path (JSON.parse throws) independently from the
+    // "subprocess itself failed" path above (missing-script test case).
+    const nonJsonScript = join(__dirname, 'fixtures', 'invalid-json-collector.mjs');
+
+    expect(() => loadToolBodyShapes(nonJsonScript)).toThrow(BodyShapeCollectorError);
+  });
+
+  it('a successful collector run (real collect-tool-shapes.mjs) returns an object, does not throw', () => {
+    // Proves the refactor (adding the scriptPath param, replacing swallow-and-null with
+    // throw-on-failure) did not break the happy path: the REAL collector against the REAL
+    // repo state must still resolve normally.
+    const shapes = loadToolBodyShapes();
+
+    expect(shapes).toBeTypeOf('object');
+    expect(shapes).not.toBeNull();
+    expect(Object.keys(shapes as Record<string, unknown>).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/fixtures/invalid-json-collector.mjs
+++ b/tests/fixtures/invalid-json-collector.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+/**
+ * Test fixture for tests/body-shape-collector.test.ts (#173): simulates a body-shape
+ * collector that runs to completion (exit 0) but does NOT print valid JSON on stdout —
+ * exercises loadToolBodyShapes()'s `JSON.parse(output)` failure path, independent of the
+ * "npx tsx <path> itself fails" path (missing-script test case).
+ */
+console.log('this is not json output');


### PR DESCRIPTION
## Summary

- **#173**: `loadToolBodyShapes()` used to swallow any failure of the `tsx` body-shape
  collector subprocess and return `null`, which `computeValidation()` treats identically
  to "body-checks intentionally not requested". A genuine collector crash was therefore
  indistinguishable from "nobody asked for body checks" — the hard
  `BODY_PARAM_MISSING_REQUIRED` gate (#172) went silently fail-open on a broken collector.
  `loadToolBodyShapes()` now throws a `BodyShapeCollectorError` on any collector failure
  (subprocess error or invalid JSON stdout); `validate()` catches it and hard-exits(1) with
  a `body-contract collector failed` message *before* `computeValidation()` runs. A
  successful run that legitimately reports zero shapes is unaffected.
- **#176**: `npm run lint` referenced `eslint`, which was neither a devDependency nor
  installed. Installing `eslint` + `typescript-eslint` does not currently fix this:
  `typescript-eslint` refuses to run at all against the pinned `typescript@^7.0.2`
  devDependency (hard runtime error, not just a peer-dependency warning — see
  [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)).
  No CI gate depends on the lint script, so it was removed and the blocker documented in
  README's Development section instead of forcing a workaround around an untested
  TS-6-API side-by-side setup.

## Test plan

- [x] `npx vitest run` — 654/654 tests pass across 50 files (incl. 4 new tests in
      `tests/body-shape-collector.test.ts` covering: subprocess failure throws
      `BodyShapeCollectorError`, error message contains `body-contract collector failed`,
      invalid-JSON-stdout failure path, and the real successful collector run still
      returns an object)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `node scripts/validate-mcp-tools.mjs` exits 0 on the real repo state (286 tool body
      shapes collected, 0 `BODY_PARAM_MISSING_REQUIRED`)
- [x] Manually verified the fail-closed path: injected a throw into
      `scripts/collect-tool-shapes.mjs`, ran `node scripts/validate-mcp-tools.mjs`, got
      exit code 1 and the `[validate] KRITISCH: body-contract collector failed: ...`
      message, then reverted the injected change
- [x] `npm run lint` script removed (was unrunnable); no CI workflow referenced it

Closes #173
Closes #176