### PR TITLE
feat(security): opt-in Host/Origin allowlist and bearer auth for /mcp transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,34 @@ DOCKHAND_PASSWORD=CHANGE_ME
 # MCP Server Port (optional, default: 8080)
 MCP_PORT=8080
 
+# MCP Server Listen Address (optional, default: 0.0.0.0)
+# Left as the wildcard address by default so the published Docker port keeps
+# working; the /mcp endpoint is protected via MCP_ALLOWED_HOSTS/MCP_AUTH_TOKEN
+# below instead of binding loopback-only. See README "Securing the transport".
+#MCP_HOST=0.0.0.0
+
+# Allowed `Host` header values for /mcp, comma-separated (optional, default:
+# unset = no Host check at all -- opt-in, kept off by default so existing
+# deployments aren't broken by an update). Once set, requests with any other
+# Host header get a 403 (DNS-rebinding protection). Set this to whatever
+# host:port your client actually sends -- localhost:8080/127.0.0.1:8080 for
+# the documented local setup, or your real hostname/address for a remote or
+# reverse-proxied deployment, e.g. 100.100.50.40:8222. RECOMMENDED once /mcp
+# is reachable beyond your own loopback -- see README "Securing the transport".
+#MCP_ALLOWED_HOSTS=127.0.0.1:8080,localhost:8080
+
+# Allowed `Origin` header values for /mcp, comma-separated (optional, default:
+# unset = check disabled, opt-in). Only enforced when a caller sends an Origin
+# header at all; most non-browser MCP clients never do -- MCP_ALLOWED_HOSTS
+# above is the check that actually stops DNS-rebinding.
+#MCP_ALLOWED_ORIGINS=
+
+# Shared-secret bearer token for /mcp (optional, default: unset = /mcp is
+# unauthenticated, opt-in). With this AND MCP_ALLOWED_HOSTS both unset, a
+# startup warning is logged. RECOMMENDED alongside MCP_ALLOWED_HOSTS once
+# /mcp is reachable beyond your own loopback. Generate with:
+#   openssl rand -hex 32
+#MCP_AUTH_TOKEN=CHANGE_ME
+
 # Log Level (optional, default: info)
 LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -70,7 +70,55 @@ DOCKHAND_URL=https://your-server.com DOCKHAND_USERNAME=admin DOCKHAND_PASSWORD=s
 | `MCP_SESSION_TTL_SECONDS` | No | `1800` | Inactivity timeout before a retained MCP session is expired |
 | `MCP_SESSION_CLEANUP_INTERVAL_SECONDS` | No | `300` | Interval for removing expired sessions (clamped to the session TTL) |
 | `MCP_MAX_SESSIONS` | No | `0` | Maximum retained sessions; `0` keeps the existing unlimited behavior |
