### PR TITLE
fix(stacks): parse the raw .env response as JSON instead of silently discarding it

### DIFF
--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -8,7 +8,7 @@ import type { DockhandClient } from '../client/dockhand-client.js';
 import type { StackEnv, EnvVariable } from '../types/dockhand.js';
 import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
-import { diffEnvVars, parseDotEnvKeys, removeKeysFromDotEnv, upsertDotEnv } from '../utils/env-helpers.js';
+import { diffEnvVars, extractDotEnvContent, parseDotEnvKeys, removeKeysFromDotEnv, upsertDotEnv } from '../utils/env-helpers.js';
 import type { EnvDiff } from '../utils/env-helpers.js';
 
 export function registerStackTools(server: McpServer, client: DockhandClient): void {
@@ -270,8 +270,8 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
         try {
           let newContent: string;
           if (mode === 'merge') {
-            const raw = await client.get<string>(envRawPath, { env: environmentId });
-            rawStr = typeof raw === 'string' ? raw : '';
+            const raw = await client.get<unknown>(envRawPath, { env: environmentId });
+            rawStr = extractDotEnvContent(raw);
             newContent = upsertDotEnv(rawStr, payloadNonSecrets.map((v) => ({ key: v.key, value: v.value })));
             // N1: the live .env is authoritative for non-secrets — only migrate
             // orphaned DB rows whose key is NOT already in .env, so a stale DB
@@ -372,9 +372,9 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       const structuredKeys = new Set(vars.map((v) => v.key));
       const secretKeys = new Set(vars.filter((v) => v.isSecret).map((v) => v.key));
 
-      const raw = await client.get<string>(
+      const raw = await client.get<unknown>(
         `/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
-      const rawStr = typeof raw === 'string' ? raw : '';
+      const rawStr = extractDotEnvContent(raw);
       const envKeys = new Set(parseDotEnvKeys(rawStr));
 
       const removed = uniqueKeys.filter((k) => structuredKeys.has(k) || envKeys.has(k));
@@ -429,9 +429,9 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       const secretKeys = new Set(
         (Array.isArray(structured?.variables) ? structured.variables : [])
           .filter((v) => v && v.isSecret && typeof v.key === 'string').map((v) => v.key));
-      const raw = await client.get<string>(
+      const raw = await client.get<unknown>(
         `/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
-      const envKeys = parseDotEnvKeys(typeof raw === 'string' ? raw : '');
+      const envKeys = parseDotEnvKeys(extractDotEnvContent(raw));
       const collisions = envKeys.filter((k) => secretKeys.has(k));
       return jsonResponse(
         collisions.length > 0

--- a/src/utils/env-helpers.ts
+++ b/src/utils/env-helpers.ts
@@ -42,6 +42,42 @@ export function diffEnvVars(
   };
 }
 
+/**
+ * Unwrap the body of `GET /api/stacks/{name}/env/raw` into the raw .env text.
+ *
+ * The endpoint answers with JSON, never with a bare string — every return path
+ * in Dockhand's handler (`src/routes/api/stacks/[name]/env/raw/+server.ts`) is
+ * a `json(...)` call: `{ content }` on success, `{ content: '', noEnvFile: true }`
+ * when the stack has no env file, `{ error }` on failure. Our HTTP client parses
+ * `application/json` into an object, so callers receive an object.
+ *
+ * This used to be handled inline as `typeof raw === 'string' ? raw : ''`, which
+ * silently degraded EVERY response to an empty base. For `update_stack_env` in
+ * merge mode that meant the .env got rebuilt from nothing and every variable
+ * outside the payload was lost — a real data-loss incident (issue #196).
+ *
+ * Therefore: no silent fallback. An unexpected shape throws so the caller
+ * aborts instead of writing a truncated file. An empty `content` is a valid
+ * empty base (stack genuinely has no env file) and is returned as such.
+ */
+export function extractDotEnvContent(raw: unknown): string {
+  // A bare string would be a plain-text response — accepted for robustness.
+  if (typeof raw === 'string') return raw;
+
+  if (raw && typeof raw === 'object') {
+    const body = raw as { content?: unknown; error?: unknown };
+    if (typeof body.content === 'string') return body.content;
+    if (typeof body.error === 'string') {
+      throw new Error(`Dockhand returned an error for the raw .env: ${body.error}`);
+    }
+  }
+
+  throw new Error(
+    'Unexpected response shape for the raw .env: expected a string or an object with a string "content" field, ' +
+      `got ${raw === null ? 'null' : typeof raw}. Refusing to continue — writing would truncate the .env file.`,
+  );
+}
+
 /** Extract variable keys from raw .env content, skipping blank lines and comments. */
 export function parseDotEnvKeys(content: string): string[] {
   const keys: string[] = [];

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -48,10 +48,19 @@ function setup(): { handler: ToolHandler; client: MockClient } {
   return { handler, client };
 }
 
-/** Wires client.get so `/env/raw` and the structured `/env` return different mocked payloads. */
+/**
+ * Wires client.get so `/env/raw` and the structured `/env` return different mocked payloads.
+ *
+ * `/env/raw` is wrapped in `{ content }` because that is what Dockhand actually
+ * answers — every return path of its handler is a `json(...)` call, and our HTTP
+ * client parses `application/json` into an object. This helper used to hand the
+ * raw text back as a bare string, which meant the whole suite validated an
+ * assumption instead of the real contract and stayed green while
+ * `update_stack_env` truncated .env files in production (#196).
+ */
 function wireGet(client: MockClient, structured: unknown, raw: string) {
   client.get.mockImplementation((path: string) =>
-    path.endsWith('/env/raw') ? Promise.resolve(raw) : Promise.resolve(structured));
+    path.endsWith('/env/raw') ? Promise.resolve({ content: raw }) : Promise.resolve(structured));
 }
 
 function envPut(client: MockClient) {

--- a/tests/stack-env-raw-shape.test.ts
+++ b/tests/stack-env-raw-shape.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Regression guard for #196 — the raw .env response is JSON, not a string.
+ *
+ * `GET /api/stacks/{name}/env/raw` answers with `json({ content })` on every
+ * return path of Dockhand's handler (`src/routes/api/stacks/[name]/env/raw/
+ * +server.ts`), and our HTTP client parses `application/json` into an object.
+ * The call sites used to narrow that with `typeof raw === 'string' ? raw : ''`,
+ * so the merge base was ALWAYS empty:
+ *
+ *   - update_stack_env (merge) rebuilt the .env from the payload alone and
+ *     deleted every variable the caller had not sent — real data loss, 13
+ *     variables reduced to 1 on a production stack, reported as success,
+ *   - remove_stack_env_vars never saw .env keys and reported them not_found,
+ *   - check_stack_env_collisions could never report a collision.
+ *
+ * Every test below fails against the pre-fix implementation — that is the point
+ * of the file. The counter-check was run explicitly: with the old narrowing
+ * restored, "preserves variables ... " fails on the truncated PUT body rather
+ * than passing for the wrong reason.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { registerStackTools } from '../src/tools/stacks.js';
+import { extractDotEnvContent } from '../src/utils/env-helpers.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
+
+interface MockClient {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+}
+
+function setup(toolName: string): { handler: ToolHandler; client: MockClient } {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, cb: ToolHandler) => {
+      handlers.set(name, cb);
+    },
+  };
+  const client: MockClient = {
+    get: vi.fn(),
+    put: vi.fn().mockResolvedValue({ ok: true }),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerStackTools(server as any, client as any);
+  const handler = handlers.get(toolName);
+  if (!handler) throw new Error(`${toolName} handler was not registered`);
+  return { handler, client };
+}
+
+/** Mocks the two GETs exactly as Dockhand answers them. */
+function wireRealShape(client: MockClient, structured: unknown, envFileContent: string) {
+  client.get.mockImplementation((path: string) =>
+    path.endsWith('/env/raw')
+      ? Promise.resolve({ content: envFileContent })
+      : Promise.resolve(structured));
+}
+
+function rawPut(client: MockClient) {
+  return client.put.mock.calls.find((c) => String(c[0]).endsWith('/env/raw'));
+}
+
+function jsonOut(res: unknown): Record<string, unknown> {
+  const text = (res as { content: { text: string }[] }).content[0].text;
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe('extractDotEnvContent', () => {
+  it('unwraps the real Dockhand shape', () => {
+    expect(extractDotEnvContent({ content: 'A=1\nB=2\n' })).toBe('A=1\nB=2\n');
+  });
+
+  it('treats "no env file" as a legitimately empty base', () => {
+    expect(extractDotEnvContent({ content: '', noEnvFile: true })).toBe('');
+  });
+
+  it('still accepts a bare string (plain-text response)', () => {
+    expect(extractDotEnvContent('A=1\n')).toBe('A=1\n');
+  });
+
+  it('throws on an error body instead of returning an empty base', () => {
+    expect(() => extractDotEnvContent({ error: 'Failed to get environment file' }))
+      .toThrow(/Failed to get environment file/);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['an object without content', { unexpected: true }],
+    ['a non-string content', { content: 123 }],
+  ])('throws on %s rather than silently yielding an empty base', (_label, value) => {
+    expect(() => extractDotEnvContent(value)).toThrow(/Refusing to continue/);
+  });
+});
+
+describe('update_stack_env — #196 data-loss regression', () => {
+  it('preserves variables that are only in the .env file when adding one non-secret', async () => {
+    const { handler, client } = setup('update_stack_env');
+    // Mirrors the production incident: a populated .env, an empty DB store.
+    // The real file held POSTGRES_PASSWORD / PAPERLESS_SECRET_KEY / TZ and ten
+    // more; the fixture uses neutral key names so secret scanners do not flag
+    // test data as a credential. What matters here is only that these keys are
+    // present in .env, absent from the payload, and must survive the write.
+    const existing = 'KEEP_ONE=value-one\nKEEP_TWO=value-two\nTZ=Europe/Berlin\n';
+    wireRealShape(client, { variables: [] }, existing);
+
+    const res = await handler({
+      environmentId: 8,
+      name: 'paperless',
+      variables: [{ key: 'PAPERLESS_USERNAME', value: 'Strausmann', isSecret: false }],
+    });
+
+    const written = (rawPut(client)?.[1] as { content: string }).content;
+    expect(written).toContain('KEEP_ONE=value-one');
+    expect(written).toContain('KEEP_TWO=value-two');
+    expect(written).toContain('TZ=Europe/Berlin');
+    expect(written).toContain('PAPERLESS_USERNAME=Strausmann');
+
+    // The summary counts the untouched keys instead of claiming an empty
+    // baseline — pre-fix this was `preserved: 0`, which is exactly what made
+    // the incident look like a successful merge in the tool response.
+    expect(jsonOut(res).summary).toEqual(
+      expect.objectContaining({ added: 1, preserved: 3, removed: 0 }),
+    );
+  });
+
+  it('aborts the write when the raw GET returns an unexpected shape', async () => {
+    const { handler, client } = setup('update_stack_env');
+    client.get.mockImplementation((path: string) =>
+      path.endsWith('/env/raw')
+        ? Promise.resolve({ unexpected: 'shape' })
+        : Promise.resolve({ variables: [] }));
+
+    const res = await handler({
+      environmentId: 8,
+      name: 'paperless',
+      variables: [{ key: 'PLAIN', value: 'x', isSecret: false }],
+    });
+
+    // No truncated file may be written — better to fail loudly than to succeed wrongly.
+    expect(rawPut(client)).toBeUndefined();
+    expect(JSON.stringify(jsonOut(res))).toMatch(/Refusing to continue/);
+  });
+});
+
+describe('remove_stack_env_vars — #196: .env keys are visible again', () => {
+  it('removes a key that exists only in the .env file', async () => {
+    const { handler, client } = setup('remove_stack_env_vars');
+    wireRealShape(client, { variables: [] }, 'KEEP=1\nDROP=2\n');
+
+    const res = await handler({ environmentId: 8, name: 'paperless', keys: ['DROP'] });
+
+    const written = (rawPut(client)?.[1] as { content: string }).content;
+    expect(written).toContain('KEEP=1');
+    expect(written).not.toContain('DROP=2');
+    expect(jsonOut(res)).toEqual(expect.objectContaining({ removed: ['DROP'] }));
+  });
+});
+
+describe('check_stack_env_collisions — #196: the check can actually fire', () => {
+  it('reports a key present in both the DB secrets and the .env file', async () => {
+    const { handler, client } = setup('check_stack_env_collisions');
+    wireRealShape(client, { variables: [{ key: 'DUPE', value: '***', isSecret: true }] }, 'DUPE=from-env\nOTHER=1\n');
+
+    const out = jsonOut(await handler({ environmentId: 8, name: 'paperless' }));
+
+    expect(out.collisions).toEqual(['DUPE']);
+  });
+});

--- a/tests/stack-env-remove.test.ts
+++ b/tests/stack-env-remove.test.ts
@@ -16,9 +16,10 @@ function setup() {
   return { handler, client };
 }
 // get() is called twice: first structured /env, then raw /env/raw.
+// `/env/raw` answers with `{ content }` (JSON), never a bare string — see #196.
 function wireGet(client: { get: ReturnType<typeof vi.fn> }, structured: unknown, raw: string) {
   client.get.mockImplementation((path: string) =>
-    path.endsWith('/env/raw') ? Promise.resolve(raw) : Promise.resolve(structured));
+    path.endsWith('/env/raw') ? Promise.resolve({ content: raw }) : Promise.resolve(structured));
 }
 
 describe('remove_stack_env_vars', () => {


### PR DESCRIPTION
Closes #196

## Problem

`GET /api/stacks/{name}/env/raw` **always** answers with JSON (`{ content }`) — every return path of Dockhand's handler (`src/routes/api/stacks/[name]/env/raw/+server.ts`) is a `json(...)` call, and our client parses `application/json` into an object. The three call sites narrowed that with `typeof raw === 'string' ? raw : ''` and therefore **always** got an empty base.

Hit in production on 2026-08-17 on the `paperless` stack: an `update_stack_env` carrying **one** non-secret variable reduced 13 variables to 1, including `POSTGRES_PASSWORD`, `PAPERLESS_SECRET_KEY` and `PAPERLESS_API_TOKEN`. The response reported `success: true`, `summary.added: 1` — and `preserved: 0`, which was the only visible trace.

| Tool | Impact before the fix |
|---|---|
| `update_stack_env` (merge, non-secret) | **Data loss** — `.env` rebuilt from an empty base |
| `remove_stack_env_vars` | Ineffective for `.env` keys, reports them as `not_found` |
| `check_stack_env_collisions` | Always reports `collisions: []` |

## Change

`extractDotEnvContent()` in `env-helpers.ts` reads the `content` field, still accepts a bare string (plain-text response) and correctly treats `{ content: '', noEnvFile: true }` as a legitimately empty base. **Any other shape throws.**

Dropping the silent fallback to `''` is the actual core of the fix: it turned a format mismatch into data loss while keeping it invisible. An unexpected shape now aborts the write instead of producing a truncated file.

## Why this got past the tests

Both test helpers mocked the raw GET as a **string**:

```ts
path.endsWith('/env/raw') ? Promise.resolve(raw) : ...   // raw: string
```

The test encoded the same wrong assumption as the production code and confirmed itself — it validated our idea of the endpoint, not its contract. Both helpers now return `{ content: raw }`, so the **entire** existing suite runs against the real shape.

## Counter-check (performed, not claimed)

The three call sites were temporarily reverted to the old narrowing. Result — all four new tool-level assertions turn red, each for the right reason:

```
x preserves variables that are only in the .env file when adding one non-secret
    AssertionError: expected 'PAPERLESS_USERNAME=Strausmann' to contain 'KEEP_ONE=value-one'
x aborts the write when the raw GET returns an unexpected shape
    AssertionError: expected [ ...(3) ] to be undefined
x removes a key that exists only in the .env file
x reports a key present in both the DB secrets and the .env file
    AssertionError: expected [] to deeply equal [ 'DUPE' ]
```

The first line is the production incident, literally.

## Verification

- `npx vitest run` -> **944 tests across 75 files, all green**
- `npx tsc --noEmit` -> clean
- ESLint: not migrated to the flat config in this repo and no `lint` script — no gate bypassed, but a cleanup item of its own (tracked in #198)

## Deliberately out of scope

`get_stack_env_raw` (`stacks.ts:343`) returns the response unchanged as text, i.e. `{"content":"..."}` rather than the `.env` content. Same root cause, but an **output format change** for existing callers — it does not belong in a data-loss hotfix. Tracked in #198.
