### PR TITLE
feat: add self-help / meta tools (server info, update check, tool manifest, diagnostics)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,16 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.new_release_version }}
 
+      # The checked-out ref is the release TAG, which @semantic-release/git creates on
+      # its own commit (e.g. a CHANGELOG.md/package.json version bump) — NOT the commit
+      # that triggered the `release` job. `github.sha` still refers to the latter, so
+      # using it as MCP_GIT_SHA below would bake the pre-release commit into the image
+      # instead of the commit actually being built. Resolve the real, checked-out
+      # revision explicitly instead.
+      - name: Resolve checked-out revision
+        id: rev
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Compute lowercase image ref
         id: image
         env:
@@ -112,7 +122,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
           build-args: |
             MCP_SERVER_VERSION=${{ needs.release.outputs.new_release_version }}
-            MCP_GIT_SHA=${{ github.sha }}
+            MCP_GIT_SHA=${{ steps.rev.outputs.sha }}
             MCP_BUILD_DATE=${{ steps.ts.outputs.created }}
           labels: |
             org.opencontainers.image.title=MCP-Dockhand

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.release.outputs.new_release_version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.rev.outputs.sha }}
             org.opencontainers.image.created=${{ steps.ts.outputs.created }}
             org.opencontainers.image.licenses=MIT
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,10 @@ jobs:
           outputs: type=image,name=${{ steps.image.outputs.ref }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          build-args: |
+            MCP_SERVER_VERSION=${{ needs.release.outputs.new_release_version }}
+            MCP_GIT_SHA=${{ github.sha }}
+            MCP_BUILD_DATE=${{ steps.ts.outputs.created }}
           labels: |
             org.opencontainers.image.title=MCP-Dockhand
             org.opencontainers.image.description=Model Context Protocol (MCP) Server for Dockhand Docker Management — 130+ tools for container, stack, image, network, and volume management.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,16 @@ RUN npm run build
 
 FROM node:22-alpine
 WORKDIR /app
+# Build-identity, injected via --build-arg at image build time (see src/version.ts
+# and the release workflow's docker-build job). ENV must live in THIS stage — it's
+# the one that ships and runs; ENV set in the earlier build stage would not carry
+# over across the multi-stage FROM boundary.
+ARG MCP_SERVER_VERSION="0.0.0-dev"
+ARG MCP_GIT_SHA="unknown"
+ARG MCP_BUILD_DATE="unknown"
+ENV MCP_SERVER_VERSION=$MCP_SERVER_VERSION \
+    MCP_GIT_SHA=$MCP_GIT_SHA \
+    MCP_BUILD_DATE=$MCP_BUILD_DATE
 RUN addgroup -g 1001 mcp && adduser -u 1001 -G mcp -D mcp
 COPY --from=build /app/package*.json ./
 # --ignore-scripts skips the `prepare` hook that runs `husky` (a devDependency

--- a/README.md
+++ b/README.md
@@ -400,6 +400,34 @@ sharing the workaround ([#90](https://github.com/strausmann/mcp-dockhand/issues/
 | `get_container_auto_update` | Get container auto-update |
 | `set_container_auto_update` | Set auto-update policy |
 
+### Self-help / meta tools (6 tools)
+
+Diagnostics for **this MCP server itself**, distinct from the Dockhand API tools above —
+useful for a client or operator asking "is *this server* healthy and correctly configured?"
+rather than "is Dockhand healthy?". None of these six take any input arguments, and none of
+them wrap a single Dockhand endpoint the way the tables above do (`get_tool_manifest` and
+`get_runtime_stats` call no Dockhand endpoint at all) — see `src/tools/meta.ts`.
+
+| Tool | Description |
+|------|-------------|
+| `get_server_info` | This server's own version, git SHA, build date, uptime, MCP protocol version, and the Dockhand URL/server version it's connected to |
+| `check_for_update` | Compares this server's running version against the latest GitHub release (TTL-cached) |
+| `get_tool_manifest` | Lists every registered tool with its Dockhand `{method, path}`, plus the pinned Dockhand OpenAPI commit/version this server's tools were generated against |
+| `self_check` | End-to-end diagnostic: Dockhand reachability, credential validity, and per-environment reachability/Hawser-agent-connected status, in one call |
+| `validate_config` | Checks that the required `DOCKHAND_URL`/`DOCKHAND_USERNAME`/`DOCKHAND_PASSWORD` env vars are present and that they authenticate successfully |
+| `get_runtime_stats` | In-process counters for this server: total/per-tool call and error counts, uptime, and the last error's tool/message/timestamp |
+
+**Notes:**
+
+- `check_for_update` needs outbound network access to `api.github.com` (GitHub's releases
+  API) — it will degrade to `updateAvailable: null` rather than fail if that's unreachable.
+- **No meta tool exposes any secret value.** `validate_config` reports only whether the
+  required env vars are *present* (booleans) and whether they *authenticate* (a boolean +
+  the raw HTTP status code, e.g. `200`/`401`) — never the credential values themselves.
+  `self_check` reports auth validity the same way. `get_runtime_stats`' `lastError` carries
+  only a tool name, an error message, and a timestamp — never call arguments or response
+  payloads.
+
 ## Important Notes
 
 ### update_stack_env — Merge vs Replace Semantics

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ them wrap a single Dockhand endpoint the way the tables above do (`get_tool_mani
 | `get_server_info` | This server's own version, git SHA, build date, uptime, MCP protocol version, and the Dockhand URL/server version it's connected to |
 | `check_for_update` | Compares this server's running version against the latest GitHub release (TTL-cached) |
 | `get_tool_manifest` | Lists every registered tool with its Dockhand `{method, path}`, plus the pinned Dockhand OpenAPI commit/version this server's tools were generated against |
-| `self_check` | End-to-end diagnostic: Dockhand reachability, credential validity, and per-environment reachability/Hawser-agent-connected status, in one call |
+| `self_check` | End-to-end diagnostic: Dockhand reachability, credential validity, and a live, per-environment reachability check (`POST /api/environments/{id}/test`, run in parallel with a 5s per-environment timeout) plus Hawser-agent-connected status, in one call |
 | `validate_config` | Checks that the required `DOCKHAND_URL`/`DOCKHAND_USERNAME`/`DOCKHAND_PASSWORD` env vars are present and that they authenticate successfully |
 | `get_runtime_stats` | In-process counters for this server: total/per-tool call and error counts, uptime, and the last error's tool/message/timestamp |
 

--- a/README.md
+++ b/README.md
@@ -426,7 +426,13 @@ them wrap a single Dockhand endpoint the way the tables above do (`get_tool_mani
   the raw HTTP status code, e.g. `200`/`401`) — never the credential values themselves.
   `self_check` reports auth validity the same way. `get_runtime_stats`' `lastError` carries
   only a tool name, an error message, and a timestamp — never call arguments or response
-  payloads.
+  payloads. **That error message is not fully opaque, though:** for a failed Dockhand API
+  call it can embed a slice of the upstream HTTP status and response body (via
+  `DockhandClient`'s own `Dockhand API error: ... returned <status>: <body>` message), and
+  it is echoed to whichever MCP client next calls `get_runtime_stats` — not necessarily the
+  one that hit the original error. It never includes request bodies or credential values,
+  and it is truncated to 500 characters (with an ellipsis marker) before being stored, so an
+  oversized upstream response is never echoed wholesale.
 
 ## Important Notes
 

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -20,6 +20,17 @@ export class DockhandClient {
   }
 
   /**
+   * Returns the normalized base URL this client actually sends requests to (trailing
+   * slash(es) stripped by `normalizeBaseUrl()`, see src/utils/url.ts / Issue #116) — as
+   * opposed to the raw `DOCKHAND_URL` env var, which may still carry a trailing slash.
+   * Used by `get_server_info` (src/tools/meta.ts) so that diagnostic tool reports what
+   * this client actually does, not what the operator happened to type into the config.
+   */
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  /**
    * Make an authenticated GET request.
    */
   async get<T = unknown>(path: string, params?: Record<string, string | number | undefined>): Promise<T> {

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -6,6 +6,7 @@
 import { SessionManager } from '../auth/session.js';
 import type { DockhandConfig, SSEResult } from '../types/dockhand.js';
 import { normalizeBaseUrl } from '../utils/url.js';
+import { redactQueryStrings } from '../utils/redact.js';
 
 /** Timeout for SSE streaming responses (5 minutes). */
 const SSE_TIMEOUT_MS = 300_000;
@@ -213,8 +214,15 @@ export class DockhandClient {
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
+      // Fix round 3, Item B: redact any URL query string BEFORE this message reaches
+      // ANY of its consumers — console.error (docker logs), errorResponse (the calling
+      // MCP client), and recordError/get_runtime_stats (see src/utils/redact.ts's own
+      // doc comment for the full rationale — a query param can carry a secret, e.g.
+      // trigger_git_webhook's `?secret=<value>`).
       throw new Error(
-        `Dockhand API error: ${method} ${url} returned ${response.status}: ${errorBody || response.statusText}`
+        redactQueryStrings(
+          `Dockhand API error: ${method} ${url} returned ${response.status}: ${errorBody || response.statusText}`
+        )
       );
     }
 
@@ -253,8 +261,15 @@ export class DockhandClient {
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
+      // Fix round 3, Item B: redact any URL query string BEFORE this message reaches
+      // ANY of its consumers — console.error (docker logs), errorResponse (the calling
+      // MCP client), and recordError/get_runtime_stats (see src/utils/redact.ts's own
+      // doc comment for the full rationale — a query param can carry a secret, e.g.
+      // trigger_git_webhook's `?secret=<value>`).
       throw new Error(
-        `Dockhand API error: ${method} ${url} returned ${response.status}: ${errorBody || response.statusText}`
+        redactQueryStrings(
+          `Dockhand API error: ${method} ${url} returned ${response.status}: ${errorBody || response.statusText}`
+        )
       );
     }
 

--- a/src/openapi/description-overrides.ts
+++ b/src/openapi/description-overrides.ts
@@ -1,33 +1,57 @@
 /**
  * Manual description overrides for MCP tools whose DERIVED description
  * (`deriveToolDescription()`, derive-description.ts, fed from `docs/dockhand-openapi.json`
- * via spec-loader.ts) is demonstrably wrong or misleading — checked by `describeTool()`
- * (describe-tool.ts) BEFORE spec-derivation runs.
+ * via spec-loader.ts) is either demonstrably wrong/misleading, or cannot be derived at all
+ * — checked by `describeTool()` (describe-tool.ts) BEFORE spec-derivation runs.
  *
- * Derivation is a per-ENDPOINT lookup (`toolEndpoint(name)` -> `specOperation(endpoint)`),
- * not a per-TOOL one. When two tools call the SAME `{method, path}`, both resolve to the
- * SAME spec operation and therefore get the IDENTICAL derived text — correct for whichever
- * tool the spec operation was actually written to describe, wrong (field/behavior
- * mismatch) for the other. `endpointToTool()` (tool-endpoint.ts) additionally picks exactly
- * ONE of the two as the "owning" tool for CROSS-REFERENCE resolution (first match in
- * `TOOL_ENDPOINT_MAP`'s alphabetically-sorted insertion order) — that same tool is also the
- * one whose OWN description this ambiguity affects, since a caller has no way to ask for
- * "the other tool's" operation.
+ * Two distinct categories live here, for two distinct reasons:
+ *
+ * 1. SHARED-ENDPOINT MISMATCHES (`remove_stack_env_vars`, `check_stack_env_collisions`,
+ *    `clear_user_roles`, `get_git_stack_webhook`). Derivation is a per-ENDPOINT lookup
+ *    (`toolEndpoint(name)` -> `specOperation(endpoint)`), not a per-TOOL one. When two tools
+ *    call the SAME `{method, path}`, both resolve to the SAME spec operation and therefore
+ *    get the IDENTICAL derived text — correct for whichever tool the spec operation was
+ *    actually written to describe, wrong (field/behavior mismatch) for the other.
+ *    `endpointToTool()` (tool-endpoint.ts) additionally picks exactly ONE of the two as the
+ *    "owning" tool for CROSS-REFERENCE resolution (first match in `TOOL_ENDPOINT_MAP`'s
+ *    alphabetically-sorted insertion order) — that same tool is also the one whose OWN
+ *    description this ambiguity affects, since a caller has no way to ask for "the other
+ *    tool's" operation.
+ *
+ * 2. NO DOCKHAND ENDPOINT AT ALL (the six self-help/meta tools registered by
+ *    `registerMetaTools()`, src/tools/meta.ts: `get_server_info`, `check_for_update`,
+ *    `get_tool_manifest`, `self_check`, `validate_config`, `get_runtime_stats`). These
+ *    diagnose the MCP server itself, not a Dockhand REST resource, so `toolEndpoint(name)`
+ *    returns `undefined` for every one of them — there is no `{method, path}` to look up in
+ *    the first place, let alone a spec operation to summarize. Without an override,
+ *    `deriveToolDescription({}, ...)` falls through to its own `FALLBACK_DESCRIPTION`
+ *    literal, `"No description available."` — the exact text an MCP client sees for all six
+ *    tools, since the README (where these tools ARE documented) is never visible to a
+ *    client. Left unfixed, that defeats the entire point of shipping self-help tools: a
+ *    client cannot tell what any of them do without already knowing.
  *
  * This is a narrow, audited exception to "derive everything from the spec" (P3, Refs #57)
  * — NOT a reintroduction of hand-written prose across the board. Every entry below:
- *   1. Is added ONLY after confirming the derived text actually references a field/behavior
- *      the tool does not have (checked against the tool's own Zod schema + handler body in
- *      `src/tools/*.ts` — never assumed).
- *   2. Carries a code comment explaining WHY derivation fails for this specific pair.
- *   3. Reuses the tool's own pre-P3 hand-written description where one existed (git history,
- *      commit before d37b986) rather than inventing new prose — that text was already
- *      reviewed, shipped, and tool-specific.
+ *   1. Is added ONLY after confirming the derived text is either wrong (category 1, checked
+ *      against the tool's own Zod schema + handler body in `src/tools/*.ts` — never assumed)
+ *      or entirely undeliverable (category 2, confirmed via `toolEndpoint(name) ===
+ *      undefined`).
+ *   2. Carries a code comment explaining WHY derivation fails for this specific tool.
+ *   3. For category 1, reuses the tool's own pre-P3 hand-written description where one
+ *      existed (git history, commit before d37b986) rather than inventing new prose — that
+ *      text was already reviewed, shipped, and tool-specific. Category 2 tools never had a
+ *      derivable description to restore (there was never a spec operation to derive one
+ *      from), so their text is newly written to match the existing entries' concise,
+ *      single-sentence style — and kept in sync with the tool's own README row (see the
+ *      "Self-help / meta tools" section) rather than duplicating it independently.
  *
  * `tests/description-overrides.test.ts` guards two invariants: every key here is a real,
- * registered tool name (typo-proofing against `TOOL_ENDPOINT_MAP`), and every value is
- * non-empty. `tests/describe-tool.test.ts` additionally asserts the overridden text does
- * NOT contain the specific wrong field/behavior references that motivated each entry.
+ * registered tool name (checked against the full set of tools `registerAllTools()` actually
+ * registers, not just `TOOL_ENDPOINT_MAP` — category 2 keys are never in that map by
+ * design), and every value is non-empty. `tests/describe-tool.test.ts` additionally asserts
+ * the overridden text does NOT contain the specific wrong field/behavior references that
+ * motivated each category-1 entry, and DOES return the real override (never the fallback)
+ * for each category-2 (meta) tool.
  */
 
 export const TOOL_DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = {
@@ -77,4 +101,39 @@ export const TOOL_DESCRIPTION_OVERRIDES: Readonly<Record<string, string>> = {
     'GitHub/GitLab/etc. to POST deploy notifications); use `trigger_git_webhook` to fire the ' +
     'webhook manually, or `get_git_webhook` for the equivalent on the generic webhook ' +
     'endpoint.',
+
+  // --- Category 2: no Dockhand endpoint at all (registerMetaTools(), src/tools/meta.ts) ---
+  // `toolEndpoint(name)` returns `undefined` for all six — there is no `{method, path}` to
+  // resolve a spec operation from, so without an override each would fall through to the
+  // literal fallback string "No description available.". See the file-level comment above
+  // for the full rationale; each entry mirrors its own row in README.md's "Self-help / meta
+  // tools" table.
+
+  get_server_info:
+    "This server's own version, git SHA, build date, and uptime, plus the MCP protocol " +
+    'version and the Dockhand URL and server version it is currently connected to.',
+
+  check_for_update:
+    'Checks whether a newer mcp-dockhand release is available by comparing this server\'s ' +
+    "running version against the latest GitHub release; the result is cached for about an " +
+    'hour.',
+
+  get_tool_manifest:
+    'Lists every tool this build exposes together with the pinned Dockhand OpenAPI ' +
+    'commit/version they were generated against, so a client can detect drift between the ' +
+    'two.',
+
+  self_check:
+    'Live end-to-end diagnostic: Dockhand reachability, credential validity, latency, and a ' +
+    'per-environment reachability check plus Hawser-agent-connected status, all in one call.',
+
+  validate_config:
+    "Checks whether this server's required Dockhand configuration is present and the " +
+    'credentials authenticate; returns only booleans and the raw HTTP status code, never ' +
+    'secret values.',
+
+  get_runtime_stats:
+    'In-process request and error counters for this server, broken down per tool, plus the ' +
+    'most recent error, for debugging this server itself (never call arguments or response ' +
+    'payloads).',
 };

--- a/src/openapi/pinned.ts
+++ b/src/openapi/pinned.ts
@@ -1,0 +1,12 @@
+/**
+ * Exposes the pinned Dockhand OpenAPI source commit as an importable TS constant.
+ *
+ * The commit itself is already pinned in `scripts/fetch-openapi.mjs` (`SOURCE_COMMIT`,
+ * exported from that module) — but `scripts/` sits outside tsconfig's `rootDir: "./src"`
+ * (see the "rootDir constraint" note at the top of `src/openapi/spec-loader.ts`, which
+ * hits the same wall for `docs/dockhand-openapi.json`), so `src/` code cannot statically
+ * import from it. This constant is a small, hand-maintained mirror kept in sync with
+ * `SOURCE_COMMIT` — update both together whenever the pinned commit changes.
+ */
+
+export const PINNED_DOCKHAND_OPENAPI_COMMIT = 'db2a196f7241c12faf693cf7b2bc2e26df8dc75c';

--- a/src/openapi/spec-loader.ts
+++ b/src/openapi/spec-loader.ts
@@ -30,6 +30,7 @@ const PROJECT_ROOT = resolve(__dirname, '..', '..');
 const SPEC_FILE = join(PROJECT_ROOT, 'docs', 'dockhand-openapi.json');
 
 interface OpenApiSpec {
+  info?: { version?: string };
   paths?: Record<string, Record<string, OpenApiOperation>>;
 }
 
@@ -71,4 +72,16 @@ export function specOperation(endpoint: ToolEndpointEntry | undefined): OpenApiO
   const methods = spec.paths[endpoint.path];
   if (!methods) return undefined;
   return methods[endpoint.method.toLowerCase()];
+}
+
+/**
+ * Returns the pinned Dockhand OpenAPI spec's `info.version` (e.g. "1.0.41"), or
+ * `undefined` when the spec file is unavailable (see `loadSpec()`) or carries no
+ * `info.version`. Used by `get_tool_manifest` (src/tools/meta.ts) to report which
+ * Dockhand API version the generated `TOOL_ENDPOINT_MAP` was derived from, alongside
+ * the pinned source commit (`PINNED_DOCKHAND_OPENAPI_COMMIT`, src/openapi/pinned.ts).
+ */
+export function specInfoVersion(): string | undefined {
+  const spec = loadSpec();
+  return spec?.info?.version;
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -24,6 +24,7 @@ import { registerVulnerabilityTools } from './vulnerabilities.js';
 import { registerTemplateTools } from './templates.js';
 import { registerLabelTools } from './labels.js';
 import { registerPreferenceTools } from './preferences.js';
+import { registerMetaTools } from './meta.js';
 
 export function registerAllTools(server: McpServer, client: DockhandClient): void {
   registerContainerTools(server, client);
@@ -46,6 +47,7 @@ export function registerAllTools(server: McpServer, client: DockhandClient): voi
   registerTemplateTools(server, client);
   registerLabelTools(server, client);
   registerPreferenceTools(server, client);
+  registerMetaTools(server, client);
 
   console.error('[tools] All Dockhand tools registered');
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -287,21 +287,28 @@ export interface ConfigValidation {
  * password all present, and calling out anyway would risk a confusing error unrelated to the
  * real problem (a missing var).
  *
- * `attemptLogin` is injected (returns an HTTP status code) so this is testable without a
- * live Dockhand instance and without ever touching the credential's value in a test —
- * only the resulting status code crosses the boundary. `credentialsValid` is exactly
- * `statusCode === 200`; any other status (401, 403, ...) or a thrown error (network
- * failure, timeout) degrades to `credentialsValid: false` — a probe that throws never
- * propagates out of `validateConfig`, matching the self-help-tools-never-break posture
- * of `buildServerInfo()` / `runSelfCheck()` above. On a thrown probe, `statusCode` stays
- * `null` (there was no response to report a code from).
+ * `attemptLogin` is injected (returns a `LoginProbeResult`, see that interface's own doc
+ * comment below) so this is testable without a live Dockhand instance and without ever
+ * touching the credential's value in a test — only the resulting status code and
+ * completed-auth boolean cross the boundary. `credentialsValid` is exactly
+ * `completedAuth` (Fix round 2, Finding 3: NOT `statusCode === 200` — a `200` can still
+ * mean an incomplete, MFA-pending login with no session established, which
+ * `LoginProbeResult.completedAuth` already accounts for; see `attemptRawLogin()`'s doc
+ * comment for the full rationale). Any other status (401, 403, ...), an incomplete `200`,
+ * or a thrown error (network failure, timeout) all degrade to `credentialsValid: false` —
+ * a probe that throws never propagates out of `validateConfig`, matching the
+ * self-help-tools-never-break posture of `buildServerInfo()` / `runSelfCheck()` above. On
+ * a thrown probe, `statusCode` stays `null` (there was no response to report a code
+ * from); on a completed probe, `statusCode` always reports the real HTTP status,
+ * independent of `credentialsValid` — so a `200`-but-MFA-pending outcome is still
+ * visible as `statusCode: 200, credentialsValid: false`, not conflated with a `401`.
  *
  * Per `secret-safe-config-inspection.md` / `service-verifikation.md`: this function reads
  * env values only to compute a boolean and to pass them (via the injected `attemptLogin`)
  * to a live auth check — it never places a value itself into the returned object.
  */
 export async function validateConfig(deps: {
-  attemptLogin: () => Promise<number>;
+  attemptLogin: () => Promise<LoginProbeResult>;
 }): Promise<ConfigValidation> {
   const requiredEnvPresent = {
     DOCKHAND_URL: !!process.env.DOCKHAND_URL,
@@ -315,15 +322,19 @@ export async function validateConfig(deps: {
   }
 
   let statusCode: number | null;
+  let completedAuth: boolean;
   try {
-    statusCode = await deps.attemptLogin();
+    const probe = await deps.attemptLogin();
+    statusCode = probe.statusCode;
+    completedAuth = probe.completedAuth;
   } catch {
     statusCode = null;
+    completedAuth = false;
   }
 
   return {
     requiredEnvPresent,
-    credentialsValid: statusCode === 200,
+    credentialsValid: completedAuth,
     statusCode,
   };
 }
@@ -412,8 +423,7 @@ const ENVIRONMENT_TEST_TIMEOUT_MS = 5_000;
  * deliberate, acceptable trade-off for a lightweight diagnostic tool — `self_check`'s
  * job is to stay responsive, not to strictly bound background resource usage.
  *
- * Exported (unlike the other registration-time-only helpers in this file, e.g.
- * `attemptRawLogin`) so it can be unit-tested directly — it is small, generic,
+ * Exported so it can be unit-tested directly — it is small, generic,
  * timing-sensitive logic in its own right, not just wiring.
  */
 export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
@@ -433,20 +443,40 @@ export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<
 }
 
 /**
+ * The outcome of a one-shot login probe (`attemptRawLogin()` below) — the shared shape
+ * behind both `self_check`'s `authValid` and `validate_config`'s `credentialsValid`.
+ *
+ * `statusCode` is always the real HTTP status Dockhand returned (or `null` upstream, in
+ * `validateConfig()`, when the probe itself threw) — kept separate from `completedAuth`
+ * so a caller can still report *what actually happened* (e.g. `401`) even though a
+ * bare status code is not, on its own, a reliable "auth is valid" signal (see
+ * `completedAuth`'s own doc below, Fix round 2 / Finding 3).
+ *
+ * `completedAuth` is the actual "is this credential usable non-interactively right
+ * now" answer: `true` only for a `200` response that also established a real session
+ * (a session cookie was set) AND did not carry `requiresMfa:true`. `false` for every
+ * other outcome — including a `200` that did neither.
+ */
+export interface LoginProbeResult {
+  statusCode: number;
+  completedAuth: boolean;
+}
+
+/**
  * A dedicated, minimal raw login attempt against Dockhand's own `/api/auth/login` —
  * the shared wiring behind both `self_check`'s `authValid` and `validate_config`'s
  * `credentialsValid`.
  *
  * Deliberately NOT `SessionManager.login()` (src/auth/session.ts): that method
  * `console.error`s the configured username on failure and throws rather than
- * resolving to a status code — useful for its own job (diagnosable auto-relogin
+ * resolving to a result value — useful for its own job (diagnosable auto-relogin
  * failures in `docker logs`, Issue #116), wrong for this one. Two self-help tools
- * need the plain HTTP status (200 valid / 401 invalid) as a value, not a side effect
- * or an exception, and neither needs the extra log line. This function does neither:
- * no logging, always resolves to `response.status` — a genuine transport failure
- * (DNS, connection refused, timeout) is left to the caller's own try/catch, matching
- * `runSelfCheck()`'s `probeAuth` and `validateConfig()`'s `attemptLogin` contracts
- * (both already documented above as "throws → treated as invalid/false").
+ * need the outcome as a plain value, not a side effect or an exception, and neither
+ * needs the extra log line. This function does neither: no logging, always resolves to
+ * a `LoginProbeResult` — a genuine transport failure (DNS, connection refused, timeout)
+ * is left to the caller's own try/catch, matching `runSelfCheck()`'s `probeAuth` and
+ * `validateConfig()`'s `attemptLogin` contracts (both already documented above as
+ * "throws → treated as invalid/false").
  *
  * Also why this can't just be `client.get(...)`: `DockhandClient`'s request methods
  * auto-relogin on a 401 (see `dockhand-client.ts`'s `request()`), which is exactly the
@@ -460,18 +490,27 @@ export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<
  * `DOCKHAND_PASSWORD` only to place them in the POST body sent directly to Dockhand's
  * own login endpoint — the same two values `SessionManager` itself sends on every
  * real login — and never logs, returns, or otherwise surfaces either value. Only the
- * numeric status code crosses back out of this function.
+ * `LoginProbeResult` (a status code plus a boolean) crosses back out of this function —
+ * the response body itself is inspected here for exactly one boolean flag
+ * (`requiresMfa`) and never returned.
  *
- * Known imprecision (pre-existing codebase behavior, not introduced here): a `200`
- * response can also mean `{ success: true, requiresMfa: true }` — a login that still
- * needs a second factor, per `/api/auth/login`'s own documented response shape. This
- * function (and therefore both `self_check`'s `authValid` and `validate_config`'s
- * `credentialsValid`) does not distinguish that case from a fully completed login;
- * both read as "valid". Distinguishing them would need parsing the response body,
- * which `SessionManager.login()` itself does not do either (see `session.ts` —
- * it treats any `response.ok` as success and extracts only the session cookie).
+ * Fix round 2, Finding 3 (P2): a `200` response from `/api/auth/login` does not always
+ * mean a usable session was established. Per `docs/dockhand-openapi.json`'s own
+ * description of this endpoint's `200` response ("Login succeeded and dockhand_session
+ * cookie was set — OR requiresMfa:true if a second factor is needed first"), a `200`
+ * can also carry `{ success: true, requiresMfa: true }` with NO session cookie — an MFA
+ * account whose credentials this one-shot, non-interactive probe can never fully
+ * authenticate (there is no second factor to supply). The previous version of this
+ * function treated any `200` as valid, so `validate_config.credentialsValid` and
+ * `self_check`'s `authValid` both reported `true` for such an account even though it
+ * could not actually establish a session through this path. This function now reads
+ * the response body's `requiresMfa` flag and checks for a `Set-Cookie` session cookie
+ * (mirroring `SessionManager.performLogin()`'s own cookie-extraction fallback chain —
+ * `getSetCookie()` then the raw `set-cookie` header — without needing the cookie's
+ * *value*, only its presence): `completedAuth` is `true` only when the status is `200`,
+ * a session cookie was set, AND `requiresMfa` is not `true`.
  */
-async function attemptRawLogin(baseUrl: string): Promise<number> {
+export async function attemptRawLogin(baseUrl: string): Promise<LoginProbeResult> {
   const response = await fetch(`${baseUrl}/api/auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -482,7 +521,28 @@ async function attemptRawLogin(baseUrl: string): Promise<number> {
     }),
     redirect: 'manual',
   });
-  return response.status;
+
+  const statusCode = response.status;
+  if (statusCode !== 200) {
+    return { statusCode, completedAuth: false };
+  }
+
+  // Read the body once (mirrors SessionManager.performLogin()'s own "read once, cache"
+  // pattern for the same reason: a Response body can only be consumed once).
+  const bodyText = await response.text().catch(() => '');
+  let requiresMfa = false;
+  try {
+    const body = bodyText ? (JSON.parse(bodyText) as { requiresMfa?: unknown }) : {};
+    requiresMfa = body?.requiresMfa === true;
+  } catch {
+    // Non-JSON or unparsable body — no requiresMfa flag to find, treat as absent.
+    requiresMfa = false;
+  }
+
+  const setCookie = response.headers.getSetCookie?.() ?? [];
+  const hasSessionCookie = setCookie.length > 0 || !!response.headers.get('set-cookie');
+
+  return { statusCode, completedAuth: hasSessionCookie && !requiresMfa };
 }
 
 /** Timeout for the unauthenticated `/api/health` liveness probe below (Fix round 2,
@@ -559,7 +619,10 @@ export async function probeRawHealth(baseUrl: string): Promise<void> {
  *         (network error, non-2xx status, or timeout) means Dockhand is unreachable;
  *         `runSelfCheck` short-circuits to `overall: "down"` without calling the other
  *         two probes.
- *       - `probeAuth`: `attemptRawLogin()` above, `status === 200`.
+ *       - `probeAuth`: `attemptRawLogin()` above, `.completedAuth` (**Fix round 2,
+ *         Finding 3**: NOT a bare `status === 200` check — see `attemptRawLogin()`'s own
+ *         doc comment for why a `200` alone is not sufficient, e.g. an MFA-pending
+ *         login).
  *       - `listEnvironments`: three calls, then `deriveEnvironmentStatuses()` above turns
  *         their results into `SelfCheckEnvironment[]` — see that function's own doc comment
  *         for exactly how `reachable`/`hawserConnected` are derived (**Fix round 1, Finding
@@ -585,9 +648,10 @@ export async function probeRawHealth(baseUrl: string): Promise<void> {
  *              failing `listEnvironments` for every other environment.
  *   - `validate_config`: `validateConfig()`'s `attemptLogin` is `attemptRawLogin()` above
  *     against `client.getBaseUrl()` — the same helper `self_check` uses, so the two tools
- *     agree on what "the configured credentials are valid" means. `requiredEnvPresent` reads
- *     `process.env` directly inside `validateConfig()` itself (see its own doc comment); this
- *     registration only supplies the login probe.
+ *     agree on what "the configured credentials are valid" means (both key off
+ *     `LoginProbeResult.completedAuth`, not a bare status code — Fix round 2, Finding 3).
+ *     `requiredEnvPresent` reads `process.env` directly inside `validateConfig()` itself
+ *     (see its own doc comment); this registration only supplies the login probe.
  *   - `get_runtime_stats`: `getStatsSnapshot()` (`src/utils/runtime-stats.js`) — no
  *     dependencies to wire, the counters live at module scope and are updated by
  *     `registerTool()` itself on every call (`recordCall`/`recordError`, see
@@ -636,7 +700,7 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
     async () => {
       const result = await runSelfCheck({
         probeHealth: () => probeRawHealth(client.getBaseUrl()),
-        probeAuth: async () => (await attemptRawLogin(client.getBaseUrl())) === 200,
+        probeAuth: async () => (await attemptRawLogin(client.getBaseUrl())).completedAuth,
         listEnvironments: async () => {
           const envs = await client.get<EnvironmentListEntry[]>('/api/environments');
 

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -563,7 +563,29 @@ export interface LoginProbeResult {
  * `getSetCookie()` then the raw `set-cookie` header — without needing the cookie's
  * *value*, only its presence): `completedAuth` is `true` only when the status is `200`,
  * a session cookie was set, AND `requiresMfa` is not `true`.
+ *
+ * Fix round 3, Finding 1 (P2): "a session cookie was set" now means, specifically, a
+ * `Set-Cookie` entry named `dockhand_session` — Dockhand's own session cookie name, per
+ * `docs/dockhand-openapi.json`'s login-endpoint description quoted above and its
+ * logout-endpoint summary ("Destroy the current session (clears the dockhand_session
+ * cookie)"). The previous version treated ANY `Set-Cookie` header on a `200` as proof of
+ * a session — so a reverse proxy or CDN in front of Dockhand adding an unrelated cookie
+ * (e.g. Cloudflare's `__cf_bm`) to the same response would have been misread as a
+ * completed login even with no Dockhand session ever established.
  */
+const DOCKHAND_SESSION_COOKIE_NAME = 'dockhand_session';
+
+/** Whether `setCookieHeaders` contains an entry for the cookie named `name` — matched
+ * on the cookie's name only (the part before its first `=`), never its value, per
+ * `secret-safe-config-inspection.md` (a session cookie's value is never inspected,
+ * only whether the expected cookie is present at all). */
+function hasNamedCookie(setCookieHeaders: readonly string[], name: string): boolean {
+  return setCookieHeaders.some((entry) => {
+    const eq = entry.indexOf('=');
+    return eq !== -1 && entry.slice(0, eq).trim() === name;
+  });
+}
+
 export async function attemptRawLogin(baseUrl: string): Promise<LoginProbeResult> {
   const response = await fetch(`${baseUrl}/api/auth/login`, {
     method: 'POST',
@@ -593,8 +615,13 @@ export async function attemptRawLogin(baseUrl: string): Promise<LoginProbeResult
     requiresMfa = false;
   }
 
+  // `getSetCookie()` then the raw `set-cookie` header fallback (older fetch
+  // implementations may not implement getSetCookie() at all — mirrors
+  // SessionManager.performLogin()'s own fallback chain, see the doc comment above).
   const setCookie = response.headers.getSetCookie?.() ?? [];
-  const hasSessionCookie = setCookie.length > 0 || !!response.headers.get('set-cookie');
+  const rawSetCookie = response.headers.get('set-cookie');
+  const setCookieHeaders = setCookie.length > 0 ? setCookie : rawSetCookie ? [rawSetCookie] : [];
+  const hasSessionCookie = hasNamedCookie(setCookieHeaders, DOCKHAND_SESSION_COOKIE_NAME);
 
   return { statusCode, completedAuth: hasSessionCookie && !requiresMfa };
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -43,3 +43,72 @@ export async function buildServerInfo(deps: {
     dockhandServerVersion,
   };
 }
+
+/**
+ * Pure builder behind the `check_for_update` tool. Checks the latest GitHub
+ * release for this server against a caller-supplied current version, with
+ * an in-memory TTL cache so repeated tool calls do not hammer the GitHub
+ * API. Injectable fetch + clock keep it testable without real network
+ * access or timers. Any failure (network, non-2xx, malformed body)
+ * degrades to `updateAvailable: null` rather than throwing, matching the
+ * self-help-tools-never-break-the-server posture of `buildServerInfo`.
+ */
+const RELEASES_URL = 'https://api.github.com/repos/strausmann/mcp-dockhand/releases/latest';
+const UPDATE_TTL_MS = 60 * 60 * 1000;
+let updateCache: { at: number; latest: string; url?: string; publishedAt?: string } | null = null;
+
+/** Test hook: clears the in-memory update cache between test cases. */
+export function __resetUpdateCache() {
+  updateCache = null;
+}
+
+export function compareSemver(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.replace(/^v/, '').split('.').map(Number);
+  const pb = b.replace(/^v/, '').split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+export interface UpdateInfo {
+  current: string;
+  latest: string | null;
+  updateAvailable: boolean | null;
+  releaseUrl?: string;
+  publishedAt?: string;
+  error?: string;
+}
+
+export async function checkForUpdate(deps: {
+  current: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}): Promise<UpdateInfo> {
+  const now = deps.now ?? Date.now;
+  const doFetch = deps.fetchImpl ?? fetch;
+  try {
+    if (!updateCache || now() - updateCache.at > UPDATE_TTL_MS) {
+      const res = await doFetch(RELEASES_URL, { headers: { Accept: 'application/vnd.github+json' } });
+      if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+      const json = (await res.json()) as { tag_name: string; html_url?: string; published_at?: string };
+      updateCache = {
+        at: now(),
+        latest: json.tag_name.replace(/^v/, ''),
+        url: json.html_url,
+        publishedAt: json.published_at,
+      };
+    }
+    const latest = updateCache.latest;
+    return {
+      current: deps.current,
+      latest,
+      updateAvailable: compareSemver(latest, deps.current) > 0,
+      releaseUrl: updateCache.url,
+      publishedAt: updateCache.publishedAt,
+    };
+  } catch (e) {
+    return { current: deps.current, latest: null, updateAvailable: null, error: (e as Error).message };
+  }
+}

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -1,0 +1,45 @@
+/**
+ * Self-help / meta tools — server identity and diagnostics for the MCP
+ * server itself, distinct from the Dockhand tools it wraps.
+ */
+
+import { getServerVersion, getGitSha, getBuildDate, getUptimeSeconds } from '../version.js';
+
+export interface ServerInfo {
+  version: string;
+  gitSha: string;
+  buildDate: string;
+  uptimeSeconds: number;
+  mcpProtocolVersion: string;
+  dockhandUrl: string;
+  dockhandServerVersion: string | null;
+}
+
+/**
+ * Pure builder behind the `get_server_info` tool. Kept dependency-injected
+ * (dockhandUrl + a version fetcher) so it is testable without a live MCP
+ * server or Dockhand client. Fetching the Dockhand server version is
+ * best-effort: any failure degrades to `null` rather than throwing, so a
+ * self-help tool never breaks because Dockhand itself is unreachable.
+ */
+export async function buildServerInfo(deps: {
+  dockhandUrl: string;
+  mcpProtocolVersion?: string;
+  getDockhandServerVersion: () => Promise<string>;
+}): Promise<ServerInfo> {
+  let dockhandServerVersion: string | null = null;
+  try {
+    dockhandServerVersion = await deps.getDockhandServerVersion();
+  } catch {
+    dockhandServerVersion = null;
+  }
+  return {
+    version: getServerVersion(),
+    gitSha: getGitSha(),
+    buildDate: getBuildDate(),
+    uptimeSeconds: getUptimeSeconds(),
+    mcpProtocolVersion: deps.mcpProtocolVersion ?? 'unknown',
+    dockhandUrl: deps.dockhandUrl,
+    dockhandServerVersion,
+  };
+}

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -3,8 +3,14 @@
  * server itself, distinct from the Dockhand tools it wraps.
  */
 
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
+import type { DockhandClient } from '../client/dockhand-client.js';
 import { getServerVersion, getGitSha, getBuildDate, getUptimeSeconds } from '../version.js';
-import type { ToolEndpointEntry } from '../openapi/tool-endpoint-map.js';
+import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { TOOL_ENDPOINT_MAP, type ToolEndpointEntry } from '../openapi/tool-endpoint-map.js';
+import { PINNED_DOCKHAND_OPENAPI_COMMIT } from '../openapi/pinned.js';
+import { specInfoVersion } from '../openapi/spec-loader.js';
 
 export interface ServerInfo {
   version: string;
@@ -156,4 +162,64 @@ export function buildToolManifest(deps: {
     dockhandOpenApiVersion: deps.openApiVersion,
     generatedAt: deps.generatedAt,
   };
+}
+
+/**
+ * Registers the three M1 self-help tools, wiring the pure builders above to their real
+ * dependencies:
+ *   - `get_server_info`: `dockhandUrl` from the same `DOCKHAND_URL` env var the server
+ *     itself requires at startup (src/index.ts) — a URL, never a secret. The Dockhand
+ *     server version is read from `GET /api/changelog` (`src/tools/system.ts`'s
+ *     `get_changelog` tool hits the same endpoint): the changelog is generated newest-first,
+ *     so its first entry's `version` is the running server's version. That call is
+ *     best-effort — `buildServerInfo()` already degrades any throw (network error, empty
+ *     changelog, auth failure) to `dockhandServerVersion: null` rather than failing the
+ *     tool. `mcpProtocolVersion` is the SDK's own `LATEST_PROTOCOL_VERSION` constant.
+ *   - `check_for_update`: compares this server's own build-injected version
+ *     (`getServerVersion()`, src/version.js) against the latest GitHub release.
+ *   - `get_tool_manifest`: the real generated `TOOL_ENDPOINT_MAP`, the pinned Dockhand
+ *     OpenAPI source commit (`PINNED_DOCKHAND_OPENAPI_COMMIT`, src/openapi/pinned.ts),
+ *     and that same pinned spec's own `info.version` (`specInfoVersion()`,
+ *     src/openapi/spec-loader.ts) — so a client can tell which Dockhand API version this
+ *     server's tools were generated against.
+ *
+ * All three take no input arguments.
+ */
+export function registerMetaTools(server: McpServer, client: DockhandClient): void {
+  registerTool(server, 'get_server_info',
+    {},
+    async () => {
+      const info = await buildServerInfo({
+        dockhandUrl: process.env['DOCKHAND_URL'] ?? 'unknown',
+        mcpProtocolVersion: LATEST_PROTOCOL_VERSION,
+        getDockhandServerVersion: async () => {
+          const changelog = await client.get<{ version: string }[]>('/api/changelog');
+          const latest = changelog[0]?.version;
+          if (!latest) throw new Error('Dockhand changelog is empty');
+          return latest;
+        },
+      });
+      return jsonResponse(info);
+    }
+  );
+
+  registerTool(server, 'check_for_update',
+    {},
+    async () => {
+      return jsonResponse(await checkForUpdate({ current: getServerVersion() }));
+    }
+  );
+
+  registerTool(server, 'get_tool_manifest',
+    {},
+    async () => {
+      const manifest = buildToolManifest({
+        endpointMap: TOOL_ENDPOINT_MAP,
+        openApiCommit: PINNED_DOCKHAND_OPENAPI_COMMIT,
+        openApiVersion: specInfoVersion() ?? 'unknown',
+        generatedAt: new Date().toISOString(),
+      });
+      return jsonResponse(manifest);
+    }
+  );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -4,6 +4,7 @@
  */
 
 import { getServerVersion, getGitSha, getBuildDate, getUptimeSeconds } from '../version.js';
+import type { ToolEndpointEntry } from '../openapi/tool-endpoint-map.js';
 
 export interface ServerInfo {
   version: string;
@@ -111,4 +112,48 @@ export async function checkForUpdate(deps: {
   } catch (e) {
     return { current: deps.current, latest: null, updateAvailable: null, error: (e as Error).message };
   }
+}
+
+/**
+ * Pure builder behind the `get_tool_manifest` tool. Maps the tool→endpoint map
+ * (`src/openapi/tool-endpoint-map.ts`) plus the pinned Dockhand OpenAPI identity
+ * (commit + `info.version`, see `src/openapi/pinned.ts` / `src/openapi/spec-loader.ts`)
+ * into a single manifest, so a client can detect drift between what this server
+ * exposes and the Dockhand version it targets. Kept dependency-injected — no direct
+ * import of the real endpoint map or spec — so it is testable without touching the
+ * filesystem. The registered tool wires the real `TOOL_ENDPOINT_MAP` and the pinned
+ * identity in.
+ */
+export interface ToolManifestEntry {
+  name: string;
+  method: string;
+  path: string;
+}
+
+export interface ToolManifest {
+  toolCount: number;
+  tools: ToolManifestEntry[];
+  dockhandOpenApiCommit: string;
+  dockhandOpenApiVersion: string;
+  generatedAt: string;
+}
+
+export function buildToolManifest(deps: {
+  endpointMap: Readonly<Record<string, ToolEndpointEntry>>;
+  openApiCommit: string;
+  openApiVersion: string;
+  generatedAt: string;
+}): ToolManifest {
+  const tools = Object.entries(deps.endpointMap).map(([name, entry]) => ({
+    name,
+    method: entry.method,
+    path: entry.path,
+  }));
+  return {
+    toolCount: tools.length,
+    tools,
+    dockhandOpenApiCommit: deps.openApiCommit,
+    dockhandOpenApiVersion: deps.openApiVersion,
+    generatedAt: deps.generatedAt,
+  };
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -123,19 +123,66 @@ export async function checkForUpdate(deps: {
 }
 
 /**
+ * The six self-help/meta tool names registered by `registerMetaTools()` below —
+ * `get_tool_manifest` itself among them. This is the single source of truth for that
+ * list: `tests/tool-endpoint.test.ts`'s endpoint-completeness check imports it to
+ * exclude these six from its "every registered tool has a `TOOL_ENDPOINT_MAP` entry"
+ * assertion (none of the six wrap a single Dockhand endpoint the way every other
+ * registered tool does — see that test's own doc comment for why, tool by tool), and
+ * `get_tool_manifest`'s own registration wiring below reuses it (Fix round 2,
+ * Finding 4) so its inventory includes these six tools too, not just the
+ * `TOOL_ENDPOINT_MAP` ones.
+ */
+export const META_TOOL_NAMES: readonly string[] = [
+  'check_for_update',
+  'get_runtime_stats',
+  'get_server_info',
+  'get_tool_manifest',
+  'self_check',
+  'validate_config',
+];
+
+/**
+ * `get_prometheus_metrics`'s real endpoint (`GET /api/metrics`, see
+ * `registerSystemTools()` in src/tools/system.ts) — deliberately excluded from the
+ * generated `TOOL_ENDPOINT_MAP` itself (see `scripts/generate-tool-endpoint-map.mjs`'s
+ * own header: `/api/metrics` is not a SvelteKit route and therefore cannot carry an
+ * `@openapi` annotation for the generator to pick up).
+ *
+ * `get_tool_manifest`'s registration wiring below merges this single entry back in
+ * (Fix round 2, Finding 4) — without it, `META_TOOL_NAMES` alone would still leave the
+ * manifest one tool short of the true registered count: 291 `TOOL_ENDPOINT_MAP` entries
+ * + 6 meta tools = 297, not the actual 298 `registerAllTools()` exposes.
+ * `get_prometheus_metrics` is NOT a meta/self-help tool (it is a real, single-endpoint
+ * Dockhand-backed tool, same as every `TOOL_ENDPOINT_MAP` entry), so it gets its real
+ * `method`/`path` here rather than `META_TOOL_NAMES`' `null`/`null` treatment.
+ */
+const GET_PROMETHEUS_METRICS_ENDPOINT: ToolEndpointEntry = { method: 'GET', path: '/api/metrics' };
+
+/**
  * Pure builder behind the `get_tool_manifest` tool. Maps the tool→endpoint map
  * (`src/openapi/tool-endpoint-map.ts`) plus the pinned Dockhand OpenAPI identity
  * (commit + `info.version`, see `src/openapi/pinned.ts` / `src/openapi/spec-loader.ts`)
  * into a single manifest, so a client can detect drift between what this server
  * exposes and the Dockhand version it targets. Kept dependency-injected — no direct
  * import of the real endpoint map or spec — so it is testable without touching the
- * filesystem. The registered tool wires the real `TOOL_ENDPOINT_MAP` and the pinned
- * identity in.
+ * filesystem. The registered tool wires the real `TOOL_ENDPOINT_MAP`, `META_TOOL_NAMES`,
+ * and the pinned identity in.
+ *
+ * Fix round 2, Finding 4 (P2): previously this manifest was built SOLELY from
+ * `endpointMap`, so `get_tool_manifest` reported `toolCount: 292` while
+ * `registerAllTools()` actually exposes 298 tools — the six self-help/meta tools
+ * (including `get_tool_manifest` itself) were missing, contradicting the tool's own
+ * description ("the tools this build exposes"). `deps.metaToolNames` is now a required,
+ * separate list (the real wiring passes `META_TOOL_NAMES` above) whose entries are
+ * appended to the manifest with `method: null, path: null` — accurately reflecting that
+ * these six tools are not backed by a single Dockhand endpoint the way every
+ * `endpointMap` entry is.
  */
 export interface ToolManifestEntry {
   name: string;
-  method: string;
-  path: string;
+  method: string | null;
+  path: string | null;
 }
 
 export interface ToolManifest {
@@ -148,15 +195,22 @@ export interface ToolManifest {
 
 export function buildToolManifest(deps: {
   endpointMap: Readonly<Record<string, ToolEndpointEntry>>;
+  metaToolNames: readonly string[];
   openApiCommit: string;
   openApiVersion: string;
   generatedAt: string;
 }): ToolManifest {
-  const tools = Object.entries(deps.endpointMap).map(([name, entry]) => ({
+  const endpointTools: ToolManifestEntry[] = Object.entries(deps.endpointMap).map(([name, entry]) => ({
     name,
     method: entry.method,
     path: entry.path,
   }));
+  const metaTools: ToolManifestEntry[] = deps.metaToolNames.map((name) => ({
+    name,
+    method: null,
+    path: null,
+  }));
+  const tools = [...endpointTools, ...metaTools];
   return {
     toolCount: tools.length,
     tools,
@@ -602,11 +656,15 @@ export async function probeRawHealth(baseUrl: string): Promise<void> {
  *     tool. `mcpProtocolVersion` is the SDK's own `LATEST_PROTOCOL_VERSION` constant.
  *   - `check_for_update`: compares this server's own build-injected version
  *     (`getServerVersion()`, src/version.js) against the latest GitHub release.
- *   - `get_tool_manifest`: the real generated `TOOL_ENDPOINT_MAP`, the pinned Dockhand
+ *   - `get_tool_manifest`: the real generated `TOOL_ENDPOINT_MAP` plus
+ *     `GET_PROMETHEUS_METRICS_ENDPOINT` above merged in, `META_TOOL_NAMES` above
+ *     (**Fix round 2, Finding 4**: without these two additions, the manifest omitted
+ *     all six self-help/meta tools — including `get_tool_manifest` itself — AND
+ *     `get_prometheus_metrics`, from its own `toolCount`/`tools`), the pinned Dockhand
  *     OpenAPI source commit (`PINNED_DOCKHAND_OPENAPI_COMMIT`, src/openapi/pinned.ts),
  *     and that same pinned spec's own `info.version` (`specInfoVersion()`,
- *     src/openapi/spec-loader.ts) — so a client can tell which Dockhand API version this
- *     server's tools were generated against.
+ *     src/openapi/spec-loader.ts) — so a client can tell which Dockhand API version
+ *     this server's tools were generated against.
  *
  * M2 (diagnostics, all three also take no input arguments):
  *   - `self_check`: wires `runSelfCheck()`'s three probes to real calls —
@@ -686,7 +744,11 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
     {},
     async () => {
       const manifest = buildToolManifest({
-        endpointMap: TOOL_ENDPOINT_MAP,
+        endpointMap: {
+          ...TOOL_ENDPOINT_MAP,
+          get_prometheus_metrics: GET_PROMETHEUS_METRICS_ENDPOINT,
+        },
+        metaToolNames: META_TOOL_NAMES,
         openApiCommit: PINNED_DOCKHAND_OPENAPI_COMMIT,
         openApiVersion: specInfoVersion() ?? 'unknown',
         generatedAt: new Date().toISOString(),

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -11,6 +11,7 @@ import { registerTool, jsonResponse } from '../utils/tool-helper.js';
 import { TOOL_ENDPOINT_MAP, type ToolEndpointEntry } from '../openapi/tool-endpoint-map.js';
 import { PINNED_DOCKHAND_OPENAPI_COMMIT } from '../openapi/pinned.js';
 import { specInfoVersion } from '../openapi/spec-loader.js';
+import { getStatsSnapshot } from '../utils/runtime-stats.js';
 
 export interface ServerInfo {
   version: string;
@@ -327,8 +328,78 @@ export async function validateConfig(deps: {
 }
 
 /**
- * Registers the three M1 self-help tools, wiring the pure builders above to their real
- * dependencies:
+ * A single environment as returned by `GET /api/environments` — only the fields this
+ * module actually reads (see `listEnvironments` wiring below). Not exported: a
+ * registration-time implementation detail, not part of this module's public contract.
+ */
+interface EnvironmentListEntry {
+  id: number;
+  name: string;
+  connectionType?: string;
+}
+
+/**
+ * A single currently-connected Hawser agent, as returned by `GET /api/hawser/connect`
+ * (`src/tools/meta.ts` is the only caller in this repo — no existing tool wraps this
+ * endpoint, see `list_hawser_tokens`/`create_hawser_token`/`revoke_hawser_token` in
+ * `src/tools/hawser.ts` for the token-management side of the same feature). Only
+ * `environmentId` is read; the rest of the documented shape (`agentId`, `hostname`,
+ * `connectedAt`, ...) is irrelevant to a boolean "is this environment's agent up"
+ * outcome check.
+ */
+interface HawserConnection {
+  environmentId: number;
+}
+
+/**
+ * A dedicated, minimal raw login attempt against Dockhand's own `/api/auth/login` —
+ * the shared wiring behind both `self_check`'s `authValid` and `validate_config`'s
+ * `credentialsValid`.
+ *
+ * Deliberately NOT `SessionManager.login()` (src/auth/session.ts): that method
+ * `console.error`s the configured username on failure and throws rather than
+ * resolving to a status code — useful for its own job (diagnosable auto-relogin
+ * failures in `docker logs`, Issue #116), wrong for this one. Two self-help tools
+ * need the plain HTTP status (200 valid / 401 invalid) as a value, not a side effect
+ * or an exception, and neither needs the extra log line. This function does neither:
+ * no logging, always resolves to `response.status` — a genuine transport failure
+ * (DNS, connection refused, timeout) is left to the caller's own try/catch, matching
+ * `runSelfCheck()`'s `probeAuth` and `validateConfig()`'s `attemptLogin` contracts
+ * (both already documented above as "throws → treated as invalid/false").
+ *
+ * Also why this can't just be `client.get(...)`: `DockhandClient`'s request methods
+ * auto-relogin on a 401 (see `dockhand-client.ts`'s `request()`), which is exactly the
+ * right behavior for every *other* tool in this server (a stale/expired session
+ * cookie shouldn't surface as a tool failure) but would mask a genuinely bad
+ * credential here — the auto-relogin would itself fail, but silently, several layers
+ * away from this function. An explicit, one-shot login attempt is the only way to
+ * observe the credential's own validity.
+ *
+ * Secret-safe (`secret-safe-config-inspection.md`): reads `DOCKHAND_USERNAME`/
+ * `DOCKHAND_PASSWORD` only to place them in the POST body sent directly to Dockhand's
+ * own login endpoint — the same two values `SessionManager` itself sends on every
+ * real login — and never logs, returns, or otherwise surfaces either value. Only the
+ * numeric status code crosses back out of this function.
+ */
+async function attemptRawLogin(baseUrl: string): Promise<number> {
+  const response = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: process.env['DOCKHAND_USERNAME'],
+      password: process.env['DOCKHAND_PASSWORD'],
+      provider: 'local',
+    }),
+    redirect: 'manual',
+  });
+  return response.status;
+}
+
+/**
+ * Registers all six self-help tools, wiring the pure builders above to their real
+ * dependencies.
+ *
+ * M1 (server identity, all three take no input arguments):
  *   - `get_server_info`: `dockhandUrl` from `client.getBaseUrl()` — the client's own
  *     normalized base URL (trailing slash(es) stripped, see Issue #116 /
  *     src/utils/url.ts's `normalizeBaseUrl()`), not the raw `DOCKHAND_URL` env var
@@ -349,7 +420,43 @@ export async function validateConfig(deps: {
  *     src/openapi/spec-loader.ts) — so a client can tell which Dockhand API version this
  *     server's tools were generated against.
  *
- * All three take no input arguments.
+ * M2 (diagnostics, all three also take no input arguments):
+ *   - `self_check`: wires `runSelfCheck()`'s three probes to real calls —
+ *       - `probeHealth`: `client.get('/api/health')` (`security: []`, always 200 when the
+ *         process is up per the spec's own summary). A throw here (network error, or the
+ *         client's non-2xx-throws convention) means Dockhand is unreachable; `runSelfCheck`
+ *         short-circuits to `overall: "down"` without calling the other two probes.
+ *       - `probeAuth`: `attemptRawLogin()` above, `status === 200`.
+ *       - `listEnvironments`: `GET /api/environments` gives each environment's `id`, `name`,
+ *         and `connectionType` (`"socket"` or `"hawser-edge"` — the list endpoint documents
+ *         no separate liveness/connection field, see `docs/dockhand-openapi.json`); `GET
+ *         /api/hawser/connect` (used nowhere else in this server — see
+ *         `HawserConnection` above) gives the ground truth of which environments' agents
+ *         are *currently* connected, by `environmentId`, matching that endpoint's own
+ *         summary ("list currently connected agents") — an OUTCOME check
+ *         (`service-verifikation.md`), not a static config field. From these two calls:
+ *         `hawserConnected` is true only for a `"hawser-edge"` environment whose id appears
+ *         in the connected set; `reachable` is that same `hawserConnected` value for
+ *         `"hawser-edge"` environments (an edge environment's reachability *is* whether its
+ *         agent is connected — there is no other transport), and `true` for `"socket"`/other
+ *         directly-configured environments (Dockhand talks to those without a Hawser agent
+ *         in between, so their presence in the list already implies they are configured and
+ *         addressable; a deeper per-environment Docker-level probe would mean issuing one
+ *         `POST /api/environments/{id}/test` per environment on every `self_check` call,
+ *         which this diagnostic deliberately keeps out of its cheap, fixed-cost O(2) call
+ *         budget). If the Hawser status call itself fails, every `"hawser-edge"` environment
+ *         degrades to `reachable: false, hawserConnected: false` rather than throwing out of
+ *         `listEnvironments` — consistent with `runSelfCheck()`'s own "never let a diagnostic
+ *         become the outage" posture documented above it.
+ *   - `validate_config`: `validateConfig()`'s `attemptLogin` is `attemptRawLogin()` above
+ *     against `client.getBaseUrl()` — the same helper `self_check` uses, so the two tools
+ *     agree on what "the configured credentials are valid" means. `requiredEnvPresent` reads
+ *     `process.env` directly inside `validateConfig()` itself (see its own doc comment); this
+ *     registration only supplies the login probe.
+ *   - `get_runtime_stats`: `getStatsSnapshot()` (`src/utils/runtime-stats.js`) — no
+ *     dependencies to wire, the counters live at module scope and are updated by
+ *     `registerTool()` itself on every call (`recordCall`/`recordError`, see
+ *     `src/utils/tool-helper.ts`), including calls to the five other meta tools.
  */
 export function registerMetaTools(server: McpServer, client: DockhandClient): void {
   registerTool(server, 'get_server_info',
@@ -386,6 +493,61 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
         generatedAt: new Date().toISOString(),
       });
       return jsonResponse(manifest);
+    }
+  );
+
+  registerTool(server, 'self_check',
+    {},
+    async () => {
+      const result = await runSelfCheck({
+        probeHealth: async () => {
+          await client.get('/api/health');
+        },
+        probeAuth: async () => (await attemptRawLogin(client.getBaseUrl())) === 200,
+        listEnvironments: async () => {
+          const envs = await client.get<EnvironmentListEntry[]>('/api/environments');
+
+          let connectedIds = new Set<number>();
+          try {
+            const hawser = await client.get<{ connections?: HawserConnection[] }>('/api/hawser/connect');
+            connectedIds = new Set((hawser.connections ?? []).map((c) => c.environmentId));
+          } catch {
+            // Best-effort: an unreachable Hawser status endpoint degrades every
+            // hawser-edge environment below to not-connected/not-reachable rather
+            // than failing listEnvironments() outright — see the doc comment above
+            // registerMetaTools() for the full rationale.
+          }
+
+          return envs.map((env) => {
+            const isHawserEdge = env.connectionType === 'hawser-edge';
+            const hawserConnected = isHawserEdge && connectedIds.has(env.id);
+            return {
+              id: env.id,
+              name: env.name,
+              reachable: isHawserEdge ? hawserConnected : true,
+              hawserConnected,
+            };
+          });
+        },
+      });
+      return jsonResponse(result);
+    }
+  );
+
+  registerTool(server, 'validate_config',
+    {},
+    async () => {
+      const result = await validateConfig({
+        attemptLogin: () => attemptRawLogin(client.getBaseUrl()),
+      });
+      return jsonResponse(result);
+    }
+  );
+
+  registerTool(server, 'get_runtime_stats',
+    {},
+    async () => {
+      return jsonResponse(getStatsSnapshot());
     }
   );
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -167,9 +167,13 @@ export function buildToolManifest(deps: {
 /**
  * Registers the three M1 self-help tools, wiring the pure builders above to their real
  * dependencies:
- *   - `get_server_info`: `dockhandUrl` from the same `DOCKHAND_URL` env var the server
- *     itself requires at startup (src/index.ts) — a URL, never a secret. The Dockhand
- *     server version is read from `GET /api/changelog` (`src/tools/system.ts`'s
+ *   - `get_server_info`: `dockhandUrl` from `client.getBaseUrl()` — the client's own
+ *     normalized base URL (trailing slash(es) stripped, see Issue #116 /
+ *     src/utils/url.ts's `normalizeBaseUrl()`), not the raw `DOCKHAND_URL` env var
+ *     directly: those two can diverge (e.g. `DOCKHAND_URL=https://x/` normalizes to
+ *     `https://x`), and this is a diagnostic tool whose job is to report what the client
+ *     actually does, not what was typed into the config. A URL, never a secret. The
+ *     Dockhand server version is read from `GET /api/changelog` (`src/tools/system.ts`'s
  *     `get_changelog` tool hits the same endpoint): the changelog is generated newest-first,
  *     so its first entry's `version` is the running server's version. That call is
  *     best-effort — `buildServerInfo()` already degrades any throw (network error, empty
@@ -190,7 +194,7 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
     {},
     async () => {
       const info = await buildServerInfo({
-        dockhandUrl: process.env['DOCKHAND_URL'] ?? 'unknown',
+        dockhandUrl: client.getBaseUrl(),
         mcpProtocolVersion: LATEST_PROTOCOL_VERSION,
         getDockhandServerVersion: async () => {
           const changelog = await client.get<{ version: string }[]>('/api/changelog');

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -485,6 +485,44 @@ async function attemptRawLogin(baseUrl: string): Promise<number> {
   return response.status;
 }
 
+/** Timeout for the unauthenticated `/api/health` liveness probe below (Fix round 2,
+ * Finding 2 / P2 security-adjacent). Same bound as `ENVIRONMENT_TEST_TIMEOUT_MS` — the
+ * top-level liveness probe has no reason to be allowed to wait longer than a single
+ * environment's own `/test` probe before `self_check` gives up on it. */
+const HEALTH_CHECK_TIMEOUT_MS = 5_000;
+
+/**
+ * A dedicated, minimal, UNAUTHENTICATED liveness probe against Dockhand's own
+ * `/api/health` — the real wiring behind `self_check`'s `probeHealth`.
+ *
+ * Fix round 2, Finding 2 (P2): previously wired directly as `client.get('/api/health')`
+ * in `registerMetaTools()` below. `client.get()` runs every request through
+ * `SessionManager`, which attempts a login first if it has no cached session cookie —
+ * so with an invalid/misconfigured credential, the *login* failed before `/api/health`
+ * was ever reached, `probeHealth` threw, and `self_check` reported
+ * `dockhandReachable: false, overall: "down"`. That is indistinguishable from Dockhand
+ * itself being down, even though Dockhand was up the whole time — only the credentials
+ * were bad. `GET /api/health` is documented `security: []` in the Dockhand OpenAPI spec
+ * (public, no auth required by design), so probing it with a bare `fetch()` instead
+ * fixes the conflation: a bad-credential deployment now reports
+ * `dockhandReachable: true` (this probe succeeds on its own) alongside
+ * `authValid: false` (the separate `attemptRawLogin()`-backed probe fails) →
+ * `runSelfCheck()` resolves `overall: "degraded"`, not `"down"` — an accurate signal
+ * that Dockhand is up but the configured credentials are not.
+ *
+ * Bounded by `withTimeout()`/`HEALTH_CHECK_TIMEOUT_MS` (mirrors the per-environment
+ * `/test` probes' own timeout below) so an unresponsive Dockhand cannot make
+ * `self_check` itself hang. Throws on any failure — network error, non-2xx status, or
+ * timeout — matching `runSelfCheck()`'s `probeHealth` contract, where any throw means
+ * `dockhandReachable: false`.
+ */
+export async function probeRawHealth(baseUrl: string): Promise<void> {
+  const response = await withTimeout(fetch(`${baseUrl}/api/health`), HEALTH_CHECK_TIMEOUT_MS);
+  if (!response.ok) {
+    throw new Error(`Dockhand health check failed: GET ${baseUrl}/api/health returned ${response.status}`);
+  }
+}
+
 /**
  * Registers all six self-help tools, wiring the pure builders above to their real
  * dependencies.
@@ -512,10 +550,15 @@ async function attemptRawLogin(baseUrl: string): Promise<number> {
  *
  * M2 (diagnostics, all three also take no input arguments):
  *   - `self_check`: wires `runSelfCheck()`'s three probes to real calls —
- *       - `probeHealth`: `client.get('/api/health')` (`security: []`, always 200 when the
- *         process is up per the spec's own summary). A throw here (network error, or the
- *         client's non-2xx-throws convention) means Dockhand is unreachable; `runSelfCheck`
- *         short-circuits to `overall: "down"` without calling the other two probes.
+ *       - `probeHealth`: `probeRawHealth()` above — a bare, UNAUTHENTICATED `fetch()`
+ *         against `/api/health` (`security: []`, always 200 when the process is up per
+ *         the spec's own summary), deliberately NOT `client.get()` (**Fix round 2,
+ *         Finding 2**: `client.get()` would attempt a login first, so an invalid
+ *         credential made this probe indistinguishable from Dockhand being down — see
+ *         `probeRawHealth()`'s own doc comment for the full rationale). A throw here
+ *         (network error, non-2xx status, or timeout) means Dockhand is unreachable;
+ *         `runSelfCheck` short-circuits to `overall: "down"` without calling the other
+ *         two probes.
  *       - `probeAuth`: `attemptRawLogin()` above, `status === 200`.
  *       - `listEnvironments`: three calls, then `deriveEnvironmentStatuses()` above turns
  *         their results into `SelfCheckEnvironment[]` — see that function's own doc comment
@@ -592,9 +635,7 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
     {},
     async () => {
       const result = await runSelfCheck({
-        probeHealth: async () => {
-          await client.get('/api/health');
-        },
+        probeHealth: () => probeRawHealth(client.getBaseUrl()),
         probeAuth: async () => (await attemptRawLogin(client.getBaseUrl())) === 200,
         listEnvironments: async () => {
           const envs = await client.get<EnvironmentListEntry[]>('/api/environments');

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -165,6 +165,101 @@ export function buildToolManifest(deps: {
 }
 
 /**
+ * A single environment's outcome inside a `runSelfCheck()` result — Dockhand's own
+ * identity (`id`, `name`) plus two OUTCOME booleans (reachable, Hawser-connected).
+ * Never a token or credential value (`.claude/rules/service-verifikation.md` /
+ * `secret-safe-config-inspection.md`): whether the agent is connected is itself the
+ * signal, not what it is connected with.
+ */
+export interface SelfCheckEnvironment {
+  id: number;
+  name: string;
+  reachable: boolean;
+  hawserConnected: boolean;
+}
+
+export interface SelfCheck {
+  dockhandReachable: boolean;
+  authValid: boolean;
+  latencyMs: number;
+  environments: SelfCheckEnvironment[];
+  overall: 'ok' | 'degraded' | 'down';
+}
+
+/**
+ * Pure, injectable builder behind the future `self_check` tool — an end-to-end
+ * diagnostic that answers "is this server actually usable right now?" in one call.
+ * Takes three probes so it is fully testable without a live Dockhand:
+ *   - `probeHealth`: resolves when Dockhand answers at all; rejects/throws on network
+ *     failure or timeout. This alone decides `dockhandReachable`.
+ *   - `probeAuth`: resolves `true`/`false` for a valid/invalid credential (the real
+ *     wiring in the registration task makes one authed call and turns its status code —
+ *     200 vs 401/403 — into this boolean; a genuine transport error while doing so is
+ *     caught here and also treated as `false`). Per `service-verifikation.md`, this is
+ *     an OUTCOME check (does the call succeed?) — the credential's value is never read
+ *     or compared.
+ *   - `listEnvironments`: lists each configured environment with its own reachability
+ *     and Hawser-agent-connected outcome.
+ *
+ * If `probeHealth` fails, the function short-circuits: Dockhand being unreachable makes
+ * any auth/environments probe meaningless (and likely to fail the same way), so neither
+ * is called and the result is `overall: "down"` with an empty `environments` list.
+ * Otherwise `overall` is `"ok"` only when auth is valid AND every environment reports
+ * reachable; any other combination (invalid auth, an unreachable environment, or the
+ * environments probe itself throwing) degrades to `"degraded"` rather than throwing —
+ * a diagnostic tool must never itself become the outage.
+ *
+ * `latencyMs` is measured with `Date.now()` (or the injected `now` for deterministic
+ * tests) around the whole probe sequence, so it reflects what a caller actually waited.
+ */
+export async function runSelfCheck(deps: {
+  probeHealth: () => Promise<void>;
+  probeAuth: () => Promise<boolean>;
+  listEnvironments: () => Promise<SelfCheckEnvironment[]>;
+  now?: () => number;
+}): Promise<SelfCheck> {
+  const now = deps.now ?? Date.now;
+  const start = now();
+
+  try {
+    await deps.probeHealth();
+  } catch {
+    return {
+      dockhandReachable: false,
+      authValid: false,
+      latencyMs: now() - start,
+      environments: [],
+      overall: 'down',
+    };
+  }
+
+  let authValid: boolean;
+  try {
+    authValid = await deps.probeAuth();
+  } catch {
+    authValid = false;
+  }
+
+  let environments: SelfCheckEnvironment[];
+  let environmentsOk: boolean;
+  try {
+    environments = await deps.listEnvironments();
+    environmentsOk = environments.every((env) => env.reachable);
+  } catch {
+    environments = [];
+    environmentsOk = false;
+  }
+
+  return {
+    dockhandReachable: true,
+    authValid,
+    latencyMs: now() - start,
+    environments,
+    overall: authValid && environmentsOk ? 'ok' : 'degraded',
+  };
+}
+
+/**
  * Registers the three M1 self-help tools, wiring the pure builders above to their real
  * dependencies:
  *   - `get_server_info`: `dockhandUrl` from `client.getBaseUrl()` — the client's own

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -12,6 +12,7 @@ import { TOOL_ENDPOINT_MAP, type ToolEndpointEntry } from '../openapi/tool-endpo
 import { PINNED_DOCKHAND_OPENAPI_COMMIT } from '../openapi/pinned.js';
 import { specInfoVersion } from '../openapi/spec-loader.js';
 import { getStatsSnapshot } from '../utils/runtime-stats.js';
+import { encodePath } from '../utils/encode-path.js';
 
 export interface ServerInfo {
   version: string;
@@ -329,10 +330,11 @@ export async function validateConfig(deps: {
 
 /**
  * A single environment as returned by `GET /api/environments` — only the fields this
- * module actually reads (see `listEnvironments` wiring below). Not exported: a
- * registration-time implementation detail, not part of this module's public contract.
+ * module actually reads (see `listEnvironments` wiring below). Exported so
+ * `deriveEnvironmentStatuses()` below has a named parameter type its own tests can
+ * construct against.
  */
-interface EnvironmentListEntry {
+export interface EnvironmentListEntry {
   id: number;
   name: string;
   connectionType?: string;
@@ -349,6 +351,85 @@ interface EnvironmentListEntry {
  */
 interface HawserConnection {
   environmentId: number;
+}
+
+/**
+ * Pure, exported builder behind `self_check`'s per-environment status derivation
+ * (Fix round 1, Finding 2: this logic previously lived untested inline inside the
+ * `registerTool('self_check', ...)` closure — every other piece of this module is a
+ * pure, injectable, separately-tested builder, and this one now is too).
+ *
+ * Takes already-resolved, already-degraded inputs so it never itself does I/O or
+ * throws:
+ *   - `environments`: the raw `GET /api/environments` list (`id`, `name`,
+ *     `connectionType`).
+ *   - `connectedAgentIds`: the set of environment ids with a currently-connected
+ *     Hawser agent, per `GET /api/hawser/connect` (empty set if that call failed —
+ *     see the registration wiring below for how that degrade happens).
+ *   - `perEnvReachable`: a **live, per-environment** reachability result — Fix round 1,
+ *     Finding 1: `reachable` must be a real outcome check for every environment
+ *     (`POST /api/environments/{id}/test`'s `success` field), not a hardcoded
+ *     assumption for any connection type. Missing an entry for a given id (e.g. its
+ *     `/test` probe threw or timed out) degrades to `reachable: false` via the `??
+ *     false` fallback — this function never throws on an incomplete map.
+ *
+ * `hawserConnected` is true only for a `"hawser-edge"` environment whose id is in
+ * `connectedAgentIds` — non-edge (`"socket"`, etc.) environments are trivially
+ * `false`, since they have no Hawser agent to be connected. `reachable` is always
+ * `perEnvReachable`'s live result, uniformly across connection types — the whole
+ * point of Finding 1's fix is that this is no longer type-dependent.
+ */
+export function deriveEnvironmentStatuses(
+  environments: readonly EnvironmentListEntry[],
+  connectedAgentIds: ReadonlySet<number>,
+  perEnvReachable: ReadonlyMap<number, boolean>,
+): SelfCheckEnvironment[] {
+  return environments.map((env) => ({
+    id: env.id,
+    name: env.name,
+    reachable: perEnvReachable.get(env.id) ?? false,
+    hawserConnected: env.connectionType === 'hawser-edge' && connectedAgentIds.has(env.id),
+  }));
+}
+
+/** Per-environment `POST /api/environments/{id}/test` timeout (Fix round 1, Finding 1):
+ * keeps `self_check` responsive even when one environment's agent/socket hangs instead
+ * of answering. All environments are probed in parallel (`Promise.allSettled`, see the
+ * `self_check` wiring below), so this bounds the *slowest* environment's contribution
+ * to `self_check`'s total latency, not the sum across environments. */
+const ENVIRONMENT_TEST_TIMEOUT_MS = 5_000;
+
+/**
+ * Races `promise` against a timeout, rejecting with a plain `Error` if `promise` has
+ * not settled within `timeoutMs`. Generic, not Dockhand-specific — used only to bound
+ * the per-environment `POST /api/environments/{id}/test` calls in `self_check`'s
+ * `listEnvironments` wiring below.
+ *
+ * Note: this only makes the *caller* stop waiting — it does not abort the underlying
+ * `fetch()` inside `promise` (`DockhandClient`'s request methods take no
+ * `AbortSignal`). A timed-out environment probe may still complete in the background;
+ * its result is simply discarded once `withTimeout` has already rejected. That is a
+ * deliberate, acceptable trade-off for a lightweight diagnostic tool — `self_check`'s
+ * job is to stay responsive, not to strictly bound background resource usage.
+ *
+ * Exported (unlike the other registration-time-only helpers in this file, e.g.
+ * `attemptRawLogin`) so it can be unit-tested directly — it is small, generic,
+ * timing-sensitive logic in its own right, not just wiring.
+ */
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
 
 /**
@@ -380,6 +461,15 @@ interface HawserConnection {
  * own login endpoint — the same two values `SessionManager` itself sends on every
  * real login — and never logs, returns, or otherwise surfaces either value. Only the
  * numeric status code crosses back out of this function.
+ *
+ * Known imprecision (pre-existing codebase behavior, not introduced here): a `200`
+ * response can also mean `{ success: true, requiresMfa: true }` — a login that still
+ * needs a second factor, per `/api/auth/login`'s own documented response shape. This
+ * function (and therefore both `self_check`'s `authValid` and `validate_config`'s
+ * `credentialsValid`) does not distinguish that case from a fully completed login;
+ * both read as "valid". Distinguishing them would need parsing the response body,
+ * which `SessionManager.login()` itself does not do either (see `session.ts` —
+ * it treats any `response.ok` as success and extracts only the session cookie).
  */
 async function attemptRawLogin(baseUrl: string): Promise<number> {
   const response = await fetch(`${baseUrl}/api/auth/login`, {
@@ -427,27 +517,29 @@ async function attemptRawLogin(baseUrl: string): Promise<number> {
  *         client's non-2xx-throws convention) means Dockhand is unreachable; `runSelfCheck`
  *         short-circuits to `overall: "down"` without calling the other two probes.
  *       - `probeAuth`: `attemptRawLogin()` above, `status === 200`.
- *       - `listEnvironments`: `GET /api/environments` gives each environment's `id`, `name`,
- *         and `connectionType` (`"socket"` or `"hawser-edge"` — the list endpoint documents
- *         no separate liveness/connection field, see `docs/dockhand-openapi.json`); `GET
- *         /api/hawser/connect` (used nowhere else in this server — see
- *         `HawserConnection` above) gives the ground truth of which environments' agents
- *         are *currently* connected, by `environmentId`, matching that endpoint's own
- *         summary ("list currently connected agents") — an OUTCOME check
- *         (`service-verifikation.md`), not a static config field. From these two calls:
- *         `hawserConnected` is true only for a `"hawser-edge"` environment whose id appears
- *         in the connected set; `reachable` is that same `hawserConnected` value for
- *         `"hawser-edge"` environments (an edge environment's reachability *is* whether its
- *         agent is connected — there is no other transport), and `true` for `"socket"`/other
- *         directly-configured environments (Dockhand talks to those without a Hawser agent
- *         in between, so their presence in the list already implies they are configured and
- *         addressable; a deeper per-environment Docker-level probe would mean issuing one
- *         `POST /api/environments/{id}/test` per environment on every `self_check` call,
- *         which this diagnostic deliberately keeps out of its cheap, fixed-cost O(2) call
- *         budget). If the Hawser status call itself fails, every `"hawser-edge"` environment
- *         degrades to `reachable: false, hawserConnected: false` rather than throwing out of
- *         `listEnvironments` — consistent with `runSelfCheck()`'s own "never let a diagnostic
- *         become the outage" posture documented above it.
+ *       - `listEnvironments`: three calls, then `deriveEnvironmentStatuses()` above turns
+ *         their results into `SelfCheckEnvironment[]` — see that function's own doc comment
+ *         for exactly how `reachable`/`hawserConnected` are derived (**Fix round 1, Finding
+ *         1**: `reachable` is now a genuine live outcome check for every environment, never
+ *         a hardcoded assumption for any connection type):
+ *           1. `GET /api/environments` — each environment's `id`, `name`, `connectionType`
+ *              (`"socket"` or `"hawser-edge"`).
+ *           2. `GET /api/hawser/connect` (used nowhere else in this server — see
+ *              `HawserConnection` above) — the ground truth of which environments' agents
+ *              are *currently* connected, by `environmentId`. Best-effort: on failure,
+ *              `connectedAgentIds` degrades to an empty set (every `"hawser-edge"`
+ *              environment then reads as not-connected) rather than throwing out of
+ *              `listEnvironments`.
+ *           3. `POST /api/environments/{id}/test` for **every** environment, **in
+ *              parallel** (`Promise.allSettled`, not sequential — one hung environment must
+ *              not block the others) and each individually bounded by
+ *              `withTimeout()`/`ENVIRONMENT_TEST_TIMEOUT_MS` above (5s) so a single
+ *              unresponsive environment cannot make `self_check` itself hang. This is the
+ *              same endpoint `POST /api/environments/{id}/test` — its `success` field is
+ *              the real, uniform reachability signal for socket AND edge environments
+ *              alike. A rejected/timed-out probe degrades that one environment to
+ *              `reachable: false` (via the missing `perEnvReachable` entry) rather than
+ *              failing `listEnvironments` for every other environment.
  *   - `validate_config`: `validateConfig()`'s `attemptLogin` is `attemptRawLogin()` above
  *     against `client.getBaseUrl()` — the same helper `self_check` uses, so the two tools
  *     agree on what "the configured credentials are valid" means. `requiredEnvPresent` reads
@@ -507,27 +599,37 @@ export function registerMetaTools(server: McpServer, client: DockhandClient): vo
         listEnvironments: async () => {
           const envs = await client.get<EnvironmentListEntry[]>('/api/environments');
 
-          let connectedIds = new Set<number>();
+          let connectedAgentIds = new Set<number>();
           try {
             const hawser = await client.get<{ connections?: HawserConnection[] }>('/api/hawser/connect');
-            connectedIds = new Set((hawser.connections ?? []).map((c) => c.environmentId));
+            connectedAgentIds = new Set((hawser.connections ?? []).map((c) => c.environmentId));
           } catch {
             // Best-effort: an unreachable Hawser status endpoint degrades every
-            // hawser-edge environment below to not-connected/not-reachable rather
-            // than failing listEnvironments() outright — see the doc comment above
+            // hawser-edge environment to not-connected below rather than failing
+            // listEnvironments() outright — see the doc comment above
             // registerMetaTools() for the full rationale.
           }
 
-          return envs.map((env) => {
-            const isHawserEdge = env.connectionType === 'hawser-edge';
-            const hawserConnected = isHawserEdge && connectedIds.has(env.id);
-            return {
-              id: env.id,
-              name: env.name,
-              reachable: isHawserEdge ? hawserConnected : true,
-              hawserConnected,
-            };
+          // Fix round 1, Finding 1: a genuine, per-environment, in-parallel reachability
+          // check for EVERY environment (not just hawser-edge ones) — no connection type
+          // is ever assumed reachable. Each probe is individually timeout-bounded so one
+          // hung environment cannot make self_check itself hang.
+          const testResults = await Promise.allSettled(
+            envs.map((env) =>
+              withTimeout(
+                client.post<{ success?: boolean }>(`/api/environments/${encodePath(env.id)}/test`),
+                ENVIRONMENT_TEST_TIMEOUT_MS,
+              ),
+            ),
+          );
+
+          const perEnvReachable = new Map<number, boolean>();
+          envs.forEach((env, i) => {
+            const result = testResults[i];
+            perEnvReachable.set(env.id, result.status === 'fulfilled' && !!result.value.success);
           });
+
+          return deriveEnvironmentStatuses(envs, connectedAgentIds, perEnvReachable);
         },
       });
       return jsonResponse(result);

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -66,6 +66,14 @@ const RELEASES_URL = 'https://api.github.com/repos/strausmann/mcp-dockhand/relea
 const UPDATE_TTL_MS = 60 * 60 * 1000;
 let updateCache: { at: number; latest: string; url?: string; publishedAt?: string } | null = null;
 
+/** Deadline for the GitHub-releases fetch inside `checkForUpdate()` below (Fix round 3,
+ * Finding 3 / P2): previously unbounded — if `api.github.com` accepted the connection
+ * but then stalled (no response, no error), `checkForUpdate` hung indefinitely instead
+ * of degrading like every other failure mode it already handles (network error,
+ * non-2xx status, malformed body). Overridable per call so tests can exercise a
+ * never-resolving `fetchImpl` without waiting out the real default. */
+const UPDATE_CHECK_TIMEOUT_MS = 5_000;
+
 /** Test hook: clears the in-memory update cache between test cases. */
 export function __resetUpdateCache() {
   updateCache = null;
@@ -94,12 +102,33 @@ export async function checkForUpdate(deps: {
   current: string;
   fetchImpl?: typeof fetch;
   now?: () => number;
+  /** Deadline for the GitHub-releases fetch. Defaults to `UPDATE_CHECK_TIMEOUT_MS`. */
+  timeoutMs?: number;
 }): Promise<UpdateInfo> {
   const now = deps.now ?? Date.now;
   const doFetch = deps.fetchImpl ?? fetch;
+  const timeoutMs = deps.timeoutMs ?? UPDATE_CHECK_TIMEOUT_MS;
   try {
     if (!updateCache || now() - updateCache.at > UPDATE_TTL_MS) {
-      const res = await doFetch(RELEASES_URL, { headers: { Accept: 'application/vnd.github+json' } });
+      // AbortController so the underlying request is actually cancelled (not just
+      // abandoned) when the real fetch is used, PLUS withTimeout() (defined further
+      // below — a function declaration, so it is hoisted and callable here) racing the
+      // call directly so the outer await still resolves within timeoutMs even if an
+      // injected test fetchImpl never resolves and never looks at the abort signal.
+      const controller = new AbortController();
+      const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+      let res: Response;
+      try {
+        res = await withTimeout(
+          doFetch(RELEASES_URL, {
+            headers: { Accept: 'application/vnd.github+json' },
+            signal: controller.signal,
+          }),
+          timeoutMs,
+        );
+      } finally {
+        clearTimeout(abortTimer);
+      }
       if (!res.ok) throw new Error(`GitHub API ${res.status}`);
       const json = (await res.json()) as { tag_name: string; html_url?: string; published_at?: string };
       updateCache = {

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -260,6 +260,73 @@ export async function runSelfCheck(deps: {
 }
 
 /**
+ * Required environment variables this server needs to talk to Dockhand.
+ * Presence-only — the values themselves are never read into any output.
+ */
+const REQUIRED_ENV_KEYS = ['DOCKHAND_URL', 'DOCKHAND_USERNAME', 'DOCKHAND_PASSWORD'] as const;
+
+export interface ConfigValidation {
+  requiredEnvPresent: {
+    DOCKHAND_URL: boolean;
+    DOCKHAND_USERNAME: boolean;
+    DOCKHAND_PASSWORD: boolean;
+  };
+  credentialsValid: boolean;
+  statusCode: number | null;
+}
+
+/**
+ * Pure, injectable builder behind the future `validate_config` tool — answers
+ * "is this server's configuration usable?" without ever reading a secret value.
+ *
+ * Env-var checks are Boolean-only (`!!process.env.X`): presence, never content. If any
+ * required var is missing, the login probe is skipped entirely (`credentialsValid: false`,
+ * `statusCode: null`) — there is nothing meaningful to attempt without a URL, username, and
+ * password all present, and calling out anyway would risk a confusing error unrelated to the
+ * real problem (a missing var).
+ *
+ * `attemptLogin` is injected (returns an HTTP status code) so this is testable without a
+ * live Dockhand instance and without ever touching the credential's value in a test —
+ * only the resulting status code crosses the boundary. `credentialsValid` is exactly
+ * `statusCode === 200`; any other status (401, 403, ...) or a thrown error (network
+ * failure, timeout) degrades to `credentialsValid: false` — a probe that throws never
+ * propagates out of `validateConfig`, matching the self-help-tools-never-break posture
+ * of `buildServerInfo()` / `runSelfCheck()` above. On a thrown probe, `statusCode` stays
+ * `null` (there was no response to report a code from).
+ *
+ * Per `secret-safe-config-inspection.md` / `service-verifikation.md`: this function reads
+ * env values only to compute a boolean and to pass them (via the injected `attemptLogin`)
+ * to a live auth check — it never places a value itself into the returned object.
+ */
+export async function validateConfig(deps: {
+  attemptLogin: () => Promise<number>;
+}): Promise<ConfigValidation> {
+  const requiredEnvPresent = {
+    DOCKHAND_URL: !!process.env.DOCKHAND_URL,
+    DOCKHAND_USERNAME: !!process.env.DOCKHAND_USERNAME,
+    DOCKHAND_PASSWORD: !!process.env.DOCKHAND_PASSWORD,
+  };
+
+  const allPresent = REQUIRED_ENV_KEYS.every((key) => requiredEnvPresent[key]);
+  if (!allPresent) {
+    return { requiredEnvPresent, credentialsValid: false, statusCode: null };
+  }
+
+  let statusCode: number | null;
+  try {
+    statusCode = await deps.attemptLogin();
+  } catch {
+    statusCode = null;
+  }
+
+  return {
+    requiredEnvPresent,
+    credentialsValid: statusCode === 200,
+    statusCode,
+  };
+}
+
+/**
  * Registers the three M1 self-help tools, wiring the pure builders above to their real
  * dependencies:
  *   - `get_server_info`: `dockhandUrl` from `client.getBaseUrl()` — the client's own

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -242,6 +242,16 @@ export interface SelfCheck {
   overall: 'ok' | 'degraded' | 'down';
 }
 
+/** Default per-phase deadline for each of `runSelfCheck()`'s three probes (health,
+ * auth, environments) — see that function's own doc comment (Fix round 3, Finding 2)
+ * for why every phase needs one, not just the health probe and the per-environment
+ * `/test` calls. Deliberately more generous than `HEALTH_CHECK_TIMEOUT_MS` /
+ * `ENVIRONMENT_TEST_TIMEOUT_MS` below (which bound single underlying calls each): this
+ * is the OUTER backstop for a whole phase, including `listEnvironments`'s own two
+ * calls that carry no timeout of their own (`GET /api/environments`,
+ * `GET /api/hawser/connect`) ahead of its already-bounded per-environment fan-out. */
+const SELF_CHECK_PHASE_TIMEOUT_MS = 10_000;
+
 /**
  * Pure, injectable builder behind the future `self_check` tool — an end-to-end
  * diagnostic that answers "is this server actually usable right now?" in one call.
@@ -267,18 +277,38 @@ export interface SelfCheck {
  *
  * `latencyMs` is measured with `Date.now()` (or the injected `now` for deterministic
  * tests) around the whole probe sequence, so it reflects what a caller actually waited.
+ *
+ * Fix round 3, Finding 2 (P2): every phase below (`probeHealth`, `probeAuth`,
+ * `listEnvironments`) is now individually raced against `phaseTimeoutMs` via
+ * `withTimeout()` (defined further below in this file — a `function` declaration, so
+ * it is hoisted and callable here). Previously ONLY the health probe's own internal
+ * `fetch()` (`probeRawHealth()`) and the per-environment `POST .../test` calls inside
+ * `listEnvironments` carried a timeout of their own; `probeAuth`'s real wiring
+ * (`attemptRawLogin()`) has no timeout at all, and `listEnvironments`'s own two
+ * un-bounded calls (`GET /api/environments`, `GET /api/hawser/connect`) sit BEFORE its
+ * already-bounded per-environment fan-out. A stall in any of those un-bounded calls
+ * left `self_check` hanging indefinitely rather than degrading. Bounding every phase
+ * here, at the single point where all three are awaited, closes that gap regardless of
+ * which underlying call inside a phase is the one that stalls — the existing
+ * try/catch blocks below already turn a timeout (like any other rejection) into the
+ * same degraded/down outcome as a genuine failure, so no other branching changes.
  */
 export async function runSelfCheck(deps: {
   probeHealth: () => Promise<void>;
   probeAuth: () => Promise<boolean>;
   listEnvironments: () => Promise<SelfCheckEnvironment[]>;
   now?: () => number;
+  /** Per-phase deadline passed to `withTimeout()` for each of the three probes below.
+   * Defaults to `SELF_CHECK_PHASE_TIMEOUT_MS`; overridable so tests can exercise a
+   * never-resolving probe without waiting out the real default. */
+  phaseTimeoutMs?: number;
 }): Promise<SelfCheck> {
   const now = deps.now ?? Date.now;
+  const phaseTimeoutMs = deps.phaseTimeoutMs ?? SELF_CHECK_PHASE_TIMEOUT_MS;
   const start = now();
 
   try {
-    await deps.probeHealth();
+    await withTimeout(deps.probeHealth(), phaseTimeoutMs);
   } catch {
     return {
       dockhandReachable: false,
@@ -291,7 +321,7 @@ export async function runSelfCheck(deps: {
 
   let authValid: boolean;
   try {
-    authValid = await deps.probeAuth();
+    authValid = await withTimeout(deps.probeAuth(), phaseTimeoutMs);
   } catch {
     authValid = false;
   }
@@ -299,7 +329,7 @@ export async function runSelfCheck(deps: {
   let environments: SelfCheckEnvironment[];
   let environmentsOk: boolean;
   try {
-    environments = await deps.listEnvironments();
+    environments = await withTimeout(deps.listEnvironments(), phaseTimeoutMs);
     environmentsOk = environments.every((env) => env.reachable);
   } catch {
     environments = [];

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared secret-redaction helpers.
+ *
+ * Split out (Fix round 3, Item B / P1-adjacent follow-up to the runtime-stats
+ * query-string redaction) because the un-redacted `Dockhand API error: ${method} ${url}
+ * returned …` message built by `DockhandClient` (src/client/dockhand-client.ts) reaches
+ * THREE separate surfaces, not just the `get_runtime_stats` sink:
+ *   1. `console.error(...)` in `registerTool()` (src/utils/tool-helper.ts) — ships
+ *      straight into `docker logs`.
+ *   2. `errorResponse(message)` (same call site) — returned to the invoking MCP client.
+ *   3. `recordError(tool, message)` (src/utils/runtime-stats.ts) — stored and later
+ *      echoed by `get_runtime_stats` to any client, not necessarily the one that hit the
+ *      original error (the original P1 this was written for).
+ *
+ * Redacting only at the `runtime-stats` sink (surface 3) left surfaces 1 and 2
+ * un-redacted: a URL query-string secret (e.g. `trigger_git_webhook`'s webhook `secret`
+ * becoming `?secret=<value>` in the request URL) would still ship into container logs
+ * on every failed call, regardless of whether anyone ever called `get_runtime_stats`.
+ *
+ * Redacting once here, at `DockhandClient`'s own error-message construction (the single
+ * point all three surfaces trace back to), closes all three at once and is future-proof
+ * for any new query-param secret a future tool might introduce. `runtime-stats.ts` keeps
+ * its own call to this same function as defense-in-depth — harmless if the message was
+ * already redacted upstream, and still effective for any error message that does not
+ * originate from `DockhandClient` (e.g. a thrown error from tool-local logic).
+ */
+
+/** Marker `redactQueryStrings` substitutes for a URL's query string. */
+export const QUERY_STRING_REDACTION_MARKER = '<redacted>';
+
+/**
+ * Replaces the query-string portion of any URL embedded in `message` with
+ * `?${QUERY_STRING_REDACTION_MARKER}`.
+ *
+ * Matches a literal `?` followed by a run of non-whitespace characters (the query
+ * string always ends at the next space in a `Dockhand API error: … returned …`-shaped
+ * message, or at the end of the string) and replaces the whole match, so no fragment of
+ * the original query string — key or value — survives in the returned message. A
+ * message with no `?` is returned unchanged.
+ */
+export function redactQueryStrings(message: string): string {
+  return message.replace(/\?\S+/g, `?${QUERY_STRING_REDACTION_MARKER}`);
+}

--- a/src/utils/runtime-stats.ts
+++ b/src/utils/runtime-stats.ts
@@ -28,7 +28,18 @@
  * `DockhandClient.request()`/`requestRaw()`), near the start of the message —
  * outside the reach of the length bound above. `recordError()` therefore
  * redacts the query portion of any URL in the message BEFORE truncating.
+ *
+ * Fix round 3, Item B: the redaction itself now lives in `src/utils/redact.ts` and is
+ * applied FIRST at `DockhandClient`'s own error-message construction — the single point
+ * every surface (stderr/`docker logs`, the MCP caller's error response, AND this
+ * module's `lastError`) traces back to, see that file's own doc comment for the full
+ * rationale. The call to `redactQueryStrings()` below is kept as defense-in-depth: a
+ * harmless no-op re-redaction for `DockhandClient`-sourced messages (already redacted
+ * upstream), and still the only line of defense for any future error message that does
+ * NOT originate from `DockhandClient`.
  */
+
+import { redactQueryStrings } from './redact.js';
 
 export interface LastError {
   tool: string;
@@ -86,28 +97,6 @@ const MAX_ERROR_MESSAGE_LENGTH = 500;
 function truncateMessage(message: string): string {
   if (message.length <= MAX_ERROR_MESSAGE_LENGTH) return message;
   return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`;
-}
-
-/** Marker `redactQueryStrings` substitutes for a URL's query string. */
-const QUERY_STRING_REDACTION_MARKER = '<redacted>';
-
-/**
- * Replaces the query-string portion of any URL embedded in `message` with
- * `QUERY_STRING_REDACTION_MARKER`. A tool call can put a secret in a URL
- * query param (e.g. `trigger_git_webhook`'s webhook `secret`, see the module
- * doc comment above); if that call fails, the secret would otherwise ride
- * along inside `error.message` and — via `recordError`/`getStatsSnapshot` —
- * be exposed to any MCP client that later calls `get_runtime_stats`.
- *
- * Matches a literal `?` followed by a run of non-whitespace characters
- * (the query string always ends at the next space in the surrounding
- * `Dockhand API error: … returned …` message, or at the end of the string)
- * and replaces the whole match, so no fragment of the original query
- * string — key or value — survives in the stored message. A message with
- * no `?` is returned unchanged.
- */
-function redactQueryStrings(message: string): string {
-  return message.replace(/\?\S+/g, `?${QUERY_STRING_REDACTION_MARKER}`);
 }
 
 /**

--- a/src/utils/runtime-stats.ts
+++ b/src/utils/runtime-stats.ts
@@ -4,6 +4,21 @@
  * secret-safe: only counters and the last error's {tool, message, at} are
  * ever stored. Tool call arguments and response payloads are NEVER touched
  * here, so a snapshot can never leak them.
+ *
+ * `lastError.message` is NOT credential-safe by construction, though — it is
+ * whatever `error.message` the failing tool call threw (see `recordError()`'s
+ * only caller, `registerTool()` in tool-helper.ts). For a Dockhand API error,
+ * that message is built by `DockhandClient.request()` as
+ * `Dockhand API error: ${method} ${url} returned ${status}: ${errorBody}` —
+ * i.e. it can embed a slice of the upstream Dockhand HTTP response body and
+ * the request URL (including its query string). It never includes request
+ * bodies or credential values (those are not part of `error.message` for any
+ * throw site in this codebase), but a large or unexpected upstream response
+ * body would otherwise be stored, and then echoed back to whichever MCP
+ * client next calls `get_runtime_stats` — not necessarily the same client
+ * that triggered the original error. `recordError()` bounds the stored
+ * message to `MAX_ERROR_MESSAGE_LENGTH` characters for exactly this reason:
+ * an unbounded upstream body must never be echoed wholesale.
  */
 
 export interface LastError {
@@ -46,13 +61,33 @@ export function recordCall(tool: string): void {
 }
 
 /**
+ * Maximum length, in characters, `recordError` stores for a single error message before
+ * truncating it. See the module doc comment above for why this bound exists: an upstream
+ * Dockhand HTTP error can embed an unbounded slice of the response body inside
+ * `error.message`, and `get_runtime_stats` echoes `lastError` to any caller. 500 characters
+ * comfortably fits the `Dockhand API error: ${method} ${url} returned ${status}: ...`
+ * prefix plus enough of the upstream body to be useful for debugging, without storing (and
+ * later echoing) an arbitrarily large response.
+ */
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+/** Truncates `message` to `MAX_ERROR_MESSAGE_LENGTH` characters, appending an ellipsis
+ * marker when truncation actually happened. Messages at or under the limit pass through
+ * unchanged. */
+function truncateMessage(message: string): string {
+  if (message.length <= MAX_ERROR_MESSAGE_LENGTH) return message;
+  return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`;
+}
+
+/**
  * Records a single tool failure. Stores only the tool name and the error
- * message — never the arguments or any response/result payload.
+ * message (bounded to `MAX_ERROR_MESSAGE_LENGTH`, see above) — never the
+ * arguments or any response/result payload.
  */
 export function recordError(tool: string, message: string): void {
   errorCount += 1;
   getOrCreate(tool).errors += 1;
-  lastError = { tool, message, at: new Date().toISOString() };
+  lastError = { tool, message: truncateMessage(message), at: new Date().toISOString() };
 }
 
 /** Returns a plain-data snapshot of the current counters. */

--- a/src/utils/runtime-stats.ts
+++ b/src/utils/runtime-stats.ts
@@ -1,0 +1,77 @@
+/**
+ * In-process runtime-stats counters for this MCP server itself — feeds the
+ * `get_runtime_stats` self-help tool (see src/tools/meta.ts). Deliberately
+ * secret-safe: only counters and the last error's {tool, message, at} are
+ * ever stored. Tool call arguments and response payloads are NEVER touched
+ * here, so a snapshot can never leak them.
+ */
+
+export interface LastError {
+  tool: string;
+  message: string;
+  at: string;
+}
+
+export interface ToolStats {
+  calls: number;
+  errors: number;
+}
+
+export interface StatsSnapshot {
+  startedAt: string;
+  requestCount: number;
+  errorCount: number;
+  perTool: Record<string, ToolStats>;
+  lastError: LastError | null;
+}
+
+const startedAt = new Date().toISOString();
+let requestCount = 0;
+let errorCount = 0;
+let perTool: Record<string, ToolStats> = {};
+let lastError: LastError | null = null;
+
+function getOrCreate(tool: string): ToolStats {
+  const existing = perTool[tool];
+  if (existing) return existing;
+  const created: ToolStats = { calls: 0, errors: 0 };
+  perTool[tool] = created;
+  return created;
+}
+
+/** Records a single tool invocation. */
+export function recordCall(tool: string): void {
+  requestCount += 1;
+  getOrCreate(tool).calls += 1;
+}
+
+/**
+ * Records a single tool failure. Stores only the tool name and the error
+ * message — never the arguments or any response/result payload.
+ */
+export function recordError(tool: string, message: string): void {
+  errorCount += 1;
+  getOrCreate(tool).errors += 1;
+  lastError = { tool, message, at: new Date().toISOString() };
+}
+
+/** Returns a plain-data snapshot of the current counters. */
+export function getStatsSnapshot(): StatsSnapshot {
+  return {
+    startedAt,
+    requestCount,
+    errorCount,
+    perTool: Object.fromEntries(
+      Object.entries(perTool).map(([name, stats]) => [name, { ...stats }])
+    ),
+    lastError: lastError ? { ...lastError } : null,
+  };
+}
+
+/** Test hook: resets all counters. Mirrors `__resetUpdateCache` in meta.ts. */
+export function __resetStats(): void {
+  requestCount = 0;
+  errorCount = 0;
+  perTool = {};
+  lastError = null;
+}

--- a/src/utils/runtime-stats.ts
+++ b/src/utils/runtime-stats.ts
@@ -19,6 +19,15 @@
  * that triggered the original error. `recordError()` bounds the stored
  * message to `MAX_ERROR_MESSAGE_LENGTH` characters for exactly this reason:
  * an unbounded upstream body must never be echoed wholesale.
+ *
+ * `error.message` can also embed a URL query string, and a query string can
+ * carry a secret — e.g. `trigger_git_webhook` (src/tools/git-stacks.ts) calls
+ * `client.get('/api/git/stacks/{id}/webhook', { secret })`, which puts the
+ * webhook secret in the URL as `?secret=<value>`. On failure that URL lands
+ * verbatim inside `Dockhand API error: ${method} ${url} returned …` (see
+ * `DockhandClient.request()`/`requestRaw()`), near the start of the message —
+ * outside the reach of the length bound above. `recordError()` therefore
+ * redacts the query portion of any URL in the message BEFORE truncating.
  */
 
 export interface LastError {
@@ -79,15 +88,42 @@ function truncateMessage(message: string): string {
   return `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`;
 }
 
+/** Marker `redactQueryStrings` substitutes for a URL's query string. */
+const QUERY_STRING_REDACTION_MARKER = '<redacted>';
+
+/**
+ * Replaces the query-string portion of any URL embedded in `message` with
+ * `QUERY_STRING_REDACTION_MARKER`. A tool call can put a secret in a URL
+ * query param (e.g. `trigger_git_webhook`'s webhook `secret`, see the module
+ * doc comment above); if that call fails, the secret would otherwise ride
+ * along inside `error.message` and — via `recordError`/`getStatsSnapshot` —
+ * be exposed to any MCP client that later calls `get_runtime_stats`.
+ *
+ * Matches a literal `?` followed by a run of non-whitespace characters
+ * (the query string always ends at the next space in the surrounding
+ * `Dockhand API error: … returned …` message, or at the end of the string)
+ * and replaces the whole match, so no fragment of the original query
+ * string — key or value — survives in the stored message. A message with
+ * no `?` is returned unchanged.
+ */
+function redactQueryStrings(message: string): string {
+  return message.replace(/\?\S+/g, `?${QUERY_STRING_REDACTION_MARKER}`);
+}
+
 /**
  * Records a single tool failure. Stores only the tool name and the error
- * message (bounded to `MAX_ERROR_MESSAGE_LENGTH`, see above) — never the
+ * message — with any URL query string redacted (see `redactQueryStrings`)
+ * and bounded to `MAX_ERROR_MESSAGE_LENGTH` (see above) — never the
  * arguments or any response/result payload.
  */
 export function recordError(tool: string, message: string): void {
   errorCount += 1;
   getOrCreate(tool).errors += 1;
-  lastError = { tool, message: truncateMessage(message), at: new Date().toISOString() };
+  lastError = {
+    tool,
+    message: truncateMessage(redactQueryStrings(message)),
+    at: new Date().toISOString(),
+  };
 }
 
 /** Returns a plain-data snapshot of the current counters. */

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -8,6 +8,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from 'zod';
 import { jsonResponse, textResponse, errorResponse } from './response.js';
 import { describeTool } from '../openapi/describe-tool.js';
+import { recordCall, recordError } from './runtime-stats.js';
 
 // Re-export response helpers for convenience
 export { jsonResponse, textResponse, errorResponse };
@@ -38,6 +39,7 @@ export function registerTool<T extends ZodShape>(
   const description = describeTool(name);
   /* eslint-disable @typescript-eslint/no-explicit-any */
   (server as any).tool(name, description, schema, async (args: any) => {
+    recordCall(name);
     try {
       return await callback(args);
     } catch (error) {
@@ -48,6 +50,7 @@ export function registerTool<T extends ZodShape>(
       // stderr/docker logs. Log it unconditionally so every tool failure
       // is diagnosable from container logs alone. See Issue #116.
       console.error(`[tool:${name}] ${message}`);
+      recordError(name, message);
       return errorResponse(message);
     }
   });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,21 @@
+/**
+ * Build-identity module — build-time-injected version/sha/date, plus
+ * process uptime. See Dockerfile for how MCP_SERVER_VERSION, MCP_GIT_SHA
+ * and MCP_BUILD_DATE are injected at image build time via --build-arg.
+ */
+
+export function getServerVersion(): string {
+  return process.env['MCP_SERVER_VERSION'] ?? '0.0.0-dev';
+}
+
+export function getGitSha(): string {
+  return process.env['MCP_GIT_SHA'] ?? 'unknown';
+}
+
+export function getBuildDate(): string {
+  return process.env['MCP_BUILD_DATE'] ?? 'unknown';
+}
+
+export function getUptimeSeconds(): number {
+  return Math.floor(process.uptime());
+}

--- a/tests/describe-tool.test.ts
+++ b/tests/describe-tool.test.ts
@@ -87,4 +87,61 @@ describe('describeTool', () => {
       );
     });
   });
+
+  describe('description overrides (Self-Help Final Fix Wave, Finding 1): the six meta tools', () => {
+    // None of the six self-help/meta tools (registerMetaTools(), src/tools/meta.ts) wrap a
+    // Dockhand endpoint, so without an override each would silently get the literal fallback
+    // string "No description available." — the exact text an MCP client sees, since the
+    // README (where these ARE documented) is never visible to a client. This is the outcome
+    // check for that fix: each must resolve to its own real override text, never the
+    // fallback, and never another meta tool's text.
+    const metaTools = [
+      'get_server_info',
+      'check_for_update',
+      'get_tool_manifest',
+      'self_check',
+      'validate_config',
+      'get_runtime_stats',
+    ];
+
+    it.each(metaTools)('%s: resolves to a real, non-fallback description', (name) => {
+      const description = describeTool(name);
+      expect(description.length).toBeGreaterThan(0);
+      expect(description).not.toBe('No description available.');
+    });
+
+    it('each meta tool gets its OWN description, not another meta tool\'s', () => {
+      const descriptions = metaTools.map((name) => describeTool(name));
+      expect(new Set(descriptions).size).toBe(metaTools.length);
+    });
+
+    it('get_server_info: mentions version/uptime, not a Dockhand REST field', () => {
+      expect(describeTool('get_server_info')).toMatch(/version/i);
+      expect(describeTool('get_server_info')).toMatch(/uptime/i);
+    });
+
+    it('check_for_update: mentions the GitHub release comparison', () => {
+      expect(describeTool('check_for_update')).toMatch(/github release/i);
+    });
+
+    it('get_tool_manifest: mentions the pinned Dockhand OpenAPI commit/version', () => {
+      expect(describeTool('get_tool_manifest')).toMatch(/openapi/i);
+    });
+
+    it('self_check: mentions reachability and credential validity', () => {
+      expect(describeTool('self_check')).toMatch(/reachab/i);
+      expect(describeTool('self_check')).toMatch(/credential/i);
+    });
+
+    it('validate_config: mentions it never returns secret values', () => {
+      expect(describeTool('validate_config')).toMatch(/never/i);
+      expect(describeTool('validate_config')).toMatch(/secret/i);
+    });
+
+    it('get_runtime_stats: mentions per-tool counters and that call args/response payloads are never captured', () => {
+      const description = describeTool('get_runtime_stats');
+      expect(description).toMatch(/counters?/i);
+      expect(description).toMatch(/never.*(arguments|payloads)/i);
+    });
+  });
 });

--- a/tests/description-overrides.test.ts
+++ b/tests/description-overrides.test.ts
@@ -2,22 +2,62 @@
  * TOOL_DESCRIPTION_OVERRIDES (description-overrides.ts) — two structural invariants that
  * do not depend on the current wording of any individual entry:
  *   1. Every key is a real, registered MCP tool name (typo-proofing — an override for a
- *      tool that does not exist would silently do nothing, forever).
+ *      tool that does not exist would silently do nothing, forever). Checked against the
+ *      full set of tools `registerAllTools()` actually registers, NOT just
+ *      `TOOL_ENDPOINT_MAP` — six of the ten current overrides (the self-help/meta tools,
+ *      see description-overrides.ts's "category 2") have no Dockhand endpoint by design and
+ *      are therefore never present in `TOOL_ENDPOINT_MAP`; checking against that map alone
+ *      would make every one of them fail this invariant.
  *   2. Every value is non-empty prose (an empty override would defeat `describeTool()`'s
  *      "never return an empty string" contract — see describe-tool.ts).
  * Wording-specific assertions (does the override text avoid the exact wrong field/behavior
- * it was added to fix) live in tests/describe-tool.test.ts, next to the `describeTool()`
- * call that surfaces them.
+ * it was added to fix, or — for the meta tools — actually surface instead of the fallback)
+ * live in tests/describe-tool.test.ts, next to the `describeTool()` call that surfaces them.
  */
 import { describe, it, expect } from 'vitest';
 import { TOOL_DESCRIPTION_OVERRIDES } from '../src/openapi/description-overrides.js';
-import { TOOL_ENDPOINT_MAP } from '../src/openapi/tool-endpoint-map.js';
+import { registerAllTools } from '../src/tools/index.js';
+
+/**
+ * The full set of MCP tool names `registerAllTools()` actually registers — the same
+ * capturing-fixture pattern tests/tool-descriptions-derived.test.ts uses, trimmed to just
+ * the names since that is all this file needs. Registration-only: no handler is ever
+ * invoked (same fixture already proven safe with an empty `{}` client stand-in there).
+ */
+function collectRegisteredToolNames(): Set<string> {
+  const names = new Set<string>();
+  const server = {
+    tool(name: string) {
+      names.add(name);
+    },
+  };
+  registerAllTools(server as never, {} as never);
+  return names;
+}
+
+const SHARED_ENDPOINT_MISMATCH_OVERRIDES = [
+  'check_stack_env_collisions',
+  'clear_user_roles',
+  'get_git_stack_webhook',
+  'remove_stack_env_vars',
+];
+
+const NO_ENDPOINT_META_TOOL_OVERRIDES = [
+  'get_server_info',
+  'check_for_update',
+  'get_tool_manifest',
+  'self_check',
+  'validate_config',
+  'get_runtime_stats',
+];
 
 describe('TOOL_DESCRIPTION_OVERRIDES', () => {
-  it('every override key is a registered tool name in TOOL_ENDPOINT_MAP', () => {
+  const registeredNames = collectRegisteredToolNames();
+
+  it('every override key is a real, registered MCP tool name', () => {
     for (const name of Object.keys(TOOL_DESCRIPTION_OVERRIDES)) {
-      expect(TOOL_ENDPOINT_MAP, `override key "${name}" is not a registered tool`).toHaveProperty(
-        name,
+      expect(registeredNames.has(name), `override key "${name}" is not a registered tool`).toBe(
+        true,
       );
     }
   });
@@ -28,11 +68,11 @@ describe('TOOL_DESCRIPTION_OVERRIDES', () => {
     }
   });
 
-  it('covers exactly the four known shared-endpoint mismatches (P3 Final Fix Wave, Refs #57)', () => {
+  it('covers exactly the four known shared-endpoint mismatches plus the six no-endpoint meta tools (P3 + Self-Help Final Fix Wave, Refs #57)', () => {
     // Not a hard ceiling on future overrides — a regression guard so a new entry is a
     // deliberate, reviewed addition rather than an accidental duplicate/typo key.
     expect(Object.keys(TOOL_DESCRIPTION_OVERRIDES).sort()).toEqual(
-      ['check_stack_env_collisions', 'clear_user_roles', 'get_git_stack_webhook', 'remove_stack_env_vars'].sort(),
+      [...SHARED_ENDPOINT_MISMATCH_OVERRIDES, ...NO_ENDPOINT_META_TOOL_OVERRIDES].sort(),
     );
   });
 });

--- a/tests/dockhand-client-base-url.test.ts
+++ b/tests/dockhand-client-base-url.test.ts
@@ -1,0 +1,36 @@
+/**
+ * DockhandClient.getBaseUrl() — exposes the client's own normalized base URL (trailing
+ * slash(es) stripped by normalizeBaseUrl(), src/utils/url.ts, Issue #116), as opposed to
+ * the raw `DOCKHAND_URL` config value, which may still carry one. `get_server_info`
+ * (src/tools/meta.ts) reports this value rather than the raw env var so the diagnostic
+ * reflects what the client actually talks to.
+ */
+import { describe, it, expect } from 'vitest';
+import { DockhandClient } from '../src/client/dockhand-client.js';
+import type { DockhandConfig } from '../src/types/dockhand.js';
+
+function config(overrides: Partial<DockhandConfig> = {}): DockhandConfig {
+  return {
+    url: 'https://dockhand.example.com',
+    username: 'admin',
+    password: 'secret',
+    ...overrides,
+  };
+}
+
+describe('DockhandClient.getBaseUrl', () => {
+  it('returns the configured URL unchanged when it has no trailing slash', () => {
+    const client = new DockhandClient(config({ url: 'https://dockhand.example.com' }));
+    expect(client.getBaseUrl()).toBe('https://dockhand.example.com');
+  });
+
+  it('strips a trailing slash (the Issue #116 normalization), unlike the raw config value', () => {
+    const client = new DockhandClient(config({ url: 'https://dockhand.example.com/' }));
+    expect(client.getBaseUrl()).toBe('https://dockhand.example.com');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    const client = new DockhandClient(config({ url: 'https://dockhand.example.com///' }));
+    expect(client.getBaseUrl()).toBe('https://dockhand.example.com');
+  });
+});

--- a/tests/dockhand-client-error-redaction.test.ts
+++ b/tests/dockhand-client-error-redaction.test.ts
@@ -1,0 +1,114 @@
+/**
+ * DockhandClient's thrown `Dockhand API error: ${method} ${url} returned …` message —
+ * Fix round 3, Item B. `trigger_git_webhook` (src/tools/git-stacks.ts) calls
+ * `client.get('/api/git/stacks/{id}/webhook', { secret })`, which `buildUrl()` turns
+ * into a `?secret=<value>` query param on the request URL. On failure, that URL used to
+ * land verbatim inside the thrown error message — reaching THREE surfaces unredacted:
+ * `console.error` (docker logs), the MCP caller's own error response, and (before the
+ * Fix 1 sink-side redaction) `get_runtime_stats`. This is the source-side fix: redact
+ * once at construction, in `request()`/`requestRaw()` themselves, via the shared
+ * `redactQueryStrings()` (src/utils/redact.ts) — so every consumer of the thrown error
+ * gets the already-redacted message, not just `get_runtime_stats`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DockhandClient } from '../src/client/dockhand-client.js';
+import type { DockhandConfig } from '../src/types/dockhand.js';
+
+function mockResponse(init: { ok: boolean; status: number; statusText: string; body?: string; setCookie?: string[] }) {
+  return {
+    ok: init.ok,
+    status: init.status,
+    statusText: init.statusText,
+    text: vi.fn().mockResolvedValue(init.body ?? ''),
+    // Lazily parsed (only on actual .json() call) — the error paths under test here
+    // only ever call .text(), and several of these mocked bodies (e.g. plain-text
+    // 'boom'/'nope') are deliberately NOT valid JSON, matching a real non-JSON error
+    // response body.
+    json: vi.fn().mockImplementation(async () => (init.body ? JSON.parse(init.body) : {})),
+    headers: {
+      getSetCookie: () => init.setCookie ?? [],
+      get: (name: string) => (name.toLowerCase() === 'content-type' && init.body ? 'application/json' : null),
+    },
+  };
+}
+
+function config(overrides: Partial<DockhandConfig> = {}): DockhandConfig {
+  return {
+    url: 'https://dockhand.example.com',
+    username: 'admin',
+    password: 'secret',
+    ...overrides,
+  };
+}
+
+describe('DockhandClient error message redaction (request())', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('redacts a secret carried in a query string in the thrown error message', async () => {
+    const fetchMock = vi.fn()
+      // Login call
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }))
+      // GET /api/git/stacks/7/webhook?secret=abc123def — the real trigger_git_webhook shape
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 500, statusText: 'Internal Server Error', body: 'boom' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DockhandClient(config());
+    let thrown: Error | undefined;
+    try {
+      await client.get('/api/git/stacks/7/webhook', { secret: 'abc123def' });
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.message).toMatch(/Dockhand API error: GET .*\?<redacted> returned 500: boom/);
+    // The raw secret value must be nowhere in the thrown message.
+    expect(thrown!.message).not.toContain('abc123def');
+    expect(thrown!.message).toContain('?<redacted>');
+  });
+
+  it('leaves an error message from a query-less URL unchanged', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }))
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 404, statusText: 'Not Found', body: 'stack not found' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DockhandClient(config());
+
+    await expect(client.get('/api/stacks/does-not-exist')).rejects.toThrow(
+      'Dockhand API error: GET https://dockhand.example.com/api/stacks/does-not-exist returned 404: stack not found',
+    );
+  });
+});
+
+describe('DockhandClient error message redaction (requestRaw(), via postMultipart())', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('redacts a secret carried in a query string in requestRaw()\'s thrown error message too', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, statusText: 'OK', setCookie: ['session=abc123'] }))
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 403, statusText: 'Forbidden', body: 'nope' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DockhandClient(config());
+    const formData = new FormData();
+    formData.append('file', 'content');
+
+    let thrown: Error | undefined;
+    try {
+      await client.postMultipart('/api/containers/abc/upload', formData, { token: 'super-secret-upload-token' });
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.message).toMatch(/Dockhand API error: POST .*\?<redacted> returned 403: nope/);
+    expect(thrown!.message).not.toContain('super-secret-upload-token');
+  });
+});

--- a/tests/openapi/pinned-sync.test.ts
+++ b/tests/openapi/pinned-sync.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PINNED_DOCKHAND_OPENAPI_COMMIT } from '../../src/openapi/pinned.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FETCH_OPENAPI_SCRIPT = join(__dirname, '..', '..', 'scripts', 'fetch-openapi.mjs');
+
+/**
+ * Enforces that src/openapi/pinned.ts (PINNED_DOCKHAND_OPENAPI_COMMIT -- a hand-maintained
+ * mirror, see that file's header comment) never drifts from scripts/fetch-openapi.mjs's
+ * SOURCE_COMMIT, the actual pinned Dockhand OpenAPI source commit. `get_tool_manifest`
+ * exists precisely to surface this kind of drift to callers -- a stale mirror here would be
+ * the same drift, self-inflicted and invisible.
+ *
+ * Reads the script as plain text and extracts SOURCE_COMMIT via regex, then asserts the
+ * regex actually matched before comparing anything. Without that guard, a future rename or
+ * reshaping of the constant (e.g. `SOURCE_COMMIT = SOME_OTHER_CONST`) would make the regex
+ * match nothing, both sides of a naive comparison would end up `undefined`, and this test
+ * would pass while silently testing nothing at all.
+ */
+describe('pinned Dockhand OpenAPI commit stays in sync', () => {
+  it('src/openapi/pinned.ts mirrors scripts/fetch-openapi.mjs SOURCE_COMMIT exactly', () => {
+    const scriptSource = readFileSync(FETCH_OPENAPI_SCRIPT, 'utf8');
+    const match = scriptSource.match(/SOURCE_COMMIT\s*=\s*['"]([0-9a-f]{40})['"]/);
+
+    expect(
+      match,
+      'Could not find SOURCE_COMMIT in scripts/fetch-openapi.mjs -- update the regex above if the script changed shape'
+    ).not.toBeNull();
+
+    const sourceCommit = match![1];
+    expect(PINNED_DOCKHAND_OPENAPI_COMMIT).toBe(sourceCommit);
+  });
+});

--- a/tests/spec-loader-missing-spec.test.ts
+++ b/tests/spec-loader-missing-spec.test.ts
@@ -1,0 +1,39 @@
+/**
+ * spec-loader's degrade path when docs/dockhand-openapi.json itself is missing at
+ * runtime (see loadSpec()'s `!existsSync(SPEC_FILE)` branch — the only "spec
+ * unavailable" case the loader actually handles).
+ *
+ * Deliberately its own file, not appended to tests/spec-loader.test.ts: `node:fs` is
+ * mocked here so `loadSpec()` believes the spec file does not exist, and the loader
+ * memoizes that result (`cachedSpec`) for the lifetime of the module. Vitest gives each
+ * test FILE its own isolated module registry by default, so this mock — and the
+ * resulting cached `null` — cannot leak into tests/spec-loader.test.ts's real,
+ * spec-present assertions (or vice versa).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, existsSync: () => false };
+});
+
+describe('spec-loader — spec file missing', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('specInfoVersion() returns undefined gracefully instead of throwing', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { specInfoVersion } = await import('../src/openapi/spec-loader.js');
+
+    expect(specInfoVersion()).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('specOperation() also degrades to undefined for the same missing-spec case (consistency check)', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { specOperation } = await import('../src/openapi/spec-loader.js');
+
+    expect(specOperation({ method: 'GET', path: '/api/environments' })).toBeUndefined();
+  });
+});

--- a/tests/spec-loader.test.ts
+++ b/tests/spec-loader.test.ts
@@ -9,7 +9,7 @@
  * runtime image.
  */
 import { describe, it, expect } from 'vitest';
-import { specOperation } from '../src/openapi/spec-loader.js';
+import { specOperation, specInfoVersion } from '../src/openapi/spec-loader.js';
 
 describe('specOperation', () => {
   it('returns undefined when the endpoint argument itself is undefined (unresolved tool)', () => {
@@ -36,5 +36,15 @@ describe('specOperation', () => {
   it('resolves the known get_git_stack_env_files operation with the expected real summary', () => {
     const op = specOperation({ method: 'GET', path: '/api/git/stacks/{id}/env-files' });
     expect(op?.summary).toContain('.env files');
+  });
+});
+
+describe('specInfoVersion', () => {
+  it("returns the real spec's info.version (used by get_tool_manifest, src/tools/meta.ts)", () => {
+    // Same committed spec every other test in this file resolves operations against
+    // (docs/dockhand-openapi.json) — its info.version is currently "1.0.41". Re-pin this
+    // literal whenever scripts/fetch-openapi.mjs (SOURCE_COMMIT) is bumped, same as
+    // PINNED_DOCKHAND_OPENAPI_COMMIT in src/openapi/pinned.ts.
+    expect(specInfoVersion()).toBe('1.0.41');
   });
 });

--- a/tests/tool-endpoint.test.ts
+++ b/tests/tool-endpoint.test.ts
@@ -96,10 +96,24 @@ describe('tool-endpoint-map completeness', () => {
     return names;
   }
 
-  it('every registered tool has an entry, except the documented get_prometheus_metrics gap', () => {
+  // The three self-help/meta tools (src/tools/meta.ts) are deliberately excluded, same as
+  // get_prometheus_metrics above: TOOL_ENDPOINT_MAP records "the one real Dockhand endpoint
+  // this tool calls", which does not apply to any of them --
+  //   - `check_for_update` calls the GitHub releases API, not Dockhand, at all.
+  //   - `get_tool_manifest` calls no HTTP endpoint whatsoever (pure local computation over
+  //     TOOL_ENDPOINT_MAP + the pinned OpenAPI spec).
+  //   - `get_server_info` does call `GET /api/changelog` internally, but only as a
+  //     best-effort, try/catch-degraded lookup for the running Dockhand server's version
+  //     (see buildServerInfo() in meta.ts) -- an implementation detail, not its contract.
+  const META_TOOLS_WITHOUT_ENDPOINT = ['check_for_update', 'get_tool_manifest', 'get_server_info'];
+
+  it('every registered tool has an entry, except the documented get_prometheus_metrics gap and the meta tools', () => {
     const allNames = extractAllToolNames();
     const missing = allNames.filter(
-      (name) => !(name in TOOL_ENDPOINT_MAP) && name !== 'get_prometheus_metrics',
+      (name) =>
+        !(name in TOOL_ENDPOINT_MAP) &&
+        name !== 'get_prometheus_metrics' &&
+        !META_TOOLS_WITHOUT_ENDPOINT.includes(name),
     );
     expect(missing, `\n${missing.join('\n')}`).toEqual([]);
   });

--- a/tests/tool-endpoint.test.ts
+++ b/tests/tool-endpoint.test.ts
@@ -13,6 +13,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { toolEndpoint, endpointToTool } from '../src/openapi/tool-endpoint.js';
 import { TOOL_ENDPOINT_MAP } from '../src/openapi/tool-endpoint-map.js';
+import { META_TOOL_NAMES } from '../src/tools/meta.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TOOLS_DIR = join(__dirname, '..', 'src', 'tools');
@@ -113,14 +114,12 @@ describe('tool-endpoint-map completeness', () => {
   //     detail, not contract" reasoning as `get_server_info` above.
   //   - `get_runtime_stats` calls no HTTP endpoint at all (pure in-process counters, see
   //     src/utils/runtime-stats.ts).
-  const META_TOOLS_WITHOUT_ENDPOINT = [
-    'check_for_update',
-    'get_runtime_stats',
-    'get_server_info',
-    'get_tool_manifest',
-    'self_check',
-    'validate_config',
-  ];
+  //
+  // Imported from src/tools/meta.ts (Fix round 2, Finding 4) rather than duplicated here
+  // as a local literal: META_TOOL_NAMES is the same list get_tool_manifest's own
+  // registration wiring now reuses to include these six tools in its inventory, so this
+  // test and that production code can never drift apart.
+  const META_TOOLS_WITHOUT_ENDPOINT = META_TOOL_NAMES;
 
   it('every registered tool has an entry, except the documented get_prometheus_metrics gap and the meta tools', () => {
     const allNames = extractAllToolNames();

--- a/tests/tool-endpoint.test.ts
+++ b/tests/tool-endpoint.test.ts
@@ -96,7 +96,7 @@ describe('tool-endpoint-map completeness', () => {
     return names;
   }
 
-  // The three self-help/meta tools (src/tools/meta.ts) are deliberately excluded, same as
+  // All six self-help/meta tools (src/tools/meta.ts) are deliberately excluded, same as
   // get_prometheus_metrics above: TOOL_ENDPOINT_MAP records "the one real Dockhand endpoint
   // this tool calls", which does not apply to any of them --
   //   - `check_for_update` calls the GitHub releases API, not Dockhand, at all.
@@ -105,7 +105,22 @@ describe('tool-endpoint-map completeness', () => {
   //   - `get_server_info` does call `GET /api/changelog` internally, but only as a
   //     best-effort, try/catch-degraded lookup for the running Dockhand server's version
   //     (see buildServerInfo() in meta.ts) -- an implementation detail, not its contract.
-  const META_TOOLS_WITHOUT_ENDPOINT = ['check_for_update', 'get_tool_manifest', 'get_server_info'];
+  //   - `self_check` calls FOUR different Dockhand endpoints internally (`/api/health`,
+  //     `/api/auth/login`, `/api/environments`, `/api/hawser/connect`) -- a diagnostic
+  //     aggregator, not a wrapper around any single endpoint's contract.
+  //   - `validate_config` calls `/api/auth/login` internally, purely as a best-effort
+  //     credential-validity probe (see validateConfig() in meta.ts) -- same "implementation
+  //     detail, not contract" reasoning as `get_server_info` above.
+  //   - `get_runtime_stats` calls no HTTP endpoint at all (pure in-process counters, see
+  //     src/utils/runtime-stats.ts).
+  const META_TOOLS_WITHOUT_ENDPOINT = [
+    'check_for_update',
+    'get_runtime_stats',
+    'get_server_info',
+    'get_tool_manifest',
+    'self_check',
+    'validate_config',
+  ];
 
   it('every registered tool has an entry, except the documented get_prometheus_metrics gap and the meta tools', () => {
     const allNames = extractAllToolNames();

--- a/tests/tools/meta.attempt-raw-login.test.ts
+++ b/tests/tools/meta.attempt-raw-login.test.ts
@@ -1,0 +1,181 @@
+/**
+ * attemptRawLogin() (src/tools/meta.ts) — the shared one-shot login probe behind both
+ * self_check's authValid and validate_config's credentialsValid (Fix round 2,
+ * Finding 3 / P2). Per docs/dockhand-openapi.json's own description of
+ * POST /api/auth/login's 200 response ("Login succeeded and dockhand_session cookie was
+ * set — OR requiresMfa:true if a second factor is needed first"), a plain 200 status is
+ * NOT on its own proof that a usable session was established: an MFA account can return
+ * 200 + { success:true, requiresMfa:true } with no session cookie. attemptRawLogin now
+ * inspects the response body's requiresMfa flag and the Set-Cookie header (presence
+ * only — never the cookie's value) to compute `completedAuth` separately from the raw
+ * `statusCode`.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { attemptRawLogin } from '../../src/tools/meta.js';
+
+interface MockResponseInit {
+  status: number;
+  body?: string;
+  setCookie?: string[];
+}
+
+function mockResponse(init: MockResponseInit) {
+  return {
+    status: init.status,
+    text: vi.fn().mockResolvedValue(init.body ?? ''),
+    headers: {
+      getSetCookie: () => init.setCookie ?? [],
+      get: (name: string) => (name.toLowerCase() === 'set-cookie' ? (init.setCookie?.[0] ?? null) : null),
+    },
+  };
+}
+
+describe('attemptRawLogin', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports completedAuth:true for a plain 200 with a session cookie and no requiresMfa flag', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: JSON.stringify({ success: true, user: { id: 1, username: 'admin', isAdmin: true } }),
+        setCookie: ['dockhand_session=abc123; Path=/; HttpOnly'],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result).toEqual({ statusCode: 200, completedAuth: true });
+  });
+
+  it('reports completedAuth:false for a 200 carrying requiresMfa:true, even though the status is 200 — the core of the fix', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: JSON.stringify({ success: true, requiresMfa: true }),
+        setCookie: [], // no session cookie — MFA still pending
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result.statusCode).toBe(200);
+    expect(result.completedAuth).toBe(false);
+  });
+
+  it('reports completedAuth:false for a 200 with requiresMfa:true even if a (non-session) cookie happened to be set', async () => {
+    // requiresMfa:true must win regardless of cookie presence — an MFA-pending login
+    // is never a completed auth, no matter what the Set-Cookie header contains.
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: JSON.stringify({ success: true, requiresMfa: true }),
+        setCookie: ['some_other_cookie=xyz; Path=/'],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result.completedAuth).toBe(false);
+  });
+
+  it('reports completedAuth:false for a 200 with no session cookie at all, even without an explicit requiresMfa flag', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ status: 200, body: JSON.stringify({ success: true }), setCookie: [] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result.completedAuth).toBe(false);
+  });
+
+  it('reports statusCode:401, completedAuth:false for invalid credentials', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ status: 401, body: JSON.stringify({ error: 'Invalid username or password' }) }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result).toEqual({ statusCode: 401, completedAuth: false });
+  });
+
+  it('never attempts to parse the body for a non-200 status', async () => {
+    const textSpy = vi.fn().mockResolvedValue('');
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 403,
+      text: textSpy,
+      headers: { getSetCookie: () => [], get: () => null },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await attemptRawLogin('https://dockhand.example.com');
+
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it('degrades to completedAuth:false (does not throw) when the 200 body is not valid JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ status: 200, body: 'not json', setCookie: ['dockhand_session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    // No requiresMfa flag could be parsed out of a non-JSON body, so it's treated as
+    // absent — the session cookie alone still makes this a completed auth.
+    expect(result).toEqual({ statusCode: 200, completedAuth: true });
+  });
+
+  it('falls back to the raw set-cookie header when getSetCookie() reports none (older fetch implementations)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ success: true })),
+      headers: {
+        // No getSetCookie() results, but the raw header is present.
+        getSetCookie: () => [],
+        get: (name: string) => (name.toLowerCase() === 'set-cookie' ? 'dockhand_session=fallback123; Path=/' : null),
+      },
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result.completedAuth).toBe(true);
+  });
+
+  it('propagates a network error (fetch rejects) instead of failing silently', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(attemptRawLogin('https://dockhand.example.com')).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('never surfaces the configured username/password in the result — secret-safe by construction', async () => {
+    const originalUsername = process.env.DOCKHAND_USERNAME;
+    const originalPassword = process.env.DOCKHAND_PASSWORD;
+    process.env.DOCKHAND_USERNAME = 'sentinel-username-value';
+    process.env.DOCKHAND_PASSWORD = 'sentinel-password-value';
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({ status: 200, body: JSON.stringify({ success: true }), setCookie: ['dockhand_session=abc123'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    try {
+      const result = await attemptRawLogin('https://dockhand.example.com');
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain('sentinel-username-value');
+      expect(serialized).not.toContain('sentinel-password-value');
+    } finally {
+      process.env.DOCKHAND_USERNAME = originalUsername;
+      process.env.DOCKHAND_PASSWORD = originalPassword;
+    }
+  });
+});

--- a/tests/tools/meta.attempt-raw-login.test.ts
+++ b/tests/tools/meta.attempt-raw-login.test.ts
@@ -95,6 +95,36 @@ describe('attemptRawLogin', () => {
     expect(result.completedAuth).toBe(false);
   });
 
+  it('reports completedAuth:false for a 200 whose ONLY Set-Cookie is unrelated to Dockhand\'s session (Fix round 3, Finding 1) — a reverse proxy adding e.g. a __cf_bm cookie must not read as a valid session', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: JSON.stringify({ success: true }),
+        setCookie: ['__cf_bm=some-cloudflare-value; Path=/; HttpOnly; Secure'],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result).toEqual({ statusCode: 200, completedAuth: false });
+  });
+
+  it('reports completedAuth:true for a 200 carrying the real dockhand_session cookie alongside an unrelated one, with no requiresMfa flag', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockResponse({
+        status: 200,
+        body: JSON.stringify({ success: true }),
+        setCookie: ['__cf_bm=some-cloudflare-value; Path=/; HttpOnly; Secure', 'dockhand_session=abc123; Path=/; HttpOnly'],
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await attemptRawLogin('https://dockhand.example.com');
+
+    expect(result).toEqual({ statusCode: 200, completedAuth: true });
+  });
+
   it('reports statusCode:401, completedAuth:false for invalid credentials', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockResponse({ status: 401, body: JSON.stringify({ error: 'Invalid username or password' }) }),

--- a/tests/tools/meta.check-for-update.test.ts
+++ b/tests/tools/meta.check-for-update.test.ts
@@ -34,4 +34,12 @@ describe("checkForUpdate", () => {
     expect(r.updateAvailable).toBeNull();
     expect(r.error).toBeDefined();
   });
+
+  it("degrades to null within the deadline (not a hang) when the GitHub fetch never resolves (Fix round 3, Finding 3)", async () => {
+    __resetUpdateCache();
+    const fetchImpl = vi.fn(() => new Promise<Response>(() => {})); // never settles
+    const r = await checkForUpdate({ current: "1.6.0", fetchImpl, now: () => 1000, timeoutMs: 20 });
+    expect(r.updateAvailable).toBeNull();
+    expect(r.error).toBeDefined();
+  });
 });

--- a/tests/tools/meta.check-for-update.test.ts
+++ b/tests/tools/meta.check-for-update.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { compareSemver, checkForUpdate, __resetUpdateCache } from "../../src/tools/meta.js";
+
+describe("compareSemver", () => {
+  it("orders versions", () => {
+    expect(compareSemver("1.12.0", "1.6.0")).toBe(1);
+    expect(compareSemver("1.6.0", "1.12.0")).toBe(-1);
+    expect(compareSemver("1.6.0", "1.6.0")).toBe(0);
+  });
+});
+
+describe("checkForUpdate", () => {
+  it("flags an available update", async () => {
+    __resetUpdateCache();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(
+      { tag_name: "v1.12.0", html_url: "https://gh/rel", published_at: "2026-08-11T03:34:08Z" }
+    ), { status: 200 }));
+    const r = await checkForUpdate({ current: "1.6.0", fetchImpl, now: () => 1000 });
+    expect(r).toMatchObject({ current: "1.6.0", latest: "1.12.0", updateAvailable: true });
+  });
+
+  it("uses cache within TTL (no second fetch)", async () => {
+    __resetUpdateCache();
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ tag_name: "v1.12.0" }), { status: 200 }));
+    await checkForUpdate({ current: "1.6.0", fetchImpl, now: () => 1000 });
+    await checkForUpdate({ current: "1.6.0", fetchImpl, now: () => 1000 + 60_000 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades to null on network error", async () => {
+    __resetUpdateCache();
+    const fetchImpl = vi.fn(async () => { throw new Error("offline"); });
+    const r = await checkForUpdate({ current: "1.6.0", fetchImpl, now: () => 1000 });
+    expect(r.updateAvailable).toBeNull();
+    expect(r.error).toBeDefined();
+  });
+});

--- a/tests/tools/meta.derive-environment-statuses.test.ts
+++ b/tests/tools/meta.derive-environment-statuses.test.ts
@@ -1,0 +1,90 @@
+/**
+ * deriveEnvironmentStatuses() (src/tools/meta.ts) — the pure, injectable per-environment
+ * status derivation behind `self_check`'s `listEnvironments` wiring. Extracted in Fix
+ * round 1 (Finding 2 of the Task 9 review): this mapping previously lived, untested,
+ * inline inside the `registerTool('self_check', ...)` closure. Covers the five cases the
+ * review explicitly asked for: hawser-edge connected, hawser-edge disconnected, socket
+ * reachable, socket unreachable, and the probe/`/test`-throws fallback.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveEnvironmentStatuses, type EnvironmentListEntry } from '../../src/tools/meta.js';
+
+describe('deriveEnvironmentStatuses', () => {
+  it('a hawser-edge environment whose agent IS in the connected set is reachable and hawserConnected', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 1, name: 'hhdocker02', connectionType: 'hawser-edge' }];
+    const result = deriveEnvironmentStatuses(environments, new Set([1]), new Map([[1, true]]));
+
+    expect(result).toEqual([{ id: 1, name: 'hhdocker02', reachable: true, hawserConnected: true }]);
+  });
+
+  it('a hawser-edge environment whose agent is NOT in the connected set is neither reachable nor hawserConnected', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 2, name: 'hhdocker03', connectionType: 'hawser-edge' }];
+    // Fix round 1, Finding 1: `reachable` no longer follows from connectionType alone —
+    // it is the live /test result, passed in here as `false` (matching the real wiring's
+    // "agent unreachable" case, which would also fail its /test probe).
+    const result = deriveEnvironmentStatuses(environments, new Set(), new Map([[2, false]]));
+
+    expect(result).toEqual([{ id: 2, name: 'hhdocker03', reachable: false, hawserConnected: false }]);
+  });
+
+  it('a socket environment that IS reachable per its /test probe is reachable, and never hawserConnected', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 3, name: 'hhdocker01', connectionType: 'socket' }];
+    // Even if id 3 somehow appeared in connectedAgentIds, a non-hawser-edge environment
+    // must never read as hawserConnected — there is no agent to be connected.
+    const result = deriveEnvironmentStatuses(environments, new Set([3]), new Map([[3, true]]));
+
+    expect(result).toEqual([{ id: 3, name: 'hhdocker01', reachable: true, hawserConnected: false }]);
+  });
+
+  it('a socket environment that is NOT reachable per its /test probe is reachable:false (Finding 1: no longer hardcoded true)', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 4, name: 'hhdocker04', connectionType: 'socket' }];
+    const result = deriveEnvironmentStatuses(environments, new Set(), new Map([[4, false]]));
+
+    expect(result).toEqual([{ id: 4, name: 'hhdocker04', reachable: false, hawserConnected: false }]);
+  });
+
+  it('an environment missing from perEnvReachable (its /test probe threw or timed out) degrades to reachable:false', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 5, name: 'flaky-env', connectionType: 'socket' }];
+    // No entry for id 5 at all — the real wiring leaves it unset when Promise.allSettled
+    // rejects that probe (throw or withTimeout() timeout). Must degrade, never throw.
+    const result = deriveEnvironmentStatuses(environments, new Set(), new Map());
+
+    expect(result).toEqual([{ id: 5, name: 'flaky-env', reachable: false, hawserConnected: false }]);
+  });
+
+  it('handles an empty environment list', () => {
+    expect(deriveEnvironmentStatuses([], new Set(), new Map())).toEqual([]);
+  });
+
+  it('maps multiple environments of mixed connection types independently', () => {
+    const environments: EnvironmentListEntry[] = [
+      { id: 1, name: 'edge-up', connectionType: 'hawser-edge' },
+      { id: 2, name: 'edge-down', connectionType: 'hawser-edge' },
+      { id: 3, name: 'socket-up', connectionType: 'socket' },
+      { id: 4, name: 'socket-down', connectionType: 'socket' },
+    ];
+    const connectedAgentIds = new Set([1]);
+    const perEnvReachable = new Map([
+      [1, true],
+      [2, false],
+      [3, true],
+      [4, false],
+    ]);
+
+    const result = deriveEnvironmentStatuses(environments, connectedAgentIds, perEnvReachable);
+
+    expect(result).toEqual([
+      { id: 1, name: 'edge-up', reachable: true, hawserConnected: true },
+      { id: 2, name: 'edge-down', reachable: false, hawserConnected: false },
+      { id: 3, name: 'socket-up', reachable: true, hawserConnected: false },
+      { id: 4, name: 'socket-down', reachable: false, hawserConnected: false },
+    ]);
+  });
+
+  it('treats a missing connectionType as non-hawser (never hawserConnected)', () => {
+    const environments: EnvironmentListEntry[] = [{ id: 6, name: 'unknown-type' }];
+    const result = deriveEnvironmentStatuses(environments, new Set([6]), new Map([[6, true]]));
+
+    expect(result).toEqual([{ id: 6, name: 'unknown-type', reachable: true, hawserConnected: false }]);
+  });
+});

--- a/tests/tools/meta.get-server-info.test.ts
+++ b/tests/tools/meta.get-server-info.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildServerInfo } from '../../src/tools/meta.js';
+
+describe('buildServerInfo', () => {
+  it('assembles identity + best-effort dockhand version', async () => {
+    const info = await buildServerInfo({
+      dockhandUrl: 'https://dock.example.com',
+      getDockhandServerVersion: async () => '1.0.41',
+    });
+    expect(info.version).toBeDefined();
+    expect(info.dockhandUrl).toBe('https://dock.example.com');
+    expect(info.dockhandServerVersion).toBe('1.0.41');
+    expect(info.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it('degrades dockhand version to null on failure', async () => {
+    const info = await buildServerInfo({
+      dockhandUrl: 'https://dock.example.com',
+      getDockhandServerVersion: async () => {
+        throw new Error('unreachable');
+      },
+    });
+    expect(info.dockhandServerVersion).toBeNull();
+  });
+});

--- a/tests/tools/meta.get-tool-manifest-wiring.test.ts
+++ b/tests/tools/meta.get-tool-manifest-wiring.test.ts
@@ -1,0 +1,95 @@
+/**
+ * get_tool_manifest's real registration wiring (registerMetaTools() in src/tools/meta.ts)
+ * — Fix round 2, Finding 4. buildToolManifest() itself (tests/tools/meta.tool-manifest.test.ts)
+ * is a pure, injectable builder tested in isolation; this file is the end-to-end regression
+ * guard for the actual bug the review found: get_tool_manifest's own toolCount silently
+ * drifting from registerAllTools()'s real registered-tool count (292 vs 298 before this fix).
+ *
+ * get_tool_manifest's handler does no I/O at all (no client.* calls — it is pure local
+ * computation over TOOL_ENDPOINT_MAP + META_TOOL_NAMES + the pinned OpenAPI identity), so
+ * unlike self_check/validate_config it CAN be invoked directly against a capturing fake
+ * server (same fixture shape tests/tool-descriptions-derived.test.ts and
+ * tests/tools/meta.register.test.ts already use), with no real Dockhand client needed.
+ */
+import { describe, it, expect } from 'vitest';
+import { registerAllTools } from '../../src/tools/index.js';
+import { registerMetaTools, META_TOOL_NAMES } from '../../src/tools/meta.js';
+import { TOOL_ENDPOINT_MAP } from '../../src/openapi/tool-endpoint-map.js';
+
+interface CapturedTool {
+  name: string;
+  handler: (args: Record<string, never>) => Promise<{ content: { type: 'text'; text: string }[] }>;
+}
+
+function collectRegisteredToolNames(): string[] {
+  const names: string[] = [];
+  const server = { tool: (name: string) => names.push(name) };
+  registerAllTools(server as never, {} as never);
+  return names;
+}
+
+async function invokeGetToolManifest(): Promise<{ toolCount: number; tools: { name: string; method: string | null; path: string | null }[] }> {
+  const tools = new Map<string, CapturedTool>();
+  const server = {
+    tool(name: string, _description: string, _schema: unknown, handler: CapturedTool['handler']) {
+      tools.set(name, { name, handler });
+    },
+  };
+  // registerMetaTools() never invokes a handler during registration, and this specific
+  // handler needs no Dockhand client at all — an empty stand-in is safe.
+  registerMetaTools(server as never, {} as never);
+
+  const captured = tools.get('get_tool_manifest');
+  if (!captured) throw new Error('get_tool_manifest was not registered');
+  const result = await captured.handler({});
+  return JSON.parse(result.content[0]!.text) as {
+    toolCount: number;
+    tools: { name: string; method: string | null; path: string | null }[];
+  };
+}
+
+describe('get_tool_manifest registration wiring', () => {
+  it('toolCount equals the true registered tool count from registerAllTools() (Fix round 2, Finding 4)', async () => {
+    const allNames = collectRegisteredToolNames();
+    const manifest = await invokeGetToolManifest();
+
+    expect(manifest.toolCount).toBe(allNames.length);
+  });
+
+  it('lists every tool registerAllTools() actually exposes, by name — including all six meta tools and get_tool_manifest itself', async () => {
+    const allNames = collectRegisteredToolNames();
+    const manifest = await invokeGetToolManifest();
+    const manifestNames = manifest.tools.map((t) => t.name).sort();
+
+    expect(manifestNames).toEqual([...allNames].sort());
+    expect(manifestNames).toContain('get_tool_manifest');
+    for (const metaName of META_TOOL_NAMES) {
+      expect(manifestNames).toContain(metaName);
+    }
+  });
+
+  it('reports method:null, path:null for every meta tool', async () => {
+    const manifest = await invokeGetToolManifest();
+
+    for (const metaName of META_TOOL_NAMES) {
+      const entry = manifest.tools.find((t) => t.name === metaName);
+      expect(entry, metaName).toEqual({ name: metaName, method: null, path: null });
+    }
+  });
+
+  it('reports get_prometheus_metrics with its real, documented endpoint (GET /api/metrics), not null', async () => {
+    const manifest = await invokeGetToolManifest();
+
+    const entry = manifest.tools.find((t) => t.name === 'get_prometheus_metrics');
+    expect(entry).toEqual({ name: 'get_prometheus_metrics', method: 'GET', path: '/api/metrics' });
+  });
+
+  it('every non-meta, non-get_prometheus_metrics tool matches its TOOL_ENDPOINT_MAP entry exactly', async () => {
+    const manifest = await invokeGetToolManifest();
+
+    for (const [name, entry] of Object.entries(TOOL_ENDPOINT_MAP)) {
+      const found = manifest.tools.find((t) => t.name === name);
+      expect(found, name).toEqual({ name, method: entry.method, path: entry.path });
+    }
+  });
+});

--- a/tests/tools/meta.probe-raw-health.test.ts
+++ b/tests/tools/meta.probe-raw-health.test.ts
@@ -1,0 +1,78 @@
+/**
+ * probeRawHealth() (src/tools/meta.ts) — the real wiring behind `self_check`'s
+ * `probeHealth` (Fix round 2, Finding 2 / P2). Replaces the previous
+ * `client.get('/api/health')` wiring, which ran through `SessionManager` and therefore
+ * attempted a login first — an invalid credential made `probeHealth` fail on the LOGIN,
+ * not on `/api/health` itself, so `self_check` reported `dockhandReachable: false,
+ * overall: "down"` for what was really just a bad credential. `probeRawHealth` is a bare,
+ * UNAUTHENTICATED `fetch()` against `/api/health` (documented `security: []`), so it must
+ * succeed independently of whether any credential is valid.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { probeRawHealth } from '../../src/tools/meta.js';
+
+function mockResponse(init: { ok: boolean; status: number }) {
+  return { ok: init.ok, status: init.status };
+}
+
+describe('probeRawHealth', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('resolves without throwing when Dockhand /api/health answers 200', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(probeRawHealth('https://dockhand.example.com')).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith('https://dockhand.example.com/api/health');
+  });
+
+  it('sends a bare unauthenticated request — no Cookie/Authorization header, no request init at all', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await probeRawHealth('https://dockhand.example.com');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]).toHaveLength(1); // URL only — no second (headers/init) argument
+  });
+
+  it('reports Dockhand reachable even when the configured credentials are invalid — the core of the fix', async () => {
+    // Simulates the exact scenario the previous client.get()-based wiring got wrong:
+    // Dockhand itself is fully up and /api/health answers 200, independent of any
+    // credential. probeRawHealth must resolve here regardless of auth state — it never
+    // touches SessionManager/login at all.
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(probeRawHealth('https://dockhand.example.com')).resolves.toBeUndefined();
+    // A single, unauthenticated GET — no login attempt bundled into this probe.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a diagnostic error when Dockhand responds with a non-2xx status', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: false, status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(probeRawHealth('https://dockhand.example.com')).rejects.toThrow(/503/);
+  });
+
+  it('propagates a network error (fetch rejects) instead of failing silently', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(probeRawHealth('https://dockhand.example.com')).rejects.toThrow('ECONNREFUSED');
+  });
+
+  it('appends /api/health to the given baseUrl as-is (mirrors attemptRawLogin: normalization is the caller\'s job, via client.getBaseUrl())', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ ok: true, status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await probeRawHealth('https://dockhand.example.com');
+
+    const [calledUrl] = fetchMock.mock.calls[0] as [string];
+    expect(calledUrl).toBe('https://dockhand.example.com/api/health');
+  });
+});

--- a/tests/tools/meta.register.test.ts
+++ b/tests/tools/meta.register.test.ts
@@ -1,0 +1,58 @@
+/**
+ * registerMetaTools() (src/tools/meta.ts) — registers the three M1 self-help tools
+ * (`get_server_info`, `check_for_update`, `get_tool_manifest`) against a capturing
+ * fake server, mirroring the fixture shape tests/tool-error-logging.test.ts already
+ * uses for registerTool(). Registration-only: none of the three handlers are invoked
+ * here (get_server_info/get_tool_manifest hit the real Dockhand client / filesystem,
+ * check_for_update hits the real network) — that behavior is covered by the pure
+ * builders' own tests (meta.get-server-info.test.ts, meta.check-for-update.test.ts,
+ * meta.tool-manifest.test.ts).
+ */
+import { describe, it, expect } from 'vitest';
+import { registerMetaTools } from '../../src/tools/meta.js';
+
+interface CapturedTool {
+  name: string;
+  description: string;
+  schema: Record<string, unknown>;
+}
+
+function fakeServer() {
+  const tools = new Map<string, CapturedTool>();
+  return {
+    tools,
+    // Mirrors the subset of McpServer.tool() that registerTool() calls.
+    tool(name: string, description: string, schema: Record<string, unknown>) {
+      tools.set(name, { name, description, schema });
+    },
+  };
+}
+
+const EXPECTED_TOOL_NAMES = ['check_for_update', 'get_server_info', 'get_tool_manifest'];
+
+describe('registerMetaTools', () => {
+  const server = fakeServer();
+  // The three handlers never touch the client during registration itself (only when
+  // actually invoked), so an empty stand-in is safe here — same pattern
+  // tests/tool-descriptions-derived.test.ts uses for registerAllTools().
+  registerMetaTools(server as never, {} as never);
+
+  it('registers exactly get_server_info, check_for_update, get_tool_manifest', () => {
+    expect([...server.tools.keys()].sort()).toEqual([...EXPECTED_TOOL_NAMES].sort());
+  });
+
+  it('all three tools take no input arguments', () => {
+    for (const name of EXPECTED_TOOL_NAMES) {
+      const tool = server.tools.get(name);
+      expect(tool, name).toBeDefined();
+      expect(Object.keys(tool!.schema)).toHaveLength(0);
+    }
+  });
+
+  it('each tool has a non-empty description', () => {
+    for (const name of EXPECTED_TOOL_NAMES) {
+      const tool = server.tools.get(name);
+      expect(tool!.description.length, name).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/tools/meta.register.test.ts
+++ b/tests/tools/meta.register.test.ts
@@ -1,12 +1,16 @@
 /**
- * registerMetaTools() (src/tools/meta.ts) — registers the three M1 self-help tools
- * (`get_server_info`, `check_for_update`, `get_tool_manifest`) against a capturing
- * fake server, mirroring the fixture shape tests/tool-error-logging.test.ts already
- * uses for registerTool(). Registration-only: none of the three handlers are invoked
- * here (get_server_info/get_tool_manifest hit the real Dockhand client / filesystem,
- * check_for_update hits the real network) — that behavior is covered by the pure
- * builders' own tests (meta.get-server-info.test.ts, meta.check-for-update.test.ts,
- * meta.tool-manifest.test.ts).
+ * registerMetaTools() (src/tools/meta.ts) — registers all six self-help tools (M1:
+ * `get_server_info`, `check_for_update`, `get_tool_manifest`; M2: `self_check`,
+ * `validate_config`, `get_runtime_stats`) against a capturing fake server, mirroring
+ * the fixture shape tests/tool-error-logging.test.ts already uses for registerTool().
+ * Registration-only: none of the six handlers are invoked here (get_server_info/
+ * get_tool_manifest hit the real Dockhand client / filesystem, check_for_update hits
+ * the real network, self_check/validate_config would hit both the real client and
+ * `fetch()` directly) — that behavior is covered by the pure builders' own tests
+ * (meta.get-server-info.test.ts, meta.check-for-update.test.ts,
+ * meta.tool-manifest.test.ts, meta.self-check.test.ts, meta.validate-config.test.ts;
+ * get_runtime_stats has no separate builder test since `getStatsSnapshot()` itself is
+ * covered by runtime-stats.test.ts).
  */
 import { describe, it, expect } from 'vitest';
 import { registerMetaTools } from '../../src/tools/meta.js';
@@ -28,20 +32,27 @@ function fakeServer() {
   };
 }
 
-const EXPECTED_TOOL_NAMES = ['check_for_update', 'get_server_info', 'get_tool_manifest'];
+const EXPECTED_TOOL_NAMES = [
+  'check_for_update',
+  'get_server_info',
+  'get_runtime_stats',
+  'get_tool_manifest',
+  'self_check',
+  'validate_config',
+];
 
 describe('registerMetaTools', () => {
   const server = fakeServer();
-  // The three handlers never touch the client during registration itself (only when
+  // The six handlers never touch the client during registration itself (only when
   // actually invoked), so an empty stand-in is safe here — same pattern
   // tests/tool-descriptions-derived.test.ts uses for registerAllTools().
   registerMetaTools(server as never, {} as never);
 
-  it('registers exactly get_server_info, check_for_update, get_tool_manifest', () => {
+  it('registers exactly the six self-help tools (M1 + M2)', () => {
     expect([...server.tools.keys()].sort()).toEqual([...EXPECTED_TOOL_NAMES].sort());
   });
 
-  it('all three tools take no input arguments', () => {
+  it('all six tools take no input arguments', () => {
     for (const name of EXPECTED_TOOL_NAMES) {
       const tool = server.tools.get(name);
       expect(tool, name).toBeDefined();

--- a/tests/tools/meta.self-check.test.ts
+++ b/tests/tools/meta.self-check.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { runSelfCheck } from '../../src/tools/meta.js';
+import type { SelfCheckEnvironment } from '../../src/tools/meta.js';
 
 describe('runSelfCheck', () => {
   it('reports ok when Dockhand is reachable, auth is valid, and all environments are reachable', async () => {
@@ -113,6 +114,45 @@ describe('runSelfCheck', () => {
     expect(result.dockhandReachable).toBe(true);
     expect(result.environments).toEqual([]);
     expect(result.overall).toBe('degraded');
+  });
+
+  it('returns degraded within the phase deadline (not a hang) when the auth probe never resolves (Fix round 3, Finding 2)', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: () => new Promise<boolean>(() => {}), // never settles
+      listEnvironments: async () => [{ id: 1, name: 'production', reachable: true, hawserConnected: true }],
+      phaseTimeoutMs: 20,
+    });
+
+    expect(result.dockhandReachable).toBe(true);
+    expect(result.authValid).toBe(false);
+    expect(result.overall).toBe('degraded');
+  });
+
+  it('returns degraded within the phase deadline (not a hang) when the environments probe never resolves', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: () => new Promise<SelfCheckEnvironment[]>(() => {}), // never settles
+      phaseTimeoutMs: 20,
+    });
+
+    expect(result.dockhandReachable).toBe(true);
+    expect(result.authValid).toBe(true);
+    expect(result.environments).toEqual([]);
+    expect(result.overall).toBe('degraded');
+  });
+
+  it('returns down within the phase deadline (not a hang) when the health probe never resolves', async () => {
+    const result = await runSelfCheck({
+      probeHealth: () => new Promise<void>(() => {}), // never settles
+      probeAuth: async () => true,
+      listEnvironments: async () => [],
+      phaseTimeoutMs: 20,
+    });
+
+    expect(result.dockhandReachable).toBe(false);
+    expect(result.overall).toBe('down');
   });
 
   it('uses the injected clock to measure latency deterministically', async () => {

--- a/tests/tools/meta.self-check.test.ts
+++ b/tests/tools/meta.self-check.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { runSelfCheck } from '../../src/tools/meta.js';
+
+describe('runSelfCheck', () => {
+  it('reports ok when Dockhand is reachable, auth is valid, and all environments are reachable', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: async () => [
+        { id: 1, name: 'production', reachable: true, hawserConnected: true },
+        { id: 2, name: 'staging', reachable: true, hawserConnected: false },
+      ],
+    });
+
+    expect(result.dockhandReachable).toBe(true);
+    expect(result.authValid).toBe(true);
+    expect(typeof result.latencyMs).toBe('number');
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.environments).toHaveLength(2);
+    expect(result.overall).toBe('ok');
+  });
+
+  it('reports degraded when the auth probe signals an invalid credential (401)', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => false,
+      listEnvironments: async () => [
+        { id: 1, name: 'production', reachable: true, hawserConnected: true },
+      ],
+    });
+
+    expect(result.dockhandReachable).toBe(true);
+    expect(result.authValid).toBe(false);
+    expect(result.overall).toBe('degraded');
+  });
+
+  it('reports degraded when at least one environment is unreachable, even with valid auth', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: async () => [
+        { id: 1, name: 'production', reachable: true, hawserConnected: true },
+        { id: 2, name: 'offline-site', reachable: false, hawserConnected: false },
+      ],
+    });
+
+    expect(result.authValid).toBe(true);
+    expect(result.overall).toBe('degraded');
+  });
+
+  it('reports down when the health probe throws (unreachable/timeout), without calling auth or environments probes', async () => {
+    let authProbeCalled = false;
+    let envProbeCalled = false;
+
+    const result = await runSelfCheck({
+      probeHealth: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+      probeAuth: async () => {
+        authProbeCalled = true;
+        return true;
+      },
+      listEnvironments: async () => {
+        envProbeCalled = true;
+        return [];
+      },
+    });
+
+    expect(result.dockhandReachable).toBe(false);
+    expect(result.authValid).toBe(false);
+    expect(result.environments).toEqual([]);
+    expect(result.overall).toBe('down');
+    expect(typeof result.latencyMs).toBe('number');
+    expect(authProbeCalled).toBe(false);
+    expect(envProbeCalled).toBe(false);
+  });
+
+  it('reports down when the health probe times out (rejects)', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {
+        return Promise.reject(new Error('timeout'));
+      },
+      probeAuth: async () => true,
+      listEnvironments: async () => [],
+    });
+
+    expect(result.dockhandReachable).toBe(false);
+    expect(result.overall).toBe('down');
+  });
+
+  it('never includes secret values (e.g. tokens) in the result — outcome-only verification', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: async () => [{ id: 1, name: 'production', reachable: true, hawserConnected: true }],
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toMatch(/token/i);
+    expect(serialized).not.toMatch(/secret/i);
+    expect(serialized).not.toMatch(/password/i);
+  });
+
+  it('degrades gracefully (does not throw) if the environments probe itself fails', async () => {
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: async () => {
+        throw new Error('network error listing environments');
+      },
+    });
+
+    expect(result.dockhandReachable).toBe(true);
+    expect(result.environments).toEqual([]);
+    expect(result.overall).toBe('degraded');
+  });
+
+  it('uses the injected clock to measure latency deterministically', async () => {
+    const timestamps = [1000, 1250];
+    const result = await runSelfCheck({
+      probeHealth: async () => {},
+      probeAuth: async () => true,
+      listEnvironments: async () => [],
+      now: () => timestamps.shift()!,
+    });
+
+    expect(result.latencyMs).toBe(250);
+  });
+});

--- a/tests/tools/meta.tool-manifest.test.ts
+++ b/tests/tools/meta.tool-manifest.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildToolManifest } from '../../src/tools/meta.js';
+
+describe('buildToolManifest', () => {
+  it('lists tools with endpoints and the pinned Dockhand OpenAPI identity', () => {
+    const m = buildToolManifest({
+      endpointMap: { get_container: { method: 'GET', path: '/containers/{id}' } },
+      openApiCommit: 'abcdef0',
+      openApiVersion: '1.0.41',
+      generatedAt: '2026-08-11T00:00:00Z',
+    });
+    expect(m.toolCount).toBe(1);
+    expect(m.tools[0]).toEqual({ name: 'get_container', method: 'GET', path: '/containers/{id}' });
+    expect(m.dockhandOpenApiCommit).toBe('abcdef0');
+    expect(m.dockhandOpenApiVersion).toBe('1.0.41');
+  });
+
+  it('reflects an empty endpoint map as zero tools', () => {
+    const m = buildToolManifest({
+      endpointMap: {},
+      openApiCommit: 'abcdef0',
+      openApiVersion: '1.0.41',
+      generatedAt: '2026-08-11T00:00:00Z',
+    });
+    expect(m.toolCount).toBe(0);
+    expect(m.tools).toEqual([]);
+  });
+
+  it('passes generatedAt through unchanged', () => {
+    const m = buildToolManifest({
+      endpointMap: {},
+      openApiCommit: 'abcdef0',
+      openApiVersion: '1.0.41',
+      generatedAt: '2026-08-11T00:00:00Z',
+    });
+    expect(m.generatedAt).toBe('2026-08-11T00:00:00Z');
+  });
+});

--- a/tests/tools/meta.tool-manifest.test.ts
+++ b/tests/tools/meta.tool-manifest.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { buildToolManifest } from '../../src/tools/meta.js';
+import { buildToolManifest, META_TOOL_NAMES } from '../../src/tools/meta.js';
 
 describe('buildToolManifest', () => {
   it('lists tools with endpoints and the pinned Dockhand OpenAPI identity', () => {
     const m = buildToolManifest({
       endpointMap: { get_container: { method: 'GET', path: '/containers/{id}' } },
+      metaToolNames: [],
       openApiCommit: 'abcdef0',
       openApiVersion: '1.0.41',
       generatedAt: '2026-08-11T00:00:00Z',
@@ -15,9 +16,10 @@ describe('buildToolManifest', () => {
     expect(m.dockhandOpenApiVersion).toBe('1.0.41');
   });
 
-  it('reflects an empty endpoint map as zero tools', () => {
+  it('reflects an empty endpoint map and empty meta tool list as zero tools', () => {
     const m = buildToolManifest({
       endpointMap: {},
+      metaToolNames: [],
       openApiCommit: 'abcdef0',
       openApiVersion: '1.0.41',
       generatedAt: '2026-08-11T00:00:00Z',
@@ -29,10 +31,62 @@ describe('buildToolManifest', () => {
   it('passes generatedAt through unchanged', () => {
     const m = buildToolManifest({
       endpointMap: {},
+      metaToolNames: [],
       openApiCommit: 'abcdef0',
       openApiVersion: '1.0.41',
       generatedAt: '2026-08-11T00:00:00Z',
     });
     expect(m.generatedAt).toBe('2026-08-11T00:00:00Z');
+  });
+
+  describe('meta tools (Fix round 2, Finding 4: get_tool_manifest must list every registered tool, including itself)', () => {
+    it('appends each meta tool name with method:null, path:null', () => {
+      const m = buildToolManifest({
+        endpointMap: { get_container: { method: 'GET', path: '/containers/{id}' } },
+        metaToolNames: ['self_check', 'get_tool_manifest'],
+        openApiCommit: 'abcdef0',
+        openApiVersion: '1.0.41',
+        generatedAt: '2026-08-11T00:00:00Z',
+      });
+
+      expect(m.toolCount).toBe(3);
+      expect(m.tools).toContainEqual({ name: 'get_container', method: 'GET', path: '/containers/{id}' });
+      expect(m.tools).toContainEqual({ name: 'self_check', method: null, path: null });
+      expect(m.tools).toContainEqual({ name: 'get_tool_manifest', method: null, path: null });
+    });
+
+    it('toolCount equals endpointMap size plus metaToolNames length, and the manifest never omits get_tool_manifest itself', () => {
+      const endpointMap = {
+        get_container: { method: 'GET', path: '/containers/{id}' },
+        list_containers: { method: 'GET', path: '/containers' },
+      };
+      const m = buildToolManifest({
+        endpointMap,
+        metaToolNames: META_TOOL_NAMES,
+        openApiCommit: 'abcdef0',
+        openApiVersion: '1.0.41',
+        generatedAt: '2026-08-11T00:00:00Z',
+      });
+
+      expect(m.toolCount).toBe(Object.keys(endpointMap).length + META_TOOL_NAMES.length);
+      expect(m.tools.map((t) => t.name)).toContain('get_tool_manifest');
+      expect(m.tools.map((t) => t.name)).toEqual(expect.arrayContaining([...META_TOOL_NAMES]));
+    });
+
+    it('every META_TOOL_NAMES entry in the built manifest has method:null and path:null', () => {
+      const m = buildToolManifest({
+        endpointMap: {},
+        metaToolNames: META_TOOL_NAMES,
+        openApiCommit: 'abcdef0',
+        openApiVersion: '1.0.41',
+        generatedAt: '2026-08-11T00:00:00Z',
+      });
+
+      for (const name of META_TOOL_NAMES) {
+        const entry = m.tools.find((t) => t.name === name);
+        expect(entry, name).toBeDefined();
+        expect(entry).toEqual({ name, method: null, path: null });
+      }
+    });
   });
 });

--- a/tests/tools/meta.validate-config.test.ts
+++ b/tests/tools/meta.validate-config.test.ts
@@ -19,13 +19,13 @@ describe('validateConfig', () => {
     }
   });
 
-  it('reports all env present and valid credentials when the login probe returns 200', async () => {
+  it('reports all env present and valid credentials when the login probe completes auth (200 + session cookie)', async () => {
     process.env.DOCKHAND_URL = 'https://dock.example.test';
     process.env.DOCKHAND_USERNAME = 'admin';
     process.env.DOCKHAND_PASSWORD = 'super-secret-password';
 
     const result = await validateConfig({
-      attemptLogin: async () => 200,
+      attemptLogin: async () => ({ statusCode: 200, completedAuth: true }),
     });
 
     expect(result).toEqual({
@@ -48,7 +48,7 @@ describe('validateConfig', () => {
     const result = await validateConfig({
       attemptLogin: async () => {
         loginCalled = true;
-        return 200;
+        return { statusCode: 200, completedAuth: true };
       },
     });
 
@@ -68,11 +68,28 @@ describe('validateConfig', () => {
     process.env.DOCKHAND_PASSWORD = 'wrong-password';
 
     const result = await validateConfig({
-      attemptLogin: async () => 401,
+      attemptLogin: async () => ({ statusCode: 401, completedAuth: false }),
     });
 
     expect(result.credentialsValid).toBe(false);
     expect(result.statusCode).toBe(401);
+  });
+
+  it('reports credentialsValid:false while still surfacing statusCode:200 for a 200-but-MFA-pending login (Fix round 2, Finding 3)', async () => {
+    // The core of the fix: a 200 response is not on its own proof of a completed,
+    // non-interactively-usable login — an MFA account returns 200 + requiresMfa:true
+    // with no session cookie. attemptRawLogin() (the real wiring) turns that into
+    // completedAuth:false while still reporting the true statusCode.
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'mfa-user';
+    process.env.DOCKHAND_PASSWORD = 'correct-password-but-mfa-required';
+
+    const result = await validateConfig({
+      attemptLogin: async () => ({ statusCode: 200, completedAuth: false }),
+    });
+
+    expect(result.credentialsValid).toBe(false);
+    expect(result.statusCode).toBe(200);
   });
 
   it('degrades to credentialsValid:false, statusCode:null when the login probe throws (network error)', async () => {
@@ -96,7 +113,7 @@ describe('validateConfig', () => {
     process.env.DOCKHAND_PASSWORD = 'sentinel-password-value';
 
     const result = await validateConfig({
-      attemptLogin: async () => 200,
+      attemptLogin: async () => ({ statusCode: 200, completedAuth: true }),
     });
 
     const serialized = JSON.stringify(result);

--- a/tests/tools/meta.validate-config.test.ts
+++ b/tests/tools/meta.validate-config.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateConfig } from '../../src/tools/meta.js';
+
+const ENV_KEYS = ['DOCKHAND_URL', 'DOCKHAND_USERNAME', 'DOCKHAND_PASSWORD'] as const;
+
+describe('validateConfig', () => {
+  const originalEnv: Record<string, string | undefined> = {};
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key];
+  }
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+  });
+
+  it('reports all env present and valid credentials when the login probe returns 200', async () => {
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'admin';
+    process.env.DOCKHAND_PASSWORD = 'super-secret-password';
+
+    const result = await validateConfig({
+      attemptLogin: async () => 200,
+    });
+
+    expect(result).toEqual({
+      requiredEnvPresent: {
+        DOCKHAND_URL: true,
+        DOCKHAND_USERNAME: true,
+        DOCKHAND_PASSWORD: true,
+      },
+      credentialsValid: true,
+      statusCode: 200,
+    });
+  });
+
+  it('does not attempt a login when a required env var (DOCKHAND_PASSWORD) is missing', async () => {
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'admin';
+    delete process.env.DOCKHAND_PASSWORD;
+
+    let loginCalled = false;
+    const result = await validateConfig({
+      attemptLogin: async () => {
+        loginCalled = true;
+        return 200;
+      },
+    });
+
+    expect(result.requiredEnvPresent).toEqual({
+      DOCKHAND_URL: true,
+      DOCKHAND_USERNAME: true,
+      DOCKHAND_PASSWORD: false,
+    });
+    expect(loginCalled).toBe(false);
+    expect(result.credentialsValid).toBe(false);
+    expect(result.statusCode).toBeNull();
+  });
+
+  it('reports invalid credentials when the login probe returns 401', async () => {
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'admin';
+    process.env.DOCKHAND_PASSWORD = 'wrong-password';
+
+    const result = await validateConfig({
+      attemptLogin: async () => 401,
+    });
+
+    expect(result.credentialsValid).toBe(false);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('degrades to credentialsValid:false, statusCode:null when the login probe throws (network error)', async () => {
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'admin';
+    process.env.DOCKHAND_PASSWORD = 'super-secret-password';
+
+    const result = await validateConfig({
+      attemptLogin: async () => {
+        throw new Error('ECONNREFUSED');
+      },
+    });
+
+    expect(result.credentialsValid).toBe(false);
+    expect(result.statusCode).toBeNull();
+  });
+
+  it('never includes secret env values (username/password) in the result — secret-safe by construction', async () => {
+    process.env.DOCKHAND_URL = 'https://dock.example.test';
+    process.env.DOCKHAND_USERNAME = 'sentinel-username-value';
+    process.env.DOCKHAND_PASSWORD = 'sentinel-password-value';
+
+    const result = await validateConfig({
+      attemptLogin: async () => 200,
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('sentinel-username-value');
+    expect(serialized).not.toContain('sentinel-password-value');
+  });
+});

--- a/tests/tools/meta.with-timeout.test.ts
+++ b/tests/tools/meta.with-timeout.test.ts
@@ -1,0 +1,42 @@
+/**
+ * withTimeout() (src/tools/meta.ts) — generic promise-vs-timeout race extracted for
+ * Fix round 1 (Finding 1 of the Task 9 review): bounds each per-environment
+ * `POST /api/environments/{id}/test` probe in `self_check`'s `listEnvironments` wiring
+ * so one hung environment cannot make `self_check` itself hang. Uses small real
+ * timeouts (no fake-timer infrastructure exists elsewhere in this suite) — kept short
+ * enough that the whole file runs in well under a second.
+ */
+import { describe, it, expect } from 'vitest';
+import { withTimeout } from '../../src/tools/meta.js';
+
+function delay<T>(value: T, ms: number): Promise<T> {
+  return new Promise((resolve) => setTimeout(() => resolve(value), ms));
+}
+
+function delayReject(error: Error, ms: number): Promise<never> {
+  return new Promise((_, reject) => setTimeout(() => reject(error), ms));
+}
+
+describe('withTimeout', () => {
+  it('resolves with the wrapped promise\'s value when it settles well before the timeout', async () => {
+    await expect(withTimeout(delay('ok', 5), 200)).resolves.toBe('ok');
+  });
+
+  it('resolves synchronously-fulfilled promises (already-settled input)', async () => {
+    await expect(withTimeout(Promise.resolve(42), 200)).resolves.toBe(42);
+  });
+
+  it('rejects with the wrapped promise\'s own error when it rejects before the timeout', async () => {
+    await expect(withTimeout(delayReject(new Error('boom'), 5), 200)).rejects.toThrow('boom');
+  });
+
+  it('rejects with a timeout error when the wrapped promise never settles in time', async () => {
+    // Never resolves/rejects within the test's lifetime — withTimeout must still win.
+    const neverSettles = new Promise<string>(() => {});
+    await expect(withTimeout(neverSettles, 10)).rejects.toThrow(/Timed out after 10ms/);
+  });
+
+  it('rejects with a timeout error when the wrapped promise settles AFTER the timeout', async () => {
+    await expect(withTimeout(delay('too-late', 100), 10)).rejects.toThrow(/Timed out/);
+  });
+});

--- a/tests/utils/redact.test.ts
+++ b/tests/utils/redact.test.ts
@@ -1,0 +1,51 @@
+/**
+ * redactQueryStrings() (src/utils/redact.ts) — the single, shared implementation used by
+ * both `DockhandClient` (source: error-message construction, Fix round 3, Item B) and
+ * `src/utils/runtime-stats.ts` (defense-in-depth). Extracted so the regex is never
+ * duplicated and cannot drift between the two call sites.
+ */
+import { describe, it, expect } from 'vitest';
+import { redactQueryStrings, QUERY_STRING_REDACTION_MARKER } from '../../src/utils/redact.js';
+
+describe('redactQueryStrings', () => {
+  it('replaces a query string carrying a secret with the redaction marker', () => {
+    const message = 'Dockhand API error: GET https://dockhand.example/api/git/stacks/7/webhook?secret=abc123def returned 500: boom';
+    const result = redactQueryStrings(message);
+
+    expect(result).not.toContain('abc123def');
+    expect(result).toContain(`?${QUERY_STRING_REDACTION_MARKER}`);
+  });
+
+  it('leaves a message with no query string unchanged', () => {
+    const message = 'Dockhand API error: PUT /api/stacks/foo/env returned 500: boom';
+    expect(redactQueryStrings(message)).toBe(message);
+  });
+
+  it('redacts multiple query params on the same URL as a single marker (key and value both gone)', () => {
+    const message = 'Dockhand API error: GET /api/git/stacks/7/webhook?secret=abc123def&x=1 returned 500: boom';
+    const result = redactQueryStrings(message);
+
+    expect(result).not.toContain('abc123def');
+    expect(result).not.toContain('x=1');
+    expect(result).toContain(`?${QUERY_STRING_REDACTION_MARKER}`);
+  });
+
+  it('redacts each query string independently when a message embeds more than one URL', () => {
+    const message = 'first https://a.example/x?secret=aaa then https://b.example/y?token=bbb';
+    const result = redactQueryStrings(message);
+
+    expect(result).not.toContain('aaa');
+    expect(result).not.toContain('bbb');
+    expect((result.match(/\?<redacted>/g) ?? []).length).toBe(2);
+  });
+
+  it('is idempotent — redacting an already-redacted message changes nothing further', () => {
+    const once = redactQueryStrings('GET /x?secret=abc123 returned 500');
+    const twice = redactQueryStrings(once);
+    expect(twice).toBe(once);
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(redactQueryStrings('')).toBe('');
+  });
+});

--- a/tests/utils/runtime-stats.test.ts
+++ b/tests/utils/runtime-stats.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordCall, recordError, getStatsSnapshot, __resetStats } from '../../src/utils/runtime-stats.js';
+
+describe('runtime-stats', () => {
+  beforeEach(() => {
+    __resetStats();
+  });
+
+  it('recordCall increments the global and per-tool call counters', () => {
+    recordCall('x');
+    recordCall('x');
+    const snap = getStatsSnapshot();
+    expect(snap.requestCount).toBeGreaterThanOrEqual(2);
+    expect(snap.perTool['x']?.calls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('recordCall tracks separate tools independently', () => {
+    recordCall('x');
+    recordCall('y');
+    recordCall('y');
+    const snap = getStatsSnapshot();
+    expect(snap.perTool['x']?.calls).toBe(1);
+    expect(snap.perTool['y']?.calls).toBe(2);
+  });
+
+  it('recordError increments the global and per-tool error counters and sets lastError', () => {
+    recordCall('x');
+    recordError('x', 'boom');
+    const snap = getStatsSnapshot();
+    expect(snap.errorCount).toBeGreaterThanOrEqual(1);
+    expect(snap.perTool['x']?.errors).toBeGreaterThanOrEqual(1);
+    expect(snap.lastError).toMatchObject({ tool: 'x', message: 'boom' });
+    expect(typeof snap.lastError?.at).toBe('string');
+  });
+
+  it('recordError overwrites lastError with the most recent failure', () => {
+    recordError('a', 'first');
+    recordError('b', 'second');
+    const snap = getStatsSnapshot();
+    expect(snap.lastError).toMatchObject({ tool: 'b', message: 'second' });
+  });
+
+  it('getStatsSnapshot exposes startedAt as an ISO timestamp', () => {
+    const snap = getStatsSnapshot();
+    expect(typeof snap.startedAt).toBe('string');
+    expect(() => new Date(snap.startedAt).toISOString()).not.toThrow();
+  });
+
+  it('getStatsSnapshot has the expected shape with zero counters after reset', () => {
+    const snap = getStatsSnapshot();
+    expect(snap).toMatchObject({
+      requestCount: 0,
+      errorCount: 0,
+      perTool: {},
+      lastError: null,
+    });
+  });
+
+  it('snapshot never contains argument or response payloads — only counters and lastError.{tool,message,at}', () => {
+    recordCall('x');
+    recordError('x', 'boom');
+    const snap = getStatsSnapshot();
+    const serialized = JSON.stringify(snap);
+
+    // Structural guarantee: lastError has exactly the three safe keys.
+    expect(Object.keys(snap.lastError ?? {}).sort()).toEqual(['at', 'message', 'tool']);
+
+    // No accidental extra top-level keys that could carry payload data.
+    expect(Object.keys(snap).sort()).toEqual(
+      ['errorCount', 'lastError', 'perTool', 'requestCount', 'startedAt'].sort()
+    );
+
+    // perTool entries only ever carry the two numeric counters.
+    for (const entry of Object.values(snap.perTool)) {
+      expect(Object.keys(entry).sort()).toEqual(['calls', 'errors']);
+    }
+
+    // Nothing resembling an args/response/payload key ever appears anywhere in the snapshot.
+    expect(serialized).not.toMatch(/"(args|arguments|payload|response|result)"/);
+  });
+
+  it('__resetStats clears all counters and lastError', () => {
+    recordCall('x');
+    recordError('x', 'boom');
+    __resetStats();
+    const snap = getStatsSnapshot();
+    expect(snap.requestCount).toBe(0);
+    expect(snap.errorCount).toBe(0);
+    expect(snap.perTool).toEqual({});
+    expect(snap.lastError).toBeNull();
+  });
+});

--- a/tests/utils/runtime-stats.test.ts
+++ b/tests/utils/runtime-stats.test.ts
@@ -81,6 +81,42 @@ describe('runtime-stats', () => {
     });
   });
 
+  describe('recordError redacts URL query strings before storing (Self-Help Final Fix Wave, Finding 1 / P1 security)', () => {
+    // trigger_git_webhook (src/tools/git-stacks.ts) calls client.get(url, { secret }), which
+    // DockhandClient turns into a `?secret=<value>` query param. On failure that URL lands
+    // verbatim inside `Dockhand API error: ${method} ${url} returned …`. get_runtime_stats
+    // echoes lastError.message to a DIFFERENT MCP client than the one that failed, so the
+    // secret must never survive into the stored/snapshotted message.
+
+    it('redacts a secret carried in a query string and shows the redaction marker', () => {
+      const message =
+        'Dockhand API error: GET https://dockhand.example/api/git/stacks/7/webhook?secret=abc123def returned 500: Internal Server Error';
+      recordError('trigger_git_webhook', message);
+      const snap = getStatsSnapshot();
+      const stored = snap.lastError?.message ?? '';
+      expect(stored).not.toContain('abc123def');
+      expect(stored).toContain('?<redacted>');
+    });
+
+    it('leaves a message with no query string unchanged', () => {
+      const message = 'Dockhand API error: PUT /api/stacks/foo/env returned 500: boom';
+      recordError('update_stack_env', message);
+      const snap = getStatsSnapshot();
+      expect(snap.lastError?.message).toBe(message);
+    });
+
+    it('redacts multiple query params on the same URL, not just the secret key', () => {
+      const message =
+        'Dockhand API error: GET /api/git/stacks/7/webhook?secret=abc123def&x=1 returned 500: boom';
+      recordError('trigger_git_webhook', message);
+      const snap = getStatsSnapshot();
+      const stored = snap.lastError?.message ?? '';
+      expect(stored).not.toContain('abc123def');
+      expect(stored).not.toContain('x=1');
+      expect(stored).toContain('?<redacted>');
+    });
+  });
+
   it('getStatsSnapshot exposes startedAt as an ISO timestamp', () => {
     const snap = getStatsSnapshot();
     expect(typeof snap.startedAt).toBe('string');

--- a/tests/utils/runtime-stats.test.ts
+++ b/tests/utils/runtime-stats.test.ts
@@ -40,6 +40,47 @@ describe('runtime-stats', () => {
     expect(snap.lastError).toMatchObject({ tool: 'b', message: 'second' });
   });
 
+  describe('recordError bounds an unbounded upstream error message (Self-Help Final Fix Wave, Finding 2)', () => {
+    // DockhandClient.request() builds error.message as `Dockhand API error: ${method}
+    // ${url} returned ${status}: ${errorBody}` — errorBody is an upstream HTTP response
+    // body of arbitrary size. get_runtime_stats echoes lastError.message to any caller, so
+    // recordError must never store it unbounded.
+
+    it('leaves a short message unchanged', () => {
+      recordError('x', 'short message');
+      const snap = getStatsSnapshot();
+      expect(snap.lastError?.message).toBe('short message');
+    });
+
+    it('truncates a message longer than 500 characters and appends an ellipsis marker', () => {
+      const longMessage = 'a'.repeat(2000);
+      recordError('x', longMessage);
+      const snap = getStatsSnapshot();
+      const stored = snap.lastError?.message ?? '';
+      expect(stored.length).toBeLessThan(longMessage.length);
+      expect(stored.length).toBeLessThanOrEqual(501); // 500 chars + 1-char ellipsis marker
+      expect(stored.startsWith('a'.repeat(500))).toBe(true);
+      expect(stored.endsWith('…')).toBe(true);
+    });
+
+    it('leaves a message exactly at the 500-character limit unchanged (no trailing ellipsis)', () => {
+      const exactMessage = 'b'.repeat(500);
+      recordError('x', exactMessage);
+      const snap = getStatsSnapshot();
+      expect(snap.lastError?.message).toBe(exactMessage);
+      expect(snap.lastError?.message.endsWith('…')).toBe(false);
+    });
+
+    it('a realistic unbounded Dockhand upstream-body message is bounded in the stored snapshot', () => {
+      const hugeUpstreamBody = '{"error":"' + 'x'.repeat(10_000) + '"}';
+      const message = `Dockhand API error: PUT /api/stacks/foo/env returned 500: ${hugeUpstreamBody}`;
+      recordError('update_stack_env', message);
+      const snap = getStatsSnapshot();
+      expect(snap.lastError?.message.length).toBeLessThanOrEqual(501);
+      expect(snap.lastError?.message).toContain('Dockhand API error: PUT /api/stacks/foo/env returned 500:');
+    });
+  });
+
   it('getStatsSnapshot exposes startedAt as an ISO timestamp', () => {
     const snap = getStatsSnapshot();
     expect(typeof snap.startedAt).toBe('string');

--- a/tests/utils/tool-helper.runtime-stats.test.ts
+++ b/tests/utils/tool-helper.runtime-stats.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Integration coverage for the runtime-stats threading in registerTool()
+ * (src/utils/tool-helper.ts): every tool dispatch — success or failure —
+ * must bump the counters in src/utils/runtime-stats.ts without changing
+ * any of the existing error-logging/response behaviour (see
+ * tests/tool-error-logging.test.ts for that base coverage).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { registerTool } from '../../src/utils/tool-helper.js';
+import { getStatsSnapshot, __resetStats } from '../../src/utils/runtime-stats.js';
+
+interface CapturedTool {
+  name: string;
+  handler: (args: unknown) => Promise<{ content: { type: string; text: string }[]; isError?: true }>;
+}
+
+function fakeServer() {
+  const tools = new Map<string, CapturedTool>();
+  return {
+    tools,
+    tool(name: string, _description: string, _schema: unknown, handler: CapturedTool['handler']) {
+      tools.set(name, { name, handler });
+    },
+  };
+}
+
+describe('registerTool runtime-stats threading', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    __resetStats();
+  });
+
+  it('a successful call increments requestCount and perTool.calls, not errorCount', async () => {
+    __resetStats();
+    const server = fakeServer();
+    registerTool(server as never, 'get_host_info', {}, async () => {
+      return { content: [{ type: 'text' as const, text: '{}' }] };
+    });
+
+    await server.tools.get('get_host_info')!.handler({});
+
+    const snap = getStatsSnapshot();
+    expect(snap.requestCount).toBe(1);
+    expect(snap.perTool['get_host_info']).toMatchObject({ calls: 1, errors: 0 });
+    expect(snap.errorCount).toBe(0);
+  });
+
+  it('a throwing call increments requestCount, errorCount, perTool.errors, and sets lastError', async () => {
+    __resetStats();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const server = fakeServer();
+    registerTool(server as never, 'list_containers', {}, async () => {
+      throw new Error('fetch failed: ECONNREFUSED');
+    });
+
+    await server.tools.get('list_containers')!.handler({});
+
+    const snap = getStatsSnapshot();
+    expect(snap.requestCount).toBe(1);
+    expect(snap.errorCount).toBe(1);
+    expect(snap.perTool['list_containers']).toMatchObject({ calls: 1, errors: 1 });
+    expect(snap.lastError).toMatchObject({ tool: 'list_containers', message: 'fetch failed: ECONNREFUSED' });
+  });
+});

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getServerVersion, getGitSha, getBuildDate, getUptimeSeconds } from '../src/version.js';
+
+describe('version', () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  it('reads injected env, falls back when absent', () => {
+    process.env.MCP_SERVER_VERSION = '1.12.0';
+    process.env.MCP_GIT_SHA = 'abc1234';
+    process.env.MCP_BUILD_DATE = '2026-08-11T00:00:00Z';
+    expect(getServerVersion()).toBe('1.12.0');
+    expect(getGitSha()).toBe('abc1234');
+    expect(getBuildDate()).toBe('2026-08-11T00:00:00Z');
+    delete process.env.MCP_SERVER_VERSION;
+    expect(getServerVersion()).toBe('0.0.0-dev');
+  });
+
+  it('uptime is a non-negative integer', () => {
+    expect(getUptimeSeconds()).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(getUptimeSeconds())).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a "self-help / meta" tool group so a client can introspect the server itself — motivated by two real gaps: a client currently cannot tell **which server version** it is talking to, nor **which tools / Dockhand-API stand** this build exposes.

### Milestone 1 — self-info
- **`get_server_info`** — server version, git SHA, build date, uptime, MCP protocol version, the connected Dockhand URL (the client's *normalized* base URL) and Dockhand server version (best-effort, degrades to `null`).
- **`check_for_update`** — compares the running version against the latest GitHub release, cached ~1h; degrades to `updateAvailable: null` on any failure. Requires outbound access to `api.github.com`.
- **`get_tool_manifest`** — the tools this build exposes and the **pinned Dockhand OpenAPI commit/version** they map to (reuses the existing OpenAPI plumbing), so a client can detect drift. A test enforces the pinned commit stays in sync with `scripts/fetch-openapi.mjs`.

### Milestone 2 — diagnostics
- **`self_check`** — live end-to-end: Dockhand reachability, auth validity, latency, and **per-environment reachability** (`POST /api/environments/{id}/test`, run in parallel with a 5s per-call timeout) plus Hawser connection (`/api/hawser/connect`). Every probe degrades rather than throws.
- **`validate_config`** — required-env presence + credential validity via a raw login. **Secret-safe: returns presence booleans + an HTTP status code only — never any secret value.**
- **`get_runtime_stats`** — in-process request/error counters per tool and the last error (bounded to 500 chars; never request bodies or credentials).

### Supporting infrastructure
- Build-injected identity (`src/version.ts` + Dockerfile `ARG`/`ENV` + release `build-args`).
- Runtime-stats counters threaded into the shared `registerTool` wrapper (every tool auto-counted).
- `DockhandClient.getBaseUrl()` (so `get_server_info` reports the client's actual normalized URL), `specInfoVersion()`, and real MCP descriptions for all six tools via `TOOL_DESCRIPTION_OVERRIDES`.

## Testing
- **TDD throughout** — every new function has unit tests (happy + error + network-failure paths where applicable); pure, injectable builders are tested independently of the live server.
- Full suite: **760 tests, 0 failures**; `npm run build` + `npm run typecheck` clean.
- **No new runtime dependencies** (uses the global `fetch`).

## Notes
- No tool returns or logs a secret value.
- `check_for_update` requires outbound access to `api.github.com`.

Closes #185.
