### PR TITLE
fix(api): fail closed when the body-shape collector dies

### DIFF
--- a/scripts/generate-body-contract-doc.mjs
+++ b/scripts/generate-body-contract-doc.mjs
@@ -27,7 +27,13 @@ import { writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { loadSchema, extractToolCalls, computeValidation } from './validate-mcp-tools.mjs';
+import {
+  loadSchema,
+  extractToolCalls,
+  computeValidation,
+  loadToolBodyShapes,
+  BodyShapeCollectorError,
+} from './validate-mcp-tools.mjs';
 import { buildBodyContractDoc } from './lib/body-contract-report.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -46,34 +52,35 @@ function stripTimestamp(content) {
   return content.replace(TIMESTAMP_LINE, '**Erzeugt:** <normalized>');
 }
 
-/**
- * Siehe loadToolBodyShapes() in validate-mcp-tools.mjs für das ausführliche WARUM
- * (tsx-Subprozess statt direktem Import) — dieselbe Logik, hier dupliziert statt
- * importiert, damit dieser Generator eigenständig lauffähig bleibt und nicht an
- * validate-mcp-tools.mjs's CLI-Seiteneffekten (validate() läuft beim direkten Import
- * NICHT automatisch, siehe dessen `import.meta.url`-Guard -- unproblematisch, aber
- * eine unnötige Kopplung für ein reines Lese-Skript).
- * @returns {Record<string, {sentFields: string[], requiredSent: string[], passthrough: boolean}>|null}
- */
-function loadToolBodyShapes() {
-  try {
-    const output = execFileSync(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['tsx', COLLECT_SHAPES_SCRIPT], {
-      cwd: PROJECT_ROOT,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'inherit'],
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    return JSON.parse(output);
-  } catch (err) {
-    console.error(`[body-contract-doc] Body-Shapes nicht verfügbar (tsx-Collector fehlgeschlagen): ${err.message}`);
-    return null;
-  }
-}
-
 function main() {
   const schema = loadSchema();
   const toolCalls = extractToolCalls();
-  const toolBodyShapes = loadToolBodyShapes();
+
+  // Fail CLOSED. Hier stand eine eigene Kopie von loadToolBodyShapes(), die jeden
+  // Collector-Fehler abfing und `null` zurueckgab — und `null` ist fuer computeValidation()
+  // das Signal "Body-Checks bewusst uebersprungen", also nicht unterscheidbar von "Collector
+  // abgestuerzt". Ergebnis waere ein Bericht mit NULL Findings, der aussieht wie ein sauberes
+  // Ergebnis. Solange der echte Bericht Findings enthaelt, faellt das im Sync-Tor noch auf;
+  // sobald das Repo legitim bei null Findings ankommt, waere das Dokument identisch und das
+  // Tor gruen, ohne dass je ein Contract geprueft wurde.
+  //
+  // validate-mcp-tools.mjs hat exakt diesen fail-open-Fehler in #173 behoben und wirft
+  // seither BodyShapeCollectorError. Diese Datei war die duplizierte Kopie, die den Fix nie
+  // bekam — deshalb jetzt importiert statt nachgebaut. Die Begruendung fuer die Duplikation
+  // ("bleibt eigenstaendig lauffaehig") trug ohnehin nicht: drei weitere Funktionen kommen
+  // bereits aus demselben Modul.
+  let toolBodyShapes;
+  try {
+    toolBodyShapes = loadToolBodyShapes();
+  } catch (err) {
+    if (err instanceof BodyShapeCollectorError) {
+      console.error(`[body-contract-doc] ${err.message}`);
+      console.error('[body-contract-doc] KEIN Bericht geschrieben — ein Bericht ohne Body-Shapes waere leer und damit falsch.');
+      process.exit(1);
+    }
+    throw err;
+  }
+
 
   const { bodyFindings } = computeValidation(schema, toolCalls, toolBodyShapes);
 


### PR DESCRIPTION
Refs #196 — follow-up to #205, found by Codex there.

## The hole

`generate-body-contract-doc.mjs` caught every collector failure and passed `null` to `computeValidation()`:

```js
} catch (err) {
  console.error(`[body-contract-doc] Body-Shapes nicht verfügbar …`);
  return null;
}
```

`null` is that function's signal for **"body checks intentionally skipped"** — indistinguishable from *"the collector crashed"*. The result is a report with **zero findings that looks like a clean result**.

Today it still surfaces: the real report has 92 findings, so a failed collector produces a different document and the sync gate from #205 catches the diff. **But that is coincidence, not design.** The moment the repository legitimately reaches zero findings, a broken collector produces the identical document, the diff is empty, and the gate goes green without a single body contract having been checked.

A gate whose correctness depends on the repo never being clean is not a gate.

## The fix was already in the repo

`validate-mcp-tools.mjs` fixed exactly this fail-open in #173, and its JSDoc says so in as many words:

> That made "the collector crashed" indistinguishable from "body checks were never requested", so the hard gate went silently fail-open on a broken collector: CI stayed green even though the check never ran.

This file was the **duplicated copy** that never got the fix. Its own header explained the duplication as "stays independently runnable" — which did not hold: three other functions already come from that same module.

So the local copy is gone and `loadToolBodyShapes` / `BodyShapeCollectorError` are imported. The duplication that caused the drift is removed along with the bug.

## Counter-check

Run, not claimed:

```console
# collector removed
$ node scripts/generate-body-contract-doc.mjs
[body-contract-doc] body-contract collector failed: Command failed: npx tsx …/collect-tool-shapes.mjs
[body-contract-doc] KEIN Bericht geschrieben — ein Bericht ohne Body-Shapes waere leer und damit falsch.
exit=1
$ git diff --exit-code -- docs/body-contract-report.md   # untouched

# collector restored
[body-contract-doc] Unverändert (92 Findings) — kein Schreibvorgang
exit=0
```

## Worth noting

This is the same anti-pattern as #196, one directory over: swallow the error, substitute an empty value, write the result. There it cost twelve environment variables of a production stack. Here it would have cost the credibility of a gate — quieter, but the same shape.

## Verification

- `npx vitest run` → 977 tests, 77 files, all green
- `npm run api:validate` → exit 0
