### PR TITLE
fix(ci): give api-schema-sync bot commits a valid commitlint scope

### DIFF
--- a/.github/workflows/api-schema-sync.yml
+++ b/.github/workflows/api-schema-sync.yml
@@ -53,7 +53,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/dockhand-api-schema.json
-          git commit -m "chore: update Dockhand API schema (automated)"
+          git commit -m "chore(api): update Dockhand API schema (automated)"
           git push
 
       - name: Fetch Dockhand OpenAPI body-contract spec
@@ -81,7 +81,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/dockhand-openapi.json
-          git commit -m "chore: update Dockhand OpenAPI body-contract spec (automated)"
+          git commit -m "chore(api): update Dockhand OpenAPI body-contract spec (automated)"
           git push
 
       - name: Validate MCP tools against schema
@@ -103,7 +103,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet docs/coverage.md; then
             git add docs/coverage.md
-            git commit -m "docs: update API coverage report (automated)"
+            git commit -m "docs(api): update API coverage report (automated)"
             git push
           else
             echo "docs/coverage.md unverändert — kein Commit"
@@ -124,7 +124,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if ! git diff --quiet docs/body-contract-report.md; then
             git add docs/body-contract-report.md
-            git commit -m "docs: update body-contract findings report (automated)"
+            git commit -m "docs(api): update body-contract findings report (automated)"
             git push
           else
             echo "docs/body-contract-report.md unverändert — kein Commit"


### PR DESCRIPTION
## Problem

The scheduled **Dockhand API Schema Sync** workflow (`.github/workflows/api-schema-sync.yml`) fails at every automated commit step. Example: run [31773235761](https://github.com/strausmann/mcp-dockhand/actions/runs/31773235761).

Root cause: the repo's husky `commit-msg` hook runs commitlint against `.commitlintrc.json`, which enforces `scope-empty: never` plus a restricted `scope-enum`. The four bot commit messages in this workflow were scope-less (`chore: ...`, `docs: ...`), so every one of them fails immediately:

```
⧗   --- input ---
chore: update Dockhand API schema (automated)
✖   scope may not be empty [scope-empty]

✖   found 1 problems, 0 warnings
husky - commit-msg script failed (code 1)
##[error]Process completed with exit code 1.
```

This happens identically for all four commit steps (schema, OpenAPI body-contract spec, coverage doc, body-contract report) — none of them can ever push automatically.

## Fix

Give all four bot commit messages the existing `api` scope from `.commitlintrc.json`'s `scope-enum` — it already covers the Dockhand API schema/coverage/contract surface, so no new scope had to be added:

| Before | After |
|---|---|
| `chore: update Dockhand API schema (automated)` | `chore(api): update Dockhand API schema (automated)` |
| `chore: update Dockhand OpenAPI body-contract spec (automated)` | `chore(api): update Dockhand OpenAPI body-contract spec (automated)` |
| `docs: update API coverage report (automated)` | `docs(api): update API coverage report (automated)` |
| `docs: update body-contract findings report (automated)` | `docs(api): update body-contract findings report (automated)` |

Only `.github/workflows/api-schema-sync.yml` changed — exactly these four string literals.

## Local verification

Ran `npm install` (activates the husky hook via `prepare`), then piped each message through `npx commitlint` against this repo's real `.commitlintrc.json`:

```
$ echo "chore(api): update Dockhand API schema (automated)" | npx commitlint
exit=0
$ echo "chore(api): update Dockhand OpenAPI body-contract spec (automated)" | npx commitlint
exit=0
$ echo "docs(api): update API coverage report (automated)" | npx commitlint
exit=0
$ echo "docs(api): update body-contract findings report (automated)" | npx commitlint
exit=0
```

All 4 new messages **PASS**. Control/gegenprobe with one of the original (unscoped) messages:

```
$ echo "docs: update body-contract findings report (automated)" | npx commitlint
✖   scope may not be empty [scope-empty]
exit=1
```

The old message still **FAILs** as expected, confirming the diagnosis and the fix.

## Branch protection observation

Checked whether `main` is branch-protected, since the workflow pushes directly (`git push`, `permissions: contents: write`):

```
$ gh api repos/strausmann/mcp-dockhand/branches/main/protection
{"message":"Branch not protected", ...}  (HTTP 404)
```

`main` currently has **no** branch protection, so the bot's direct push should go through once this commitlint fix lands — no second blocker found. Flagging this only for visibility in case protection gets added later (would then need a bypass rule for `github-actions[bot]`).