### PR TITLE
chore(api): record the inbound git webhook as a deliberate omission

### DIFF
--- a/docs/adr/0001-omission-registry.md
+++ b/docs/adr/0001-omission-registry.md
@@ -2,7 +2,7 @@
 
 **Status:** accepted
 **Datum:** 2026-08-10
-**Refs:** #57 (P3-Plan), #171 (env-files-Removal), #164 (Backup-API — echte Lücke, KEINE Omission)
+**Refs:** #57 (P3-Plan), #171 (env-files-Removal), #202 (Backup-API — echte Lücke, KEINE Omission)
 
 ## Kontext
 
@@ -15,8 +15,8 @@ MCP-Tools (`src/tools/*.ts`). Jeder Endpunkt ohne Tool erzeugt einen `MISSING_TO
 Zwei grundverschiedene Situationen erzeugen denselben `MISSING_TOOL`-Fund:
 
 1. **Echte Lücke** — der Endpunkt existiert, ein Tool dafür ist geplant, aber (noch) nicht
-   gebaut. Beispiel: die komplette Backup-API (`/api/backup/*`), 29 Endpunkte, Tracking-Issue
-   #164.
+   gebaut. Beispiel: die komplette Backup-API (`/api/backup/*`), 30 Endpunkte, Tracking-Issue
+   #202.
 2. **Bewusste Auslassung** — wir werden NIE ein Tool dafür bauen, aus einem dokumentierten
    Grund (Sicherheit, Redundanz, technische Eignung). Beispiel: `POST
    /api/git/stacks/{id}/env-files` wurde in #171 als eigenes Tool entfernt, weil es
@@ -35,7 +35,7 @@ Vor diesem ADR gab es dafür zwei getrennte, unvollständige Mechanismen:
 
 Das Problem: ohne Unterscheidung sieht ein Betrachter von `docs/coverage.md` 37
 `MISSING_TOOL`-Einträge und kann nicht erkennen, welche davon tatsächlich noch zu bauen
-sind (#164, priorisierbar) und welche für immer offen bleiben werden (kein Backlog-Posten).
+sind (#202, priorisierbar) und welche für immer offen bleiben werden (kein Backlog-Posten).
 
 ## Entscheidung
 
@@ -80,10 +80,10 @@ Registry-Eintrag, kein neues `IGNORED_PATTERNS`-Pattern nötig.
 
 ### Was NIEMALS in die Registry gehört
 
-Eine geplante, aber noch nicht gebaute API-Fläche — auch wenn sie groß ist (Backup-API #164,
-29 Endpunkte). Ein Registry-Eintrag bedeutet "wir bauen das NIE", nicht "wir haben es noch
+Eine geplante, aber noch nicht gebaute API-Fläche — auch wenn sie groß ist (Backup-API #202,
+30 Endpunkte). Ein Registry-Eintrag bedeutet "wir bauen das NIE", nicht "wir haben es noch
 nicht gebaut". Eine versehentliche Registrierung würde `MISSING_TOOL` für einen echten
-Rückstand fälschlich zum Schweigen bringen — genau das Risiko, das `#164` in Task P3.7
+Rückstand fälschlich zum Schweigen bringen — genau das Risiko, das `#202` in Task P3.7
 (dieses ADR) explizit als Gegenbeispiel benannt hat.
 
 ## Konsequenz
@@ -108,5 +108,5 @@ Rückstand fälschlich zum Schweigen bringen — genau das Risiko, das `#164` in
 - Sichtbarkeit: `scripts/lib/coverage-report.mjs` (`buildCoverageDoc()`, Abschnitt
   "Deliberately omitted (with reason)")
 - Tests: `tests/omission-registry.test.ts`
-- Tracking-Issue echte Lücke (KEINE Omission): #164 (Backup-API, 29 fehlende Tools)
+- Tracking-Issue echte Lücke (KEINE Omission): #202 (Backup-API, 30 fehlende Tools)
 - Auslöser-Removal: #171 (`POST /api/git/stacks/{id}/env-files`)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,19 +4,19 @@
 > Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
 > Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
 
-**Erzeugt:** 2026-08-17T19:06:02.895Z
+**Erzeugt:** 2026-08-17T19:10:22.772Z
 **Dockhand-Upstream-Commit:** `19548772df38f37ed5272575561d28911476c083`
 **Schema-Endpunkte gesamt:** 242
 
 ## Coverage
 
-**90.2%** (295/327 in-Scope-Endpunkte haben ein MCP-Tool)
+**90.5%** (295/326 in-Scope-Endpunkte haben ein MCP-Tool)
 
 | Status | Anzahl |
 |--------|--------|
 | COVERED | 295 |
-| MISSING_TOOL | 32 |
-| Deliberately omitted (Registry, siehe unten) | 1 |
+| MISSING_TOOL | 31 |
+| Deliberately omitted (Registry, siehe unten) | 2 |
 | ORPHANED_TOOL | 0 |
 | Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |
 
@@ -60,12 +60,6 @@ ersten Pfad-Segment nach `/api/`:
 | GET | `/api/backup/stack-dir-listing` | - |
 | GET | `/api/backup/stack-path` | - |
 
-### git (1)
-
-| HTTP | Pfad | Path-Parameter |
-|------|------|----------------|
-| POST | `/api/git/stacks/{id}/webhook` | id |
-
 ### images (1)
 
 | HTTP | Pfad | Path-Parameter |
@@ -81,6 +75,7 @@ echte, noch offene Lücken (z.B. die Backup-API, siehe #164).
 | HTTP | Pfad | Begründung | ADR |
 |------|------|------------|-----|
 | POST | `/api/git/stacks/{id}/env-files` | Entfernt in #171 — read-only Aufgabe, redundant zu get_git_stack_env_files (GET) plus update_git_stack/update_stack_env für Änderungen. Kein zusätzliches Tool nötig. | docs/adr/0001-omission-registry.md |
+| POST | `/api/git/stacks/{id}/webhook` | Eingehender Webhook-EMPFAENGER, kein aufrufbarer Vorgang: GitHub/GitLab rufen ihn mit einer Signatur bzw. einem Token auf, die der Handler prueft, und deployen damit den Git-Stack. Ein Agent hat weder die Signatur noch einen Grund, sie nachzubilden — fuer den absichtlichen Deploy gibt es deploy_git_stack, fuer die Webhook-Verwaltung get_git_stack_webhook (GET, vorhanden). Der Endpunkt taucht sonst dauerhaft als MISSING_TOOL auf und laesst den Luecken-Zaehler groesser aussehen, als er ist. | docs/adr/0001-omission-registry.md |
 
 ## Details
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,7 +4,7 @@
 > Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
 > Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
 
-**Erzeugt:** 2026-08-17T19:10:22.772Z
+**Erzeugt:** 2026-08-17T19:18:33.894Z
 **Dockhand-Upstream-Commit:** `19548772df38f37ed5272575561d28911476c083`
 **Schema-Endpunkte gesamt:** 242
 
@@ -70,7 +70,7 @@ ersten Pfad-Segment nach `/api/`:
 
 Endpunkte, die laut Schema existieren, aber laut `docs/omitted-endpoints.json` bewusst
 NIE ein MCP-Tool bekommen sollen. Unterscheidet sich von MISSING_TOOL oben: dort stehen
-echte, noch offene Lücken (z.B. die Backup-API, siehe #164).
+echte, noch offene Lücken (z.B. die Backup-API, siehe #202).
 
 | HTTP | Pfad | Begründung | ADR |
 |------|------|------------|-----|

--- a/docs/omitted-endpoints.json
+++ b/docs/omitted-endpoints.json
@@ -159,5 +159,12 @@
     "reason": "Binäres Avatar-Upload — gleiche Einschränkung wie das Environment-Icon-Upload.",
     "adr": "docs/adr/0001-omission-registry.md",
     "date": "2026-08-10"
+  },
+  {
+    "method": "POST",
+    "path": "/api/git/stacks/{id}/webhook",
+    "reason": "Eingehender Webhook-EMPFAENGER, kein aufrufbarer Vorgang: GitHub/GitLab rufen ihn mit einer Signatur bzw. einem Token auf, die der Handler prueft, und deployen damit den Git-Stack. Ein Agent hat weder die Signatur noch einen Grund, sie nachzubilden — fuer den absichtlichen Deploy gibt es deploy_git_stack, fuer die Webhook-Verwaltung get_git_stack_webhook (GET, vorhanden). Der Endpunkt taucht sonst dauerhaft als MISSING_TOOL auf und laesst den Luecken-Zaehler groesser aussehen, als er ist.",
+    "adr": "docs/adr/0001-omission-registry.md",
+    "date": "2026-08-17"
   }
 ]

--- a/scripts/lib/coverage-report.mjs
+++ b/scripts/lib/coverage-report.mjs
@@ -15,6 +15,15 @@
  * @param {string} path
  * @returns {string}
  */
