### PR TITLE
test(security): add response-body safety guardrail

### DIFF
--- a/scripts/lib/response-body-safety.mjs
+++ b/scripts/lib/response-body-safety.mjs
@@ -1,0 +1,243 @@
+/**
+ * Response-body safety guardrail (Issue: security-audit-driven, `api-response-dto-boundary`
+ * leak class ported from Go to this TypeScript codebase).
+ *
+ * Background: `.claude/rules/api-response-dto-boundary.md` (homelab-management repo) documents
+ * a leak class found repeatedly in `fileee-server` — a domain/library type with its OWN
+ * `MarshalJSON`/serialization override ending up (directly, as a slice element, or as a nested
+ * field) inside an API response body. Because the type serializes itself by its own logic
+ * instead of the surrounding DTO's intended shape, it emits MORE than intended (unmapped
+ * fields, internal envelopes, secrets/PII) — regardless of how careful the handler around it
+ * is.
+ *
+ * This codebase has no DTO layer at all (`src/utils/response.ts#jsonResponse` just
+ * `JSON.stringify`s whatever `unknown` JSON `DockhandClient` returned) and no class defines a
+ * custom `toJSON()` today — so the literal Go leak class does not structurally exist here. But
+ * the underlying risk translates directly: this is a pure passthrough proxy, and the ONE thing
+ * that must never happen is a *this-codebase-owned* object (a `DockhandClient`/`SessionManager`
+ * instance, or a future domain class with its own `toJSON()`) ending up serialized into a tool
+ * response instead of the raw upstream JSON. `JSON.stringify` calls `.toJSON()` on any object
+ * that defines it — exactly the Go `MarshalJSON` mechanism, just via a different method name —
+ * so a future domain class that adds one would silently override whatever fields a handler
+ * intended to send.
+ *
+ * Two guardrails, both preventive (audited: no current violation — see
+ * `tests/response-body-safety.test.ts`):
+ *
+ *   1. `findToJsonMethodDefinitions()` — no class/object anywhere under `src/` may define a
+ *      `toJSON()` method. This is the direct TS/JS analog of "no domain type may own a custom
+ *      Marshaler" — it blocks the mechanism before it can be combined with #2.
+ *   2. `findUnsafeResponseArguments()` — no `jsonResponse(...)`/`textResponse(...)` call site in
+ *      `src/tools/*.ts` may pass (directly, nested in an object/array literal, indirectly via a
+ *      locally `new`-constructed variable, or via the bare `client`/`session` identifiers) an
+ *      instance of anything other than a small allow-listed set of JS built-ins whose own
+ *      `toJSON()` (if any) is well-understood and does not leak extra fields (e.g. `Date`).
+ *
+ * This is intentionally NOT a full TS AST/type-checker pass (no `typescript` compiler API) —
+ * `client.get<T>()` etc. return `unknown` at essentially every call site in this codebase (no
+ * caller pins `T`), so a type-level check would pass vacuously everywhere and catch nothing.
+ * A textual/structural scan that recognizes the concrete danger shapes (`new X(...)`, a bare
+ * `client`/`session` argument, a `toJSON` method definition) is what actually catches a future
+ * regression — same tier of tool as the rest of this repo's static-analysis tests
+ * (`scripts/validate-mcp-tools.mjs`, `tests/route-handlers.test.ts`), reusing the same
+ * string/template/comment-aware scanner (`findMatchingClose`) so it doesn't get confused by a
+ * `new Foo(` appearing inside a string literal or a comment.
+ *
+ * Improvement over the `fileee-server` guardrail this is modeled on: that guard needed a
+ * hand-maintained list of "registered response types" that could silently drift out of sync
+ * with the actual handlers. Here there is no type registry to maintain — the test scans
+ * `readdirSync('src/tools')` itself (same pattern as `tests/tool-registration.test.ts`), so a
+ * brand-new tool file is covered automatically the moment it exists, with nothing to remember
+ * to register.
+ */
+
+import { skipString, skipTemplate, findMatchingClose } from './js-scan.mjs';
+
+/**
+ * JS/TS built-in constructors considered safe to construct anywhere near a response body.
+ * None of these emit undisclosed extra fields when serialized (most either have no own
+ * enumerable properties, or a well-understood `toJSON()` like `Date`'s ISO-string form) —
+ * unlike a codebase-owned domain/client class, which could grow secret-bearing fields (or a
+ * `toJSON()` override) at any point without anyone touching this guardrail.
+ */
+export const DEFAULT_ALLOWED_CONSTRUCTORS = new Set([
+  'Date', 'Error', 'TypeError', 'RangeError', 'SyntaxError', 'EvalError', 'URIError',
+  'URL', 'URLSearchParams', 'RegExp', 'Map', 'Set', 'WeakMap', 'WeakSet', 'Promise',
+  'AbortController', 'FormData', 'Blob', 'TextEncoder', 'TextDecoder', 'Buffer',
+  'Array', 'Object', 'Number', 'String', 'Boolean',
+]);
+
+/**
+ * Bare identifiers that must never be the (sole) argument to a response-building call — these
+ * are this codebase's own domain objects (the Dockhand HTTP client and its session manager).
+ * `jsonResponse(client)` would serialize the client instance itself instead of `await
+ * client.get(...)`'s result — exactly the "domain object where a DTO belongs" shape, just
+ * without even needing a `new` keyword at the call site because `client`/`session` are already
+ * in scope as constructor parameters.
+ */
+export const DEFAULT_FORBIDDEN_IDENTIFIERS = new Set(['client', 'session']);
+
+/**
+ * Replaces the contents of every string literal, template literal and comment in `content`
+ * with spaces (newlines preserved), leaving every other character — including the enclosing
+ * quotes/comment markers — untouched in place. The result has the exact same length and line
+ * structure as `content`, so indices/line numbers computed against it apply unchanged to the
+ * original source, while `new Foo(` (or similar) appearing only inside a string or a comment
+ * can no longer produce a false positive.
+ * @param {string} content
+ * @returns {string}
+ */
+export function stripNoise(content) {
+  const chars = content.split('');
+  const blank = (start, end) => {
+    for (let j = start; j < end; j++) {
+      if (chars[j] !== '\n') chars[j] = ' ';
+    }
+  };
+
+  let i = 0;
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "'" || ch === '"') {
+      const end = skipString(content, i, ch);
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === '`') {
+      const end = skipTemplate(content, i);
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '/') {
+      const nl = content.indexOf('\n', i);
+      const end = nl === -1 ? content.length : nl;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === '/' && content[i + 1] === '*') {
+      const close = content.indexOf('*/', i);
+      const end = close === -1 ? content.length : close + 2;
+      blank(i, end);
+      i = end;
+      continue;
+    }
+    i++;
+  }
+  return chars.join('');
+}
+
+/** 1-based line number of `index` within `content`. */
+function lineOf(content, index) {
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (content[i] === '\n') line++;
+  }
+  return line;
+}
+
+/**
+ * Finds every `toJSON` METHOD DEFINITION (class method, class field arrow function, or object
+ * literal method) in `content` — never a call site (`someValue.toJSON()`), which is excluded by
+ * requiring the match not be preceded by `.`.
+ *
+ * Matches: `toJSON() {`, `toJSON(...) {`, `toJSON = () => {`, `toJSON = async () => {`.
+ * Does NOT match: `x.toJSON()`, `foo.toJSON`, a `toJSON` occurring inside a string/comment
+ * (both blanked out by `stripNoise` before this regex runs).
+ *
+ * @param {string} content
+ * @returns {Array<{line: number, snippet: string}>}
+ */
+export function findToJsonMethodDefinitions(content) {
+  const clean = stripNoise(content);
+  const re = /(?<![.\w$])toJSON\s*(?:=\s*(?:async\s*)?\(|\()/g;
+  const results = [];
+  let m;
+  while ((m = re.exec(clean)) !== null) {
+    const snippet = content.slice(m.index, m.index + 60).split('\n')[0].trim();
+    results.push({ line: lineOf(content, m.index), snippet });
+  }
+  return results;
+}
+
+/**
+ * Finds response-building call sites (`jsonResponse(...)`/`textResponse(...)` by default) whose
+ * argument is unsafe: a bare forbidden identifier (`client`, `session`), or a `new <Ctor>(...)`
+ * construction of a non-allow-listed type — direct, nested inside an object/array literal, or
+ * indirect via a same-file `const/let/var IDENT = new <Ctor>(...)` declaration.
+ *
+ * Scope, deliberately: this is a structural/textual scanner, not a dataflow analysis. It
+ * resolves ONE level of local variable indirection (`const x = new Foo(); jsonResponse(x)`) but
+ * does not chase a value across function boundaries, through destructuring, or through a field
+ * on an otherwise-safe object (`jsonResponse({ inner: someVar })` where `someVar` was
+ * constructed elsewhere is not traced beyond the direct-assignment case above). That is
+ * sufficient to catch the concrete regression this guards against (a domain/client instance —
+ * or a future custom-`toJSON()` class — landing directly in a response body) without the
+ * complexity/fragility of a full type-aware analysis, which would also be defeated in practice
+ * by this codebase's pervasive `unknown` typing (see module doc comment).
+ *
+ * @param {string} content
+ * @param {{calleeNames?: string[], allowedConstructors?: Set<string>, forbiddenIdentifiers?: Set<string>}} [options]
+ * @returns {Array<{line: number, callee: string, reason: string, detail: string}>}
+ */
+export function findUnsafeResponseArguments(content, options = {}) {
+  const calleeNames = options.calleeNames ?? ['jsonResponse', 'textResponse'];
+  const allowedConstructors = options.allowedConstructors ?? DEFAULT_ALLOWED_CONSTRUCTORS;
+  const forbiddenIdentifiers = options.forbiddenIdentifiers ?? DEFAULT_FORBIDDEN_IDENTIFIERS;
+
+  const clean = stripNoise(content);
+  const violations = [];
+
+  // One level of local-variable indirection: `const foo = new Bar(...)`.
+  const declRe = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$]*)\s*\(/g;
+  const declaredCtor = new Map();
+  let dm;
+  while ((dm = declRe.exec(clean)) !== null) {
+    declaredCtor.set(dm[1], dm[2]);
+  }
+
+  for (const callee of calleeNames) {
+    const calleeRe = new RegExp(`(?<![.\\w$])${callee}\\s*\\(`, 'g');
+    let cm;
+    while ((cm = calleeRe.exec(clean)) !== null) {
+      const openParenIndex = cm.index + cm[0].length - 1;
+      const closeParenIndex = findMatchingClose(clean, openParenIndex);
+      if (closeParenIndex === -1) continue; // unbalanced — not our concern here
+
+      const argClean = clean.slice(openParenIndex + 1, closeParenIndex);
+      const trimmed = argClean.trim();
+      const line = lineOf(content, cm.index);
+
+      if (forbiddenIdentifiers.has(trimmed)) {
+        violations.push({ line, callee, reason: 'forbidden-identifier', detail: trimmed });
+        continue;
+      }
+
+      if (declaredCtor.has(trimmed)) {
+        const ctor = declaredCtor.get(trimmed);
+        if (!allowedConstructors.has(ctor)) {
+          violations.push({
+            line,
+            callee,
+            reason: 'constructed-instance-indirect',
+            detail: `${trimmed} = new ${ctor}(...)`,
+          });
+          continue;
+        }
+      }
+
+      const newRe = /\bnew\s+([A-Za-z_$][\w$]*)\s*\(/g;
+      let nm;
+      while ((nm = newRe.exec(argClean)) !== null) {
+        const ctor = nm[1];
+        if (!allowedConstructors.has(ctor)) {
+          violations.push({ line, callee, reason: 'constructed-instance', detail: `new ${ctor}(...)` });
+        }
+      }
+    }
+  }
+
+  return violations;
+}

--- a/tests/response-body-safety.test.ts
+++ b/tests/response-body-safety.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  findToJsonMethodDefinitions,
+  findUnsafeResponseArguments,
+} from '../scripts/lib/response-body-safety.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = join(__dirname, '..', 'src');
+const toolsDir = join(srcDir, 'tools');
+
+/**
+ * Recursively collects every `.ts` file under `dir` (skipping `.test.ts` files — this
+ * guardrail cares about shipped code, not test fixtures).
+ */
+function walkTsFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...walkTsFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Response-body safety guardrail — see `scripts/lib/response-body-safety.mjs` for the full
+ * rationale. Ported from the Go `api-response-dto-boundary` leak class
+ * (`.claude/rules/api-response-dto-boundary.md` in homelab-management) after a security audit
+ * of this repo found NO active violation: this server has no DTO layer and no class anywhere
+ * defines a custom `toJSON()` today (verified below, not assumed) — both guards are preventive,
+ * so a future regression fails the build instead of reaching review.
+ */
+describe('Response-body safety guardrail', () => {
+  describe('no toJSON() overrides anywhere under src/', () => {
+    const files = walkTsFiles(srcDir);
+
+    it('scans at least the known source files (sanity check the walker itself works)', () => {
+      expect(files.length).toBeGreaterThan(20);
+    });
+
+    for (const file of files) {
+      const rel = relative(join(__dirname, '..'), file);
+      it(`${rel}: defines no toJSON() method`, () => {
+        const content = readFileSync(file, 'utf-8');
+        const hits = findToJsonMethodDefinitions(content);
+        expect(
+          hits,
+          `${rel} defines toJSON() at line(s) ${hits.map((h) => h.line).join(', ')} ` +
+            `(${hits.map((h) => JSON.stringify(h.snippet)).join(', ')}). ` +
+            `A custom toJSON() lets JSON.stringify() silently emit more than a response ` +
+            `handler intends — see .claude/rules/api-response-dto-boundary.md.`
+        ).toEqual([]);
+      });
+    }
+  });
+
+  describe('no unsafe jsonResponse()/textResponse() arguments in src/tools/', () => {
+    // Auto-derived from the directory listing (same pattern as tests/tool-registration.test.ts)
+    // — a newly added tool file is covered automatically, nothing to register by hand.
+    const files = readdirSync(toolsDir)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => join(toolsDir, f));
+
+    it('scans at least the known tool files (sanity check the walker itself works)', () => {
+      expect(files.length).toBeGreaterThanOrEqual(20);
+    });
+
+    for (const file of files) {
+      const rel = relative(join(__dirname, '..'), file);
+      it(`${rel}: passes no domain-object argument to jsonResponse()/textResponse()`, () => {
+        const content = readFileSync(file, 'utf-8');
+        const violations = findUnsafeResponseArguments(content);
+        expect(
+          violations,
+          violations
+            .map(
+              (v) =>
+                `line ${v.line}: ${v.callee}(...) — ${v.reason}: ${v.detail}`
+            )
+            .join('\n')
+        ).toEqual([]);
+      });
+    }
+  });
+
+  // --- Meta-tests: prove the detectors actually catch the shapes they claim to, and don't
+  // flag the safe shapes this codebase actually uses (fixtures only — never real source). ---
+
+  describe('findToJsonMethodDefinitions (meta-tests)', () => {
+    it('flags a class method named toJSON', () => {
+      const src = `
+        export class Widget {
+          toJSON() {
+            return { ...this, secret: this.internalToken };
+          }
+        }
+      `;
+      expect(findToJsonMethodDefinitions(src)).toHaveLength(1);
+    });
+
+    it('flags a class-field arrow function named toJSON', () => {
+      const src = `
+        export class Widget {
+          toJSON = () => ({ ...this });
+        }
+      `;
+      expect(findToJsonMethodDefinitions(src)).toHaveLength(1);
+    });
+
+    it('flags an async class-field arrow function named toJSON', () => {
+      const src = `
+        export class Widget {
+          toJSON = async () => ({ ...this });
+        }
+      `;
+      expect(findToJsonMethodDefinitions(src)).toHaveLength(1);
+    });
+
+    it('does NOT flag a toJSON() call site (e.g. Date.prototype.toJSON)', () => {
+      const src = `const generatedAt = new Date().toJSON();`;
+      expect(findToJsonMethodDefinitions(src)).toEqual([]);
+    });
+
+    it('does NOT flag toJSON mentioned only inside a string or comment', () => {
+      const src = `
+        // Does NOT define toJSON() here, just talking about it.
+        const note = 'call toJSON() on the result';
+      `;
+      expect(findToJsonMethodDefinitions(src)).toEqual([]);
+    });
+  });
+
+  describe('findUnsafeResponseArguments (meta-tests)', () => {
+    it('flags a directly constructed domain instance', () => {
+      const src = `
+        async () => {
+          return jsonResponse(new SomeDomainClass());
+        }
+      `;
+      const violations = findUnsafeResponseArguments(src);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('constructed-instance');
+    });
+
+    it('flags a domain instance nested inside an object literal field', () => {
+      const src = `
+        async () => {
+          return jsonResponse({ status: 'ok', debug: new SomeDomainClass() });
+        }
+      `;
+      const violations = findUnsafeResponseArguments(src);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('constructed-instance');
+    });
+
+    it('flags a domain instance passed indirectly via a local variable', () => {
+      const src = `
+        async () => {
+          const summary = new SomeDomainClass();
+          return jsonResponse(summary);
+        }
+      `;
+      const violations = findUnsafeResponseArguments(src);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('constructed-instance-indirect');
+    });
+
+    it('flags the bare "client" identifier (the DockhandClient instance itself)', () => {
+      const src = `
+        async (server, client) => {
+          return jsonResponse(client);
+        }
+      `;
+      const violations = findUnsafeResponseArguments(src);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('forbidden-identifier');
+      expect(violations[0].detail).toBe('client');
+    });
+
+    it('flags the bare "session" identifier', () => {
+      const src = `textResponse(session);`;
+      const violations = findUnsafeResponseArguments(src);
+      expect(violations).toHaveLength(1);
+      expect(violations[0].detail).toBe('session');
+    });
+
+    it('does NOT flag the real-world pass-through pattern (await client.get(...))', () => {
+      const src = `
+        registerTool(server, 'list_users', {}, async () => {
+          return jsonResponse(await client.get('/api/users'));
+        });
+      `;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag a plain object literal response', () => {
+      const src = `return jsonResponse({ ok: true, id: userId });`;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag an allow-listed built-in (Date) used inline', () => {
+      const src = `return jsonResponse({ generatedAt: new Date().toISOString() });`;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag a "client"/"session"-named field access, only the bare identifier', () => {
+      const src = `return jsonResponse(result.client);`;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag "new X(" appearing only inside a string literal', () => {
+      const src = `return jsonResponse({ note: 'call new SomeDomainClass() yourself' });`;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag "new X(" appearing only inside a comment', () => {
+      const src = `
+        // example: new SomeDomainClass() is what NOT to do here
+        return jsonResponse({ ok: true });
+      `;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+
+    it('does NOT flag an unrelated call with the same name as a forbidden identifier', () => {
+      // "client" as an object field, not the bare argument itself.
+      const src = `return jsonResponse({ client: 'chrome', ok: true });`;
+      expect(findUnsafeResponseArguments(src)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Security audit for the `api-response-dto-boundary` leak class (`.claude/rules/api-response-dto-boundary.md` in `homelab-management`): a domain/library type with its own custom serialization override (Go `MarshalJSON`) ending up in an API response and emitting more than the intended DTO — repeatedly found in `fileee-server` / `fileee-mcp-server`.

**Audit result: no active leak found.** This server has no DTO layer at all — every tool does `jsonResponse(await client.<verb>(...))`, forwarding whatever `unknown` JSON the Dockhand backend returned (see `src/utils/response.ts`, `src/client/dockhand-client.ts`). No class in `src/` defines a custom `toJSON()` today. Cross-checked the documented Dockhand REST contract (`docs/dockhand-openapi.json`) for every credential/token/secret-bearing endpoint this server calls (`get_git_credential`, `list_git_credentials`, `create_git_credential`, `list_auth_tokens`, `create_auth_token`, `list_hawser_tokens`, `create_hawser_token`, `get_stack_env`, `get_git_stack_webhook`) — all consistently mask/omit secret values in their response schema except the two documented one-time-reveal endpoints (`create_auth_token`, `create_hawser_token`), which are expected by design, not a leak.

The literal leak class (a Go struct with an overriding `MarshalJSON`) doesn't structurally exist in this TypeScript codebase. Per the task's own instruction for this case, added the guardrail as **prevention** anyway, since the underlying risk translates directly: `JSON.stringify()` calls `.toJSON()` on any object that defines it — same mechanism, different method name — and this server's whole design (bare passthrough) means the one thing that must never happen is a codebase-owned object (`DockhandClient`/`SessionManager`, or a future domain class with its own `toJSON()`) landing in a tool response instead of the raw upstream JSON.

## What was added

`scripts/lib/response-body-safety.mjs` (two pure, testable scan functions) + `tests/response-body-safety.test.ts` (85 tests):

1. **`findToJsonMethodDefinitions()`** — fails if any class/object anywhere under `src/` defines a `toJSON()` method (class method, class-field arrow, async arrow). Scanned today: 0 hits.
2. **`findUnsafeResponseArguments()`** — fails if any `jsonResponse()`/`textResponse()` call in `src/tools/*.ts` passes:
   - a `new <Ctor>(...)` construction of anything outside a small built-in allowlist (`Date`, `Error`, `Map`, `URL`, ...) — direct, nested in an object/array literal, or via one level of local-variable indirection (`const x = new Foo(); jsonResponse(x)`)
   - the bare `client` or `session` identifier (this codebase's own domain objects)

   Scanned today across all 21 tool files (183 call sites): 0 hits.

Both lists are **auto-derived from `readdirSync()`** (same pattern as `tests/tool-registration.test.ts`), not a hand-maintained type registry — the one weakness the `fileee-server` guardrail this is modeled on has (a registry that can drift). A new file under `src/` or `src/tools/` is covered automatically, nothing to remember to register.

The scan reuses this repo's existing string/template/comment-aware bracket scanner (`scripts/lib/js-scan.mjs`: `findMatchingClose`, `skipString`, `skipTemplate`) so a `new Foo(` or `toJSON` appearing only inside a string literal or a comment cannot produce a false positive — verified by dedicated meta-tests, which also prove each detector actually catches the shape it claims to (constructed instance, nested field, indirect variable, forbidden identifier) and doesn't flag the real passthrough pattern this codebase uses everywhere.

Not a full TS-AST/type-checker pass on purpose: `client.get<T>()` returns `unknown` at essentially every call site here (no caller pins `T`), so a type-level check would pass vacuously everywhere and catch nothing — a textual/structural scan of the concrete danger shapes is what actually catches a future regression.

## Verification

- `npm run typecheck` — clean
- `npx vitest run` — 74 files / 931 tests pass (931 = 846 pre-existing + 85 new)
- Meta-tests confirm true positives (constructed instance / nested field / indirect variable / forbidden identifier / `toJSON` definition variants) and true negatives (real `await client.get(...)` pattern, plain object literals, `Date` inline, `new Foo(` inside strings/comments, unrelated field named `client`)

## Not touched

No production code changed (`src/tools/**` unmodified) — audit found nothing to fix. Not merging or cleaning up the workspace per instructions.