### PR TITLE
docs: show bearer-token client config when MCP_AUTH_TOKEN is enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,31 @@ Add to your MCP settings:
 }
 ```
 
+> **If the server enforces a bearer token** (`MCP_AUTH_TOKEN` set — see
+> [Securing the transport](#securing-the-transport)), the client must send it as an
+> `Authorization` header, or every request is rejected with `401`. In Claude Code's
+> `.mcp.json`, add a `headers` block — reference an environment variable so the token
+> never lives in the (often version-controlled) config file:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "dockhand": {
+>       "type": "http",
+>       "url": "http://your-server:8080/mcp",
+>       "headers": { "Authorization": "Bearer ${DOCKHAND_MCP_TOKEN}" }
+>     }
+>   }
+> }
+> ```
+>
+> Export `DOCKHAND_MCP_TOKEN` in the environment Claude Code is launched from (e.g. from a
+> gitignored `.env` you `source` before starting). The `Host`/`host:port` you connect to
+> must also be in the server's `MCP_ALLOWED_HOSTS` if that allowlist is set. For **Claude
+> Desktop** (native config has no `headers` field), pass the token through the mcp-proxy
+> workaround below — mcp-proxy forwards an `Authorization` header via its own
+> environment/args.
+
 #### Claude Desktop with a remote server (mcp-proxy)
 
 Claude Desktop can fail to connect to a **remote** mcp-dockhand server (not

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ Add to your MCP settings:
 > }
 > ```
 >
+> **Send the token only over an encrypted transport.** A bearer over plain `http://` on a
+> shared network can be sniffed — terminate TLS at a reverse proxy, or reach the server over
+> a WireGuard/Tailscale/VPN link (the app-layer HTTP is then encrypted by the tunnel).
+>
 > Export `DOCKHAND_MCP_TOKEN` in the environment Claude Code is launched from (e.g. from a
 > gitignored `.env` you `source` before starting). The `Host`/`host:port` you connect to
 > must also be in the server's `MCP_ALLOWED_HOSTS` if that allowlist is set. For **Claude


### PR DESCRIPTION
Follow-up to #188. The **MCP Client Configuration** section showed only the tokenless `url` config; with `MCP_AUTH_TOKEN` enforced, a reader following it gets `401` on every request with no hint why.

Adds, right after the plain client-config example:
- a note that the client must send `Authorization: Bearer <token>` when the server enforces one,
- a Claude Code `.mcp.json` example using `"Authorization": "Bearer ${DOCKHAND_MCP_TOKEN}"` (token stays out of the version-controlled config; export the env var at launch),
- the `MCP_ALLOWED_HOSTS` host:port reminder,
- the Claude Desktop / mcp-proxy path for the header.

Doc-only; cross-links to the existing *Securing the transport* section.