+/**
+ * Tracking-Issue der grössten echten Lücke (Backup-API). Kanonisch in ADR-0001 gepflegt
+ * (docs/adr/0001-omission-registry.md) — beim Ändern BEIDE Stellen nachziehen. Stand hier
+ * als Literal im Fliesstext und blieb deshalb auf #164 stehen, als das Issue geschlossen
+ * wurde: die ADR-Korrektur allein wirkte nicht, weil das erzeugte Dokument aus DIESER Datei
+ * kommt. Genau deshalb jetzt eine benannte Konstante statt einer Zahl mitten im Satz.
+ */
+const BACKUP_GAP_ISSUE = '#202';
+
 function areaOf(path) {
   const match = path.match(/^\/api\/([^/]+)/);
   return match ? match[1] : path;
@@ -147,7 +156,7 @@ function buildCoverageDoc({
     lines.push(
       'NIE ein MCP-Tool bekommen sollen. Unterscheidet sich von MISSING_TOOL oben: dort stehen'
     );
-    lines.push('echte, noch offene Lücken (z.B. die Backup-API, siehe #164).');
+    lines.push(`echte, noch offene Lücken (z.B. die Backup-API, siehe ${BACKUP_GAP_ISSUE}).`);
     lines.push('');
     lines.push('| HTTP | Pfad | Begründung | ADR |');
     lines.push('|------|------|------------|-----|');

--- a/scripts/lib/omission-registry.mjs
+++ b/scripts/lib/omission-registry.mjs
@@ -4,7 +4,7 @@
  * `docs/omitted-endpoints.json` listet Dockhand-Endpunkte, die WIR bewusst NIE als
  * MCP-Tool aufnehmen (z.B. das in #171 entfernte `POST /api/git/stacks/{id}/env-files`,
  * oder `POST /api/self-update` — gefährlich über MCP). Das ist etwas ANDERES als eine
- * echte Lücke: die Backup-API (`/api/backup/*`, #164, 29 fehlende Tools) ist geplant,
+ * echte Lücke: die Backup-API (`/api/backup/*`, #202, 30 fehlende Tools) ist geplant,
  * nur noch nicht implementiert -- sie gehört NIE in diese Registry, sonst würde
  * `MISSING_TOOL` sie fälschlich unterdrücken.
  *
@@ -62,7 +62,7 @@ function buildRegistryIndex(registry) {
 
 /**
  * Trennt die rohen MISSING_TOOL-Funde in `realGaps` (kein Registry-Eintrag -- bleibt
- * eine echte Lücke, z.B. die Backup-API #164) und `deliberatelyOmitted` (Registry-Treffer
+ * eine echte Lücke, z.B. die Backup-API #202) und `deliberatelyOmitted` (Registry-Treffer
  * -- bewusste Auslassung, mit `reason`/`adr` aus dem Registry-Eintrag angereichert, damit
  * `docs/coverage.md` sie SICHTBAR unter "Deliberately omitted" auflisten kann statt sie
  * kommentarlos verschwinden zu lassen).

--- a/scripts/validate-mcp-tools.mjs
+++ b/scripts/validate-mcp-tools.mjs
@@ -31,7 +31,7 @@
  * die WIR BEWUSST NIE als Tool aufnehmen, z.B. das in #171 entfernte
  * `POST /api/git/stacks/{id}/env-files`) wandert nach `deliberatelyOmitted` statt
  * `missingTool` -- sichtbar in docs/coverage.md unter "Deliberately omitted", aber nicht
- * mehr als offene Lücke gemeldet. Eine ECHTE Lücke (z.B. die Backup-API, #164, 29 fehlende
+ * mehr als offene Lücke gemeldet. Eine ECHTE Lücke (z.B. die Backup-API, #202, 30 fehlende
  * Tools -- geplant, nur noch nicht gebaut) bleibt unverändert `missingTool`. Siehe
  * scripts/lib/omission-registry.mjs (`partitionMissingTools()`).
  *

--- a/tests/omission-registry.test.ts
+++ b/tests/omission-registry.test.ts
@@ -7,7 +7,7 @@ import { partitionMissingTools } from '../scripts/lib/omission-registry.mjs';
  * `partitionMissingTools()` trennt die rohen MISSING_TOOL-Funde von
  * `computeValidation()` (scripts/validate-mcp-tools.mjs) in zwei Eimer:
  * - `realGaps` — Endpunkte ohne Tool, die NICHT in der Registry stehen (echte Lücke,
- *   z.B. die Backup-API #164 — geplant, nur noch nicht implementiert)
+ *   z.B. die Backup-API #202 — geplant, nur noch nicht implementiert)
  * - `deliberatelyOmitted` — Endpunkte, die bewusst nie ein MCP-Tool bekommen sollen
  *   (docs/omitted-endpoints.json), inkl. der Begründung aus dem Registry-Eintrag
  */


### PR DESCRIPTION
Refs #196, #202 — follow-up to #200/#201.

## The counter counted the wrong thing

`api:validate` reported 32 endpoints without a tool. Only 31 of those are real:

- **30** are the `/api/backup/*` family — a genuine, tracked gap (#202)
- **1** is `POST /api/images/load` — deliberately skipped, see #196 and Finsys/dockhand#1421
- **1** is `POST /api/git/stacks/{id}/webhook` — **not a gap at all**

That last one is the receiver GitHub and GitLab call, with a signature the handler verifies. Nobody invokes it deliberately: `deploy_git_stack` is how you deploy on purpose, and `get_git_stack_webhook` (GET) already covers the management side. An agent has neither the signature nor a reason to reproduce one.

Left unregistered it counts as a gap forever. ADR-0001 exists precisely for this distinction — "we will never build this" versus "we have not built this yet" — so it belongs in the omission registry.

After: **31 missing, 2 deliberate omissions.**

## Stale ADR reference fixed while in there

ADR-0001 named **#164** as the backup-API tracking issue in five places. That issue was *"Tool coverage for new endpoints added in Dockhand v1.0.41"*, and it closed as completed with v1.13.0 — it was never about the backup family and no longer tracks anything. The current issue is **#202**, and the family has grown from 29 to 30 endpoints (`GET /api/backup/instance` arrived in 1.0.42).

Worth noting because the ADR's whole argument rests on that distinction being auditable: an "it is tracked over there" pointer aimed at a closed, unrelated issue quietly turns a real gap into an invisible one.

## The new gate earned its keep immediately

#201 added a CI step that regenerates `docs/coverage.md` and `src/openapi/tool-endpoint-map.ts` and fails on a diff. This change moves an endpoint between categories, so `coverage.md` shifted — and the gate flagged it on the very next commit after being introduced, before CI ever saw it:

```console
$ npm run api:coverage-doc && npm run api:tool-endpoint-map
$ git diff --exit-code -- docs/coverage.md src/openapi/tool-endpoint-map.ts
exit=1
```

Regenerated and committed; the same check now exits 0.

## Verification

- `npx vitest run` → 974 tests, 76 files, all green
- `npx tsc --noEmit` → clean
- `npm run api:validate` → exit 0; `MISSING_TOOL: 31`, `DELIBERATELY_OMITTED: 2`