+| `MCP_HOST` | No | `0.0.0.0` | Listen address. Kept as the wildcard address by default so the published Docker port (`-p 8080:8080` / `docker-compose.yml`) keeps working; see [Securing the transport](#securing-the-transport) for the recommended way to protect the endpoint instead of binding loopback-only |
+| `MCP_ALLOWED_HOSTS` | No | *(unset — Host check disabled)* | Comma-separated `Host` header allowlist for `/mcp` (DNS-rebinding protection). **Opt-in**: unset means no Host check at all (pre-existing behavior, so existing deployments aren't broken by an update). Recommended once you set it up — see [Securing the transport](#securing-the-transport) |
+| `MCP_ALLOWED_ORIGINS` | No | *(unset — Origin check disabled)* | Comma-separated `Origin` header allowlist for `/mcp`. Opt-in, same as above. Only enforced when a caller actually sends an `Origin` header at all (non-browser MCP clients typically don't) |
+| `MCP_AUTH_TOKEN` | No | *(unset — endpoint unauthenticated)* | Shared secret required as `Authorization: Bearer <token>` on every `/mcp` request. Opt-in; recommended once the endpoint is reachable beyond your own loopback — see [Securing the transport](#securing-the-transport) |
 | `LOG_LEVEL` | No | `info` | Log level |
+
+### Securing the transport
+
+`/mcp` binds `0.0.0.0:8080` by default (see `MCP_HOST` above), and out of the box — with none of
+`MCP_ALLOWED_HOSTS`, `MCP_ALLOWED_ORIGINS`, or `MCP_AUTH_TOKEN` set — it accepts **any** request
+with **no** Host/Origin check and **no** authentication. This is the same behavior mcp-dockhand
+has always had, kept as the default deliberately: enabling a check by default would reject
+requests from any client that doesn't reach the server as `localhost`/`127.0.0.1` (a LAN IP, a
+reverse proxy, a Docker network alias), breaking existing deployments on a routine update.
+
+**You should turn this on** once `/mcp` is reachable beyond your own machine's loopback interface
+— the server holds one Dockhand admin credential and every tool call acts with that identity, so
+anyone who can open an MCP session controls Docker (container exec, host bind-mounts via
+`create_container`, file read/write, stored git credentials). With no protection configured, the
+server logs a `[security] WARNING` at startup as a reminder. Three independent, all-opt-in layers
+are available:
+
+1. **Host allowlist (`MCP_ALLOWED_HOSTS`).** Once set to a non-empty value, every request to
+   `/mcp` — `POST`, `GET`, and `DELETE` — is rejected with `403` unless its `Host` header matches
+   the allowlist. This is the primary defense against
+   [DNS-rebinding](https://en.wikipedia.org/wiki/DNS_rebinding): a malicious web page cannot make
+   the operator's browser reach the server under a Host value the allowlist accepts. Set it to
+   however your client actually reaches the server — `localhost:8080`/`127.0.0.1:8080` for the
+   documented local setup, or, if you connect directly by address rather than through
+   `localhost` (including the mcp-proxy remote-server setup below), the exact `host:port` your
+   client sends, e.g. `100.100.50.40:8222`. Get this wrong and every request is rejected with
+   `403 Invalid Host header` — check the message, it echoes the Host value it saw.
+2. **Origin allowlist (`MCP_ALLOWED_ORIGINS`).** Once set, any request that *does* send an
+   `Origin` header not in the list is rejected with `403`. A missing `Origin` header always passes
+   (the SDK's own MCP client and most non-browser tooling never send one), so this is only useful
+   if a browser-based client talks to `/mcp` directly; the Host allowlist above is what actually
+   stops DNS-rebinding.
+3. **Bearer token (`MCP_AUTH_TOKEN`).** Once set, every `/mcp` request must carry
+   `Authorization: Bearer <token>` or is rejected with `401`; the comparison is constant-time.
+   Recommended alongside the Host allowlist for any deployment reachable from more than the
+   operator's own machine.
+
+```bash
+# .env — recommended configuration once /mcp is reachable beyond loopback
+MCP_ALLOWED_HOSTS=dock-mcp.internal.example.com
+# or, connecting directly by address instead of a hostname:
+#MCP_ALLOWED_HOSTS=100.100.50.40:8222
+MCP_AUTH_TOKEN=<a long random secret, e.g. `openssl rand -hex 32`>
+```
 
 ## MCP Client Configuration
 

--- a/src/auth/transport-guard.ts
+++ b/src/auth/transport-guard.ts
@@ -1,0 +1,162 @@
+/**
+ * Transport-level access control for the /mcp Streamable HTTP endpoint.
+ *
+ * Two independent, **both opt-in** layers:
+ *  - Host/Origin allowlisting (DNS-rebinding protection). Implemented as our
+ *    own Express middleware rather than the MCP SDK's transport-level
+ *    `enableDnsRebindingProtection`/`allowedHosts`/`allowedOrigins` options,
+ *    which the SDK itself marks `@deprecated` in favor of exactly this
+ *    pattern (see `@modelcontextprotocol/sdk` server/webStandardStreamableHttp.d.ts).
+ *    `server.ts` still passes the same allowlists to the transport too, as
+ *    cheap defense-in-depth, but this middleware is the primary, tested
+ *    enforcement point and runs first.
+ *  - A shared-secret bearer token, checked in constant time.
+ *
+ * Both are opt-in and OFF by default: with neither `MCP_ALLOWED_HOSTS` nor
+ * `MCP_ALLOWED_ORIGINS` set, no Host/Origin check runs at all (and the guard
+ * middleware isn't even registered — see server.ts); with `MCP_AUTH_TOKEN`
+ * unset, no bearer check runs. This is a deliberate compatibility decision:
+ * enabling either by default would reject every existing remote/reverse-
+ * proxied deployment whose client doesn't send a `localhost`/`127.0.0.1`
+ * Host header, breaking them on update. Operators opt in explicitly once the
+ * endpoint is reachable beyond their own loopback — see the README section
+ * "Securing the transport".
+ *
+ * Security note: the DNS-rebinding scenario the Host/Origin layer guards
+ * against is a browser page that gets its own hostname rebound (low-TTL DNS)
+ * to the server's loopback/LAN address. Because the browser still considers
+ * the request same-origin as the page (the URL string is unchanged), it
+ * sends the request with the *rebound* Host header (e.g.
+ * `attacker.example:8080`) but often without any Origin header for a
+ * same-origin request. Host validation therefore has to be the primary
+ * check; Origin validation is complementary and only enforced when the
+ * caller actually sends an Origin header.
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+export interface TransportSecurityConfig {
+  /** Allowed `Host` header values. Empty array disables the Host check entirely. */
+  allowedHosts: string[];
+  /** Allowed `Origin` header values. Empty array disables the Origin check entirely. */
+  allowedOrigins: string[];
+  /** Shared-secret bearer token required on every /mcp request, or undefined to leave /mcp unauthenticated. */
+  authToken: string | undefined;
+}
+
+function parseCommaList(value: string | undefined): string[] {
+  if (value === undefined) return [];
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Resolves the Host/Origin allowlists and the optional bearer token from the
+ * environment. `port` is accepted for API symmetry with the rest of the
+ * config-loading pattern in this codebase (see `getSessionLifecycleConfig`)
+ * but is not used to synthesize a default allowlist — see below.
+ *
+ * Host/Origin enforcement is **opt-in, off by default**: with
+ * `MCP_ALLOWED_HOSTS` unset (or set to an empty value), `allowedHosts` is an
+ * empty array, which `createHostOriginGuard`/the SDK transport treat as "no
+ * check" — i.e. exactly the pre-existing behavior, so already-deployed
+ * clients (including ones reaching the server via a LAN IP or a reverse
+ * proxy, not `localhost`) are not broken by an update. The same applies to
+ * `MCP_ALLOWED_ORIGINS`. Operators enable Host/Origin protection by setting
+ * `MCP_ALLOWED_HOSTS` (and optionally `MCP_ALLOWED_ORIGINS`) explicitly —
+ * see `isHostOriginEnforcementActive()` and the README "Securing the
+ * transport" section, which also covers the `host:port` form needed when
+ * connecting directly rather than via `localhost` (e.g.
+ * `100.100.50.40:8222`).
+ *
+ * `MCP_AUTH_TOKEN` is likewise opt-in: unset means `/mcp` stays
+ * unauthenticated (pre-existing behavior).
+ */
+export function getTransportSecurityConfig(
+  port: number,
+  env: NodeJS.ProcessEnv = process.env,
+): TransportSecurityConfig {
+  const allowedHosts = parseCommaList(env['MCP_ALLOWED_HOSTS']);
+  const allowedOrigins = parseCommaList(env['MCP_ALLOWED_ORIGINS']);
+  const rawToken = env['MCP_AUTH_TOKEN']?.trim();
+  const authToken = rawToken && rawToken.length > 0 ? rawToken : undefined;
+
+  return { allowedHosts, allowedOrigins, authToken };
+}
+
+/**
+ * True once the operator has opted into Host/Origin (DNS-rebinding)
+ * enforcement by setting either allowlist to a non-empty value.
+ */
+export function isHostOriginEnforcementActive(config: Pick<TransportSecurityConfig, 'allowedHosts' | 'allowedOrigins'>): boolean {
+  return config.allowedHosts.length > 0 || config.allowedOrigins.length > 0;
+}
+
+/**
+ * Rejects requests whose `Host` header is not in `allowedHosts` (when
+ * non-empty), and requests that send an `Origin` header not in
+ * `allowedOrigins` (when non-empty). A missing `Origin` header always passes
+ * — see module docs.
+ */
+export function createHostOriginGuard(allowedHosts: string[], allowedOrigins: string[]): RequestHandler {
+  const hostAllowlist = new Set(allowedHosts.map((host) => host.toLowerCase()));
+  const originAllowlist = new Set(allowedOrigins);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (hostAllowlist.size > 0) {
+      const hostHeader = req.headers.host;
+      if (!hostHeader || !hostAllowlist.has(hostHeader.toLowerCase())) {
+        res.status(403).json({ error: `Invalid Host header: ${hostHeader ?? '(missing)'}` });
+        return;
+      }
+    }
+
+    if (originAllowlist.size > 0) {
+      const originHeader = req.headers.origin;
+      if (originHeader && !originAllowlist.has(originHeader)) {
+        res.status(403).json({ error: `Invalid Origin header: ${originHeader}` });
+        return;
+      }
+    }
+
+    next();
+  };
+}
+
+const BEARER_PREFIX = 'Bearer ';
+
+function timingSafeTokenMatch(provided: string, expected: string): boolean {
+  const providedBuf = Buffer.from(provided);
+  const expectedBuf = Buffer.from(expected);
+  if (providedBuf.length !== expectedBuf.length) return false;
+  return timingSafeEqual(providedBuf, expectedBuf);
+}
+
+/**
+ * Requires `Authorization: Bearer <token>` on every request when `token` is
+ * set. When `token` is undefined the guard is a no-op (opt-in
+ * authentication) — callers MUST emit a startup warning in that case (see
+ * server.ts) so silently-unauthenticated operation is never invisible to the
+ * operator.
+ */
+export function createBearerAuthGuard(token: string | undefined): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!token) {
+      next();
+      return;
+    }
+
+    const header = req.headers.authorization;
+    const provided = header?.startsWith(BEARER_PREFIX) ? header.slice(BEARER_PREFIX.length) : undefined;
+
+    if (!provided || !timingSafeTokenMatch(provided, token)) {
+      res.status(401).json({ error: 'unauthorized' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@
  * bounded through configurable inactivity cleanup and an optional LRU cap.
  */
 
+import type { Server as HttpServer } from 'node:http';
 import { readFileSync } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -13,6 +14,12 @@ import express from 'express';
 import type { Request, Response } from 'express';
 import { DockhandClient } from './client/dockhand-client.js';
 import { registerAllTools } from './tools/index.js';
+import {
+  createBearerAuthGuard,
+  createHostOriginGuard,
+  getTransportSecurityConfig,
+  isHostOriginEnforcementActive,
+} from './auth/transport-guard.js';
 import {
   beginFoundingSession,
   completeFoundingSession,
@@ -46,9 +53,21 @@ function createMcpServer(client: DockhandClient): McpServer {
   return server;
 }
 
-export async function createServer(config: ServerConfig): Promise<void> {
+export async function createServer(config: ServerConfig): Promise<HttpServer> {
   const client = new DockhandClient(config.dockhand);
   const lifecycle = getSessionLifecycleConfig();
+  const security = getTransportSecurityConfig(config.port);
+  const hostOriginEnforced = isHostOriginEnforcementActive(security);
+  if (!hostOriginEnforced && !security.authToken) {
+    console.error(
+      '[security] WARNING: /mcp has no Host/Origin allowlist (MCP_ALLOWED_HOSTS) and no bearer token ' +
+        '(MCP_AUTH_TOKEN) configured — it accepts requests from any reachable client with no checks at all.',
+    );
+    console.error(
+      '[security] This is the compatible default. Set MCP_ALLOWED_HOSTS (DNS-rebinding protection) and ' +
+        'MCP_AUTH_TOKEN ("Authorization: Bearer <token>") once this endpoint is reachable beyond loopback.',
+    );
+  }
   const app = express();
   app.use(express.json());
 
@@ -138,6 +157,22 @@ export async function createServer(config: ServerConfig): Promise<void> {
   }, lifecycle.cleanupIntervalMs);
   cleanupInterval.unref();
 
+  // DNS-rebinding protection (Host/Origin allowlist) and the opt-in bearer
+  // token guard the whole /mcp surface (POST/GET/DELETE) — registered ahead
+  // of the route handlers below so a rejected request never reaches session
+  // lookup or the MCP SDK transport. See src/auth/transport-guard.ts.
+  //
+  // The Host/Origin guard is only *registered* when the operator opted in
+  // (MCP_ALLOWED_HOSTS and/or MCP_ALLOWED_ORIGINS set): with neither set,
+  // omitting the middleware entirely reproduces the pre-existing behavior
+  // exactly, rather than relying on an always-registered guard that happens
+  // to no-op on empty allowlists. createBearerAuthGuard is always
+  // registered — it is already a no-op when no token is configured.
+  if (hostOriginEnforced) {
+    app.use('/mcp', createHostOriginGuard(security.allowedHosts, security.allowedOrigins));
+  }
+  app.use('/mcp', createBearerAuthGuard(security.authToken));
+
   app.post('/mcp', async (req: Request, res: Response) => {
     try {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
@@ -164,6 +199,16 @@ export async function createServer(config: ServerConfig): Promise<void> {
       try {
         transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => crypto.randomUUID(),
+          // Defense-in-depth, mirroring the opt-in Express guard above: only
+          // enabled when the operator actually configured an allowlist, so
+          // an unconfigured deployment sees the SDK's own compatible
+          // default (false) unchanged. The SDK marks these transport-level
+          // options @deprecated in favor of external middleware, but
+          // passing them costs nothing and covers any future call path that
+          // bypasses the Express middleware chain.
+          enableDnsRebindingProtection: hostOriginEnforced,
+          allowedHosts: security.allowedHosts,
+          allowedOrigins: security.allowedOrigins,
           onsessioninitialized: (id) => {
             initializedSessionId = id;
             // Mark the session busy (activeRequests: 1) immediately: the
@@ -253,13 +298,16 @@ export async function createServer(config: ServerConfig): Promise<void> {
   });
 
   const host = config.host || '0.0.0.0';
-  app.listen(config.port, host, () => {
-    console.error(`[server] MCP Dockhand server v${pkg.version} listening on ${host}:${config.port}`);
-    console.error(`[server] Dockhand URL: ${config.dockhand.url}`);
-    console.error(`[server] Health: http://localhost:${config.port}/health`);
-    console.error(`[server] MCP endpoint: http://localhost:${config.port}/mcp`);
-    console.error(
-      `[session] Lifecycle ttl=${lifecycle.inactivityTimeoutMs / 1000}s cleanup=${lifecycle.cleanupIntervalMs / 1000}s max=${lifecycle.maxSessions === 0 ? 'unlimited' : lifecycle.maxSessions}`,
-    );
+  return await new Promise<HttpServer>((resolve) => {
+    const httpServer = app.listen(config.port, host, () => {
+      console.error(`[server] MCP Dockhand server v${pkg.version} listening on ${host}:${config.port}`);
+      console.error(`[server] Dockhand URL: ${config.dockhand.url}`);
+      console.error(`[server] Health: http://localhost:${config.port}/health`);
+      console.error(`[server] MCP endpoint: http://localhost:${config.port}/mcp`);
+      console.error(
+        `[session] Lifecycle ttl=${lifecycle.inactivityTimeoutMs / 1000}s cleanup=${lifecycle.cleanupIntervalMs / 1000}s max=${lifecycle.maxSessions === 0 ? 'unlimited' : lifecycle.maxSessions}`,
+      );
+      resolve(httpServer);
+    });
   });
 }

--- a/tests/transport-guard.test.ts
+++ b/tests/transport-guard.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Request, Response } from 'express';
+import {
+  createBearerAuthGuard,
+  createHostOriginGuard,
+  getTransportSecurityConfig,
+  isHostOriginEnforcementActive,
+} from '../src/auth/transport-guard.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// --- getTransportSecurityConfig -------------------------------------------
+
+describe('getTransportSecurityConfig', () => {
+  it('defaults allowedHosts to an empty (disabled) allowlist when MCP_ALLOWED_HOSTS is unset -- opt-in, compatible default', () => {
+    const config = getTransportSecurityConfig(8080, {});
+    expect(config.allowedHosts).toEqual([]);
+  });
+
+  it('defaults MCP_ALLOWED_ORIGINS to an empty (disabled) allowlist when unset', () => {
+    const config = getTransportSecurityConfig(8080, {});
+    expect(config.allowedOrigins).toEqual([]);
+  });
+
+  it('does not derive a default allowlist from the port when MCP_ALLOWED_HOSTS is unset, regardless of port value', () => {
+    const config = getTransportSecurityConfig(48213, {});
+    expect(config.allowedHosts).toEqual([]);
+  });
+
+  it('defaults authToken to undefined when MCP_AUTH_TOKEN is unset', () => {
+    const config = getTransportSecurityConfig(8080, {});
+    expect(config.authToken).toBeUndefined();
+  });
+
+  it('parses a comma-separated MCP_ALLOWED_HOSTS, trimming whitespace', () => {
+    const config = getTransportSecurityConfig(8080, {
+      MCP_ALLOWED_HOSTS: ' dock.strausmann.cloud , 127.0.0.1:8080 ',
+    });
+    expect(config.allowedHosts).toEqual(['dock.strausmann.cloud', '127.0.0.1:8080']);
+  });
+
+  it('an explicit empty MCP_ALLOWED_HOSTS disables the Host allowlist (empty array, not the default)', () => {
+    const config = getTransportSecurityConfig(8080, { MCP_ALLOWED_HOSTS: '' });
+    expect(config.allowedHosts).toEqual([]);
+  });
+
+  it('parses a comma-separated MCP_ALLOWED_ORIGINS', () => {
+    const config = getTransportSecurityConfig(8080, {
+      MCP_ALLOWED_ORIGINS: 'https://a.example, https://b.example',
+    });
+    expect(config.allowedOrigins).toEqual(['https://a.example', 'https://b.example']);
+  });
+
+  it('reads MCP_AUTH_TOKEN and trims surrounding whitespace', () => {
+    const config = getTransportSecurityConfig(8080, { MCP_AUTH_TOKEN: '  s3cr3t  ' });
+    expect(config.authToken).toBe('s3cr3t');
+  });
+
+  it('treats a blank/whitespace-only MCP_AUTH_TOKEN as unset', () => {
+    const config = getTransportSecurityConfig(8080, { MCP_AUTH_TOKEN: '   ' });
+    expect(config.authToken).toBeUndefined();
+  });
+
+  it('defaults to process.env when no env argument is passed', () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', 'stubbed.example:1234');
+    const config = getTransportSecurityConfig(1234);
+    expect(config.allowedHosts).toEqual(['stubbed.example:1234']);
+  });
+});
+
+// --- isHostOriginEnforcementActive -----------------------------------------
+
+describe('isHostOriginEnforcementActive', () => {
+  it('is false when both allowlists are empty (compatible default)', () => {
+    expect(isHostOriginEnforcementActive({ allowedHosts: [], allowedOrigins: [] })).toBe(false);
+  });
+
+  it('is true when allowedHosts is non-empty', () => {
+    expect(isHostOriginEnforcementActive({ allowedHosts: ['localhost:8080'], allowedOrigins: [] })).toBe(true);
+  });
+
+  it('is true when allowedOrigins is non-empty', () => {
+    expect(isHostOriginEnforcementActive({ allowedHosts: [], allowedOrigins: ['https://good.example'] })).toBe(true);
+  });
+});
+
+// --- createHostOriginGuard --------------------------------------------------
+
+function mockReqRes(headers: Record<string, string | undefined>) {
+  const req = { headers } as unknown as Request;
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status } as unknown as Response;
+  const next = vi.fn();
+  return { req, res, status, json, next };
+}
+
+describe('createHostOriginGuard', () => {
+  it('allows a request whose Host header is in the allowlist', () => {
+    const guard = createHostOriginGuard(['127.0.0.1:8080'], []);
+    const { req, res, next, status } = mockReqRes({ host: '127.0.0.1:8080' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('matches the Host allowlist case-insensitively', () => {
+    const guard = createHostOriginGuard(['Localhost:8080'], []);
+    const { req, res, next } = mockReqRes({ host: 'LOCALHOST:8080' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a request whose Host header is not in the allowlist (403)', () => {
+    const guard = createHostOriginGuard(['127.0.0.1:8080', 'localhost:8080'], []);
+    const { req, res, next, status, json } = mockReqRes({ host: 'evil.attacker.example' });
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('Invalid Host header') }));
+  });
+
+  it('rejects a request with no Host header at all when an allowlist is configured', () => {
+    const guard = createHostOriginGuard(['127.0.0.1:8080'], []);
+    const { req, res, next, status } = mockReqRes({});
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it('skips the Host check entirely when allowedHosts is empty', () => {
+    const guard = createHostOriginGuard([], []);
+    const { req, res, next, status } = mockReqRes({ host: 'anything.example' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('allows a request with no Origin header even when an Origin allowlist is configured', () => {
+    const guard = createHostOriginGuard([], ['https://good.example']);
+    const { req, res, next, status } = mockReqRes({ host: 'irrelevant' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('allows a request whose Origin header is in the allowlist', () => {
+    const guard = createHostOriginGuard([], ['https://good.example']);
+    const { req, res, next } = mockReqRes({ host: 'irrelevant', origin: 'https://good.example' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a request whose Origin header is present but not allowlisted (403)', () => {
+    const guard = createHostOriginGuard([], ['https://good.example']);
+    const { req, res, next, status, json } = mockReqRes({ host: 'irrelevant', origin: 'https://evil.example' });
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('Invalid Origin header') }));
+  });
+
+  it('checks Host before Origin: a disallowed Host is rejected even with an allowed Origin', () => {
+    const guard = createHostOriginGuard(['localhost:8080'], ['https://good.example']);
+    const { req, res, next, status, json } = mockReqRes({ host: 'evil.example', origin: 'https://good.example' });
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('Invalid Host header') }));
+  });
+});
+
+// --- createBearerAuthGuard ---------------------------------------------------
+
+describe('createBearerAuthGuard', () => {
+  it('is a no-op (always calls next) when no token is configured', () => {
+    const guard = createBearerAuthGuard(undefined);
+    const { req, res, next, status } = mockReqRes({});
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request with no Authorization header when a token is configured (401)', () => {
+    const guard = createBearerAuthGuard('s3cr3t');
+    const { req, res, next, status, json } = mockReqRes({});
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: 'unauthorized' });
+  });
+
+  it('rejects a request with the wrong bearer token (401)', () => {
+    const guard = createBearerAuthGuard('s3cr3t');
+    const { req, res, next, status } = mockReqRes({ authorization: 'Bearer wrong-token' });
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects a request with a token of different length than expected (401, no throw)', () => {
+    const guard = createBearerAuthGuard('s3cr3t');
+    const { req, res, next, status } = mockReqRes({ authorization: 'Bearer short' });
+    expect(() => guard(req, res, next)).not.toThrow();
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+
+  it('rejects a request that omits the "Bearer " prefix (401)', () => {
+    const guard = createBearerAuthGuard('s3cr3t');
+    const { req, res, next, status } = mockReqRes({ authorization: 's3cr3t' });
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+
+  it('allows a request with the correct bearer token', () => {
+    const guard = createBearerAuthGuard('s3cr3t');
+    const { req, res, next, status } = mockReqRes({ authorization: 'Bearer s3cr3t' });
+    guard(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+});

--- a/tests/transport-security-e2e.test.ts
+++ b/tests/transport-security-e2e.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+import { createServer } from '../src/server.js';
+import type { ServerConfig } from '../src/server.js';
+
+// End-to-end regression tests for the HIGH finding: the /mcp Streamable-HTTP
+// endpoint had no authentication and no DNS-rebinding/Origin protection, and
+// bound 0.0.0.0 by default -- an unauthenticated POST /mcp with a spoofed
+// Host/Origin returned 200 + a session id and the full ~298-tool surface.
+//
+// Design decision (operator, post-fix review): Host/Origin enforcement and
+// the bearer token are BOTH opt-in, off by default. Enforcing either by
+// default would reject every already-deployed remote/reverse-proxied client
+// whose Host header isn't `localhost`/`127.0.0.1` -- a breaking change on a
+// routine update. So the default-config tests below assert the OLD
+// (unprotected) behavior is preserved byte-for-byte, and the opt-in tests
+// assert protection actually engages once MCP_ALLOWED_HOSTS/
+// MCP_ALLOWED_ORIGINS/MCP_AUTH_TOKEN are set.
+//
+// These tests exercise the real Express app end-to-end (no mocked req/res),
+// on a fixed loopback port, so they fail exactly the way the audit's dynamic
+// reproduction did if the guards regress. Dummy Dockhand credentials are
+// enough: the MCP `initialize` handshake never calls the Dockhand backend.
+
+const TEST_PORT = 48213;
+
+const DUMMY_DOCKHAND: ServerConfig['dockhand'] = {
+  url: 'http://dockhand.invalid',
+  username: 'dummy',
+  password: 'dummy',
+};
+
+interface RawResponse {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function rawRequest(
+  port: number,
+  options: { method: string; path?: string; headers?: Record<string, string>; body?: string },
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: options.path ?? '/mcp',
+        method: options.method,
+        // Force a fresh connection per request and have the server close
+        // it once the response is sent — avoids keep-alive sockets from one
+        // test leaking into the next test's server instance on the same
+        // fixed test port (both are on 127.0.0.1:TEST_PORT sequentially).
+        headers: { Connection: 'close', ...options.headers },
+        agent: false,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (options.body !== undefined) req.write(options.body);
+    req.end();
+  });
+}
+
+function initializeBody(): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-06-18',
+      capabilities: {},
+      clientInfo: { name: 'test-client', version: '1.0' },
+    },
+  });
+}
+
+function initializeHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    Host: `127.0.0.1:${TEST_PORT}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    ...extra,
+  };
+}
+
+let httpServer: HttpServer | undefined;
+
+async function startServer(config: Partial<ServerConfig> = {}): Promise<void> {
+  httpServer = await createServer({
+    dockhand: DUMMY_DOCKHAND,
+    port: TEST_PORT,
+    host: '127.0.0.1',
+    ...config,
+  });
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+    httpServer = undefined;
+  }
+});
+
+describe('/mcp Host/Origin allowlist (opt-in DNS-rebinding protection, default OFF)', () => {
+  it('(a) default, no MCP_ALLOWED_HOSTS/MCP_ALLOWED_ORIGINS: a spoofed Host+Origin is NOT rejected -- preserves the old behavior', async () => {
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Host: 'evil.attacker.example', Origin: 'https://evil.attacker.example' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+  });
+
+  it('(a) default: GET and DELETE /mcp with an arbitrary Host header are also not rejected by a Host guard', async () => {
+    await startServer();
+
+    const getRes = await rawRequest(TEST_PORT, {
+      method: 'GET',
+      headers: { Host: 'evil.attacker.example' },
+    });
+    // No session id -> SDK itself returns 400 "Missing session ID", not a
+    // guard-level 403. That 400 (not 403) is the proof no Host guard ran.
+    expect(getRes.statusCode).not.toBe(403);
+
+    const deleteRes = await rawRequest(TEST_PORT, {
+      method: 'DELETE',
+      headers: { Host: 'evil.attacker.example', 'mcp-session-id': 'nonexistent' },
+    });
+    expect(deleteRes.statusCode).not.toBe(403);
+  });
+
+  it('(b) MCP_ALLOWED_HOSTS set: rejects a disallowed/spoofed Host header (403) -- the audit repro, once opted in', async () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', `127.0.0.1:${TEST_PORT}`);
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Host: 'evil.attacker.example', Origin: 'https://evil.attacker.example' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.headers['mcp-session-id']).toBeUndefined();
+    expect(JSON.parse(res.body)).toMatchObject({ error: expect.stringContaining('Invalid Host header') });
+  });
+
+  it('(b) MCP_ALLOWED_HOSTS set: allows the request and issues a session id for an allowlisted host:port', async () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', `127.0.0.1:${TEST_PORT}`);
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders(),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+  });
+
+  it('MCP_ALLOWED_HOSTS set: applies the Host guard to GET and DELETE too, not just POST', async () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', `127.0.0.1:${TEST_PORT}`);
+    await startServer();
+
+    const getRes = await rawRequest(TEST_PORT, { method: 'GET', headers: { Host: 'evil.attacker.example' } });
+    expect(getRes.statusCode).toBe(403);
+
+    const deleteRes = await rawRequest(TEST_PORT, {
+      method: 'DELETE',
+      headers: { Host: 'evil.attacker.example', 'mcp-session-id': 'nonexistent' },
+    });
+    expect(deleteRes.statusCode).toBe(403);
+  });
+
+  it('MCP_ALLOWED_ORIGINS set (MCP_ALLOWED_HOSTS unset): rejects a disallowed Origin header even though Host is unchecked', async () => {
+    vi.stubEnv('MCP_ALLOWED_ORIGINS', 'https://good.example');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Host: 'anything-goes.example', Origin: 'https://evil.example' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toMatchObject({ error: expect.stringContaining('Invalid Origin header') });
+  });
+
+  it('honors an explicit MCP_ALLOWED_HOSTS allowlist for a non-default hostname (e.g. behind a proxy)', async () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', 'dock-mcp.example.internal');
+    await startServer();
+
+    const rejected = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Host: `127.0.0.1:${TEST_PORT}` }),
+      body: initializeBody(),
+    });
+    expect(rejected.statusCode).toBe(403);
+
+    const allowed = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Host: 'dock-mcp.example.internal' }),
+      body: initializeBody(),
+    });
+    expect(allowed.statusCode).toBe(200);
+    expect(allowed.headers['mcp-session-id']).toBeDefined();
+  });
+});
+
+describe('/mcp opt-in bearer authentication', () => {
+  it('(c) with no MCP_AUTH_TOKEN configured: requests still work (backward-compatible)', async () => {
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders(),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+  });
+
+  it('with neither MCP_ALLOWED_HOSTS nor MCP_AUTH_TOKEN configured: emits a startup warning that /mcp is unauthenticated and host-unchecked', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await startServer();
+
+    const allOutput = errorSpy.mock.calls.map((call) => String(call.join(' '))).join('\n');
+    expect(allOutput).toContain('WARNING');
+    expect(allOutput).toContain('MCP_ALLOWED_HOSTS');
+    expect(allOutput).toContain('MCP_AUTH_TOKEN');
+  });
+
+  it('with MCP_ALLOWED_HOSTS configured (but no token): does NOT emit the "no protection at all" warning', async () => {
+    vi.stubEnv('MCP_ALLOWED_HOSTS', `127.0.0.1:${TEST_PORT}`);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await startServer();
+
+    const messages = errorSpy.mock.calls.map((call) => String(call.join(' ')));
+    expect(messages.some((msg) => msg.includes('WARNING'))).toBe(false);
+  });
+
+  it('(c) with MCP_AUTH_TOKEN configured: a request with no Authorization header is rejected (401)', async () => {
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders(),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'unauthorized' });
+  });
+
+  it('(c) with MCP_AUTH_TOKEN configured: a request with the wrong bearer token is rejected (401)', async () => {
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Authorization: 'Bearer wrong-token' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('(c) with MCP_AUTH_TOKEN configured: a bearer token of a different length is rejected (401, no throw / no crash)', async () => {
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Authorization: 'Bearer short' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('(c) with MCP_AUTH_TOKEN configured: a request with the correct bearer token succeeds', async () => {
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, {
+      method: 'POST',
+      headers: initializeHeaders({ Authorization: 'Bearer top-secret-token' }),
+      body: initializeBody(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['mcp-session-id']).toBeDefined();
+  });
+
+  it('does not gate /health behind the bearer token (unchanged behavior)', async () => {
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    await startServer();
+
+    const res = await rawRequest(TEST_PORT, { method: 'GET', path: '/health', headers: {} });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **opt-in** Host/Origin allow-listing and bearer-token auth for the Streamable-HTTP `/mcp` transport. This hardens deployments that expose the MCP endpoint beyond loopback (LAN, tailnet), where the transport otherwise accepts any request — the `@modelcontextprotocol/sdk` Streamable-HTTP transport ships with `enableDnsRebindingProtection` defaulting to `false`, so without this there is no Host/Origin check and no authentication in front of tool dispatch.

**Non-breaking by design:** with no new env vars set, behaviour is byte-for-byte identical to before — no Host check, no auth. Enforcement only activates when you opt in.

## What it adds

- **`MCP_ALLOWED_HOSTS`** — comma-separated `host:port` allow-list. When set, a request whose `Host` header is not on the list gets `403`. Also wires the SDK's `enableDnsRebindingProtection` on. Unset ⇒ no Host check (opt-in).
- **`MCP_ALLOWED_ORIGINS`** — comma-separated `Origin` allow-list (browser/CORS surface). Origin-only config does **not** by itself stop DNS-rebinding — the Host allow-list is what does; documented as such.
- **`MCP_AUTH_TOKEN`** — when set, `/mcp` requires `Authorization: Bearer <token>`; missing/wrong ⇒ `401`. Constant-time compare (`timingSafeEqual`) with a length pre-check so a wrong-length token returns `401` instead of throwing. Blank/whitespace token ⇒ treated as unset.

The guard runs as Express middleware **before** the `/mcp` route handlers, so rejected requests never reach session lookup or tool dispatch. A one-line startup warning is logged only when neither Host/Origin enforcement nor a token is configured.

## How to enable

```bash
# Restrict to the addresses your clients actually use, and require a token:
MCP_ALLOWED_HOSTS=host-a.example:8222,host-b.example:8222
MCP_AUTH_TOKEN=<random-secret>
```

Include the **port** in each `MCP_ALLOWED_HOSTS` entry for non-localhost deployments. See the README section and `.env.example` for the full opt-in matrix.

## Testing

- New `tests/transport-guard.test.ts` (unit) + `tests/transport-security-e2e.test.ts` (e2e): **43 tests**, covering default-off compatibility (spoofed Host+Origin still `200` on POST/GET/DELETE), enabled enforcement (Host/Origin/combined → `403`), and all auth paths (missing/wrong/length-mismatch/no-prefix → `401`, correct → `200`).
- Full suite green; `npm run build` + `npx tsc --noEmit` clean.
- No new runtime dependencies.

## Notes

- Purely additive/opt-in ⇒ **minor** release under semantic-release (`feat(security)`), no breaking change.
- Recommended for any deployment where `/mcp` is reachable beyond `127.0.0.1`.
