### PR TITLE
fix(stacks): return the .env content from get_stack_env_raw, not the envelope

### DIFF
--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -10,7 +10,7 @@
 > hartes Gate in `scripts/validate-mcp-tools.mjs` (Exit 1 + Auto-Issue) — hier weiterhin nur
 > zur Übersicht gelistet. Die übrigen drei Typen bleiben vollständig advisory.
 
-**Erzeugt:** 2026-08-17T19:57:10.043Z
+**Erzeugt:** 2026-08-17T20:01:17.811Z
 
 ## Zusammenfassung
 
@@ -27,14 +27,14 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `activate_license` | POST | `/api/license` | `licenseKey` | system.ts:179 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:489 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:489 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:489 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:489 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:494 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:494 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:494 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:494 |
 | `create_environment` | POST | `/api/environments` | `url` | environments.ts:93 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:414 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:422 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:419 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:427 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
 | `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:161 |
 

--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -10,7 +10,7 @@
 > hartes Gate in `scripts/validate-mcp-tools.mjs` (Exit 1 + Auto-Issue) — hier weiterhin nur
 > zur Übersicht gelistet. Die übrigen drei Typen bleiben vollständig advisory.
 
-**Erzeugt:** 2026-08-17T19:42:58.112Z
+**Erzeugt:** 2026-08-17T19:57:10.043Z
 
 ## Zusammenfassung
 
@@ -27,14 +27,14 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `activate_license` | POST | `/api/license` | `licenseKey` | system.ts:179 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:477 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:477 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:477 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:477 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:489 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:489 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:489 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:489 |
 | `create_environment` | POST | `/api/environments` | `url` | environments.ts:93 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:402 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:410 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:414 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:422 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
 | `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:161 |
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,18 +4,18 @@
 > Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
 > Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
 
-**Erzeugt:** 2026-08-17T19:57:05.533Z
+**Erzeugt:** 2026-08-17T20:01:13.676Z
 **Dockhand-Upstream-Commit:** `19548772df38f37ed5272575561d28911476c083`
 **Schema-Endpunkte gesamt:** 242
 
 ## Coverage
 
-**90.2%** (294/326 in-Scope-Endpunkte haben ein MCP-Tool)
+**90.5%** (295/326 in-Scope-Endpunkte haben ein MCP-Tool)
 
 | Status | Anzahl |
 |--------|--------|
-| COVERED | 294 |
-| MISSING_TOOL | 32 |
+| COVERED | 295 |
+| MISSING_TOOL | 31 |
 | Deliberately omitted (Registry, siehe unten) | 2 |
 | ORPHANED_TOOL | 0 |
 | Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |
@@ -65,12 +65,6 @@ ersten Pfad-Segment nach `/api/`:
 | HTTP | Pfad | Path-Parameter |
 |------|------|----------------|
 | POST | `/api/images/load` | - |
-
-### stacks (1)
-
-| HTTP | Pfad | Path-Parameter |
-|------|------|----------------|
-| GET | `/api/stacks/{name}/env/raw` | name |
 
 ## Deliberately omitted (with reason)
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,18 +4,18 @@
 > Wird täglich vom Workflow `.github/workflows/api-schema-sync.yml` neu erzeugt und bei
 > Änderung committet. Grundlage: `docs/dockhand-api-schema.json`.
 
-**Erzeugt:** 2026-08-17T19:18:33.894Z
+**Erzeugt:** 2026-08-17T19:57:05.533Z
 **Dockhand-Upstream-Commit:** `19548772df38f37ed5272575561d28911476c083`
 **Schema-Endpunkte gesamt:** 242
 
 ## Coverage
 
-**90.5%** (295/326 in-Scope-Endpunkte haben ein MCP-Tool)
+**90.2%** (294/326 in-Scope-Endpunkte haben ein MCP-Tool)
 
 | Status | Anzahl |
 |--------|--------|
-| COVERED | 295 |
-| MISSING_TOOL | 31 |
+| COVERED | 294 |
+| MISSING_TOOL | 32 |
 | Deliberately omitted (Registry, siehe unten) | 2 |
 | ORPHANED_TOOL | 0 |
 | Bewusst ausgeschlossen (Streams, Callbacks, interne Routen) | 22 |
@@ -65,6 +65,12 @@ ersten Pfad-Segment nach `/api/`:
 | HTTP | Pfad | Path-Parameter |
 |------|------|----------------|
 | POST | `/api/images/load` | - |
+
+### stacks (1)
+
+| HTTP | Pfad | Path-Parameter |
+|------|------|----------------|
+| GET | `/api/stacks/{name}/env/raw` | name |
 
 ## Deliberately omitted (with reason)
 

--- a/src/openapi/description-suffixes.ts
+++ b/src/openapi/description-suffixes.ts
@@ -34,7 +34,21 @@ const CONFIG_CARRIES_CREDENTIALS =
   'to proceed and whether they would rather do it in the Dockhand UI. If they say go ahead, go ' +
   'ahead — this is a supported administrative operation, not a forbidden one.';
 
+/**
+ * `get_stack_env_raw` returns the .env file verbatim. For stacks that keep credentials there
+ * — which is the norm for internal and adopted stacks — that means the response carries them
+ * in the clear, unlike `get_stack_env`, which masks anything stored as a secret. The endpoint
+ * description says "raw", not "contains secrets", and the difference is invisible until the
+ * values are already in the transcript.
+ */
+const RETURNS_THE_FILE_VERBATIM =
+  'SECURITY: this returns the .env file exactly as it is on disk, including any credentials ' +
+  'it contains — nothing is masked. Prefer get_stack_env, which masks stored secrets, unless ' +
+  'you specifically need the file itself. If you only need to know WHICH keys exist, say so ' +
+  'and read the key names rather than printing the response.';
+
 export const TOOL_DESCRIPTION_SUFFIXES: Readonly<Record<string, string>> = {
+  get_stack_env_raw: RETURNS_THE_FILE_VERBATIM,
   create_secret_provider: CONFIG_CARRIES_CREDENTIALS,
   update_secret_provider: CONFIG_CARRIES_CREDENTIALS,
   test_secret_provider: CONFIG_CARRIES_CREDENTIALS,

--- a/src/openapi/tool-endpoint-map.ts
+++ b/src/openapi/tool-endpoint-map.ts
@@ -168,7 +168,6 @@ export const TOOL_ENDPOINT_MAP: Readonly<Record<string, ToolEndpointEntry>> = {
   "get_stack_default_path": { method: "GET", path: "/api/stacks/default-path" },
   "get_stack_delete_preview": { method: "GET", path: "/api/stacks/{name}/delete-preview" },
   "get_stack_env": { method: "GET", path: "/api/stacks/{name}/env" },
-  "get_stack_env_raw": { method: "GET", path: "/api/stacks/{name}/env/raw" },
   "get_stack_path_hints": { method: "GET", path: "/api/stacks/path-hints" },
   "get_stack_sources": { method: "GET", path: "/api/stacks/sources" },
   "get_system_disk": { method: "GET", path: "/api/system/disk" },

--- a/src/openapi/tool-endpoint-map.ts
+++ b/src/openapi/tool-endpoint-map.ts
@@ -168,6 +168,7 @@ export const TOOL_ENDPOINT_MAP: Readonly<Record<string, ToolEndpointEntry>> = {
   "get_stack_default_path": { method: "GET", path: "/api/stacks/default-path" },
   "get_stack_delete_preview": { method: "GET", path: "/api/stacks/{name}/delete-preview" },
   "get_stack_env": { method: "GET", path: "/api/stacks/{name}/env" },
+  "get_stack_env_raw": { method: "GET", path: "/api/stacks/{name}/env/raw" },
   "get_stack_path_hints": { method: "GET", path: "/api/stacks/path-hints" },
   "get_stack_sources": { method: "GET", path: "/api/stacks/sources" },
   "get_system_disk": { method: "GET", path: "/api/system/disk" },

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -344,7 +344,19 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       name: z.string().describe('Stack name'),
     },
     async ({ environmentId, name }) => {
-      return textResponse(await client.get(`/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId }));
+      // Dockhand answers with JSON (`{ content, noEnvFile? }`), never with the file's bytes.
+      // Passing that straight through handed callers `{"content":"KEY=value\n…"}` while the
+      // tool advertises "read the raw .env" — the envelope instead of the thing (#198).
+      const raw = await client.get<unknown>(`/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
+
+      // "No env file at all" and "an env file that happens to be empty" both arrive as an
+      // empty string. They are different states — one means the stack has no .env, the other
+      // that it has one with nothing in it — and an empty tool response cannot express which.
+      if (raw && typeof raw === 'object' && (raw as { noEnvFile?: unknown }).noEnvFile === true) {
+        return textResponse('This stack has no .env file.');
+      }
+
+      return textResponse(extractDotEnvContent(raw));
     }
   );
 

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -347,7 +347,12 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
       // Dockhand answers with JSON (`{ content, noEnvFile? }`), never with the file's bytes.
       // Passing that straight through handed callers `{"content":"KEY=value\n…"}` while the
       // tool advertises "read the raw .env" — the envelope instead of the thing (#198).
-      const raw = await client.get<unknown>(`/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
+      // Bewusst OHNE Typargument. Der Aufruf liefert ohnehin `unknown`, und der
+      // Endpunkt-Extraktor in scripts/validate-mcp-tools.mjs erkennt die Aufrufform nur
+      // ohne spitze Klammern — mit Typargument faellt der Endpunkt aus
+      // src/openapi/tool-endpoint-map.ts heraus. Das bleibt nicht unbemerkt:
+      // tests/tool-endpoint.test.ts schlaegt dann an (in diesem PR genau so passiert).
+      const raw = await client.get(`/api/stacks/${encodePath(name)}/env/raw`, { env: environmentId });
 
       // "No env file at all" and "an env file that happens to be empty" both arrive as an
       // empty string. They are different states — one means the stack has no .env, the other

--- a/tests/stack-env-raw-shape.test.ts
+++ b/tests/stack-env-raw-shape.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { registerStackTools } from '../src/tools/stacks.js';
 import { extractDotEnvContent } from '../src/utils/env-helpers.js';
+import { describeTool } from '../src/openapi/describe-tool.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
 
@@ -166,5 +167,67 @@ describe('check_stack_env_collisions — #196: the check can actually fire', () 
     const out = jsonOut(await handler({ environmentId: 8, name: 'paperless' }));
 
     expect(out.collisions).toEqual(['DUPE']);
+  });
+});
+
+describe('get_stack_env_raw — #198: returns the file, not the envelope', () => {
+  function setupRaw() {
+    const handlers = new Map<string, ToolHandler>();
+    const server = {
+      tool: (name: string, _d: string, _s: unknown, cb: ToolHandler) => {
+        handlers.set(name, cb);
+      },
+    };
+    const client = { get: vi.fn(), put: vi.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerStackTools(server as any, client as any);
+    const handler = handlers.get('get_stack_env_raw');
+    if (!handler) throw new Error('get_stack_env_raw was not registered');
+    return { handler, client };
+  }
+
+  const textOf = (res: unknown) => (res as { content: { text: string }[] }).content[0].text;
+
+  it('returns the .env content itself', async () => {
+    const { handler, client } = setupRaw();
+    client.get.mockResolvedValue({ content: 'A=1\nB=2\n' });
+
+    expect(textOf(await handler({ environmentId: 8, name: 'demo' }))).toBe('A=1\nB=2\n');
+  });
+
+  it('does not hand back the JSON envelope', async () => {
+    const { handler, client } = setupRaw();
+    client.get.mockResolvedValue({ content: 'A=1\n' });
+
+    // The pre-#198 behaviour: `{"content":"A=1\n"}` as text.
+    expect(textOf(await handler({ environmentId: 8, name: 'demo' }))).not.toContain('"content"');
+  });
+
+  it('distinguishes "no env file" from "an empty env file"', async () => {
+    // Both arrive as an empty string; an empty response cannot say which, and the two mean
+    // different things for the caller.
+    const noFile = setupRaw();
+    noFile.client.get.mockResolvedValue({ content: '', noEnvFile: true });
+    expect(textOf(await noFile.handler({ environmentId: 8, name: 'demo' }))).toMatch(/no \.env file/i);
+
+    const emptyFile = setupRaw();
+    emptyFile.client.get.mockResolvedValue({ content: '' });
+    expect(textOf(await emptyFile.handler({ environmentId: 8, name: 'demo' }))).toBe('');
+  });
+
+  it('aborts on an unexpected response shape instead of returning something plausible', async () => {
+    const { handler, client } = setupRaw();
+    client.get.mockResolvedValue({ unexpected: 'shape' });
+
+    const res = await handler({ environmentId: 8, name: 'demo' });
+    expect(JSON.stringify(res)).toMatch(/Refusing to continue/);
+  });
+
+  it('warns that the response carries credentials verbatim', () => {
+    const description = describeTool('get_stack_env_raw');
+
+    expect(description).toMatch(/SECURITY/);
+    expect(description).toMatch(/nothing is masked/i);
+    expect(description).toMatch(/get_stack_env/);
   });
 });


### PR DESCRIPTION
Closes #198.

Same root cause as #196, deliberately left out of that hotfix because it changes the output shape for existing callers. `get_stack_env_raw` advertises "read the raw .env" and handed back the envelope instead:

```json
{"content":"KEY=value\n…"}
```

## Two things a naive unwrap would have lost

**`noEnvFile: true` is not "empty file".** One means the stack has no `.env` at all, the other that it has one with nothing in it. Both arrive as an empty string, and an empty tool response cannot express which — so the no-file case now says so in words.

**An unexpected shape must not look plausible.** It aborts via `extractDotEnvContent()` rather than returning an empty result that reads like a successful answer. Same reasoning as #196.

## The open question from the issue

"Whether any caller already unwraps the envelope itself and would break." Checked before changing anything: `get_stack_env_raw` appears in the tool registration, the endpoint map and one README row — nowhere else. Nothing depended on the old shape.

## An operator-safety note, added while here

This tool returns the file **verbatim**. For stacks that keep credentials in `.env` — the norm for internal and adopted stacks — the response carries them unmasked, unlike `get_stack_env`, which masks anything stored as a secret.

The endpoint description says "raw", not "contains secrets", and the difference is invisible until the values are already in the transcript. So the tool now carries a suffix pointing at `get_stack_env` as the default and suggesting reading key names rather than printing the response when that is all the caller needs.

This is the second entry in `TOOL_DESCRIPTION_SUFFIXES` (added in #201) and fits its documented bar: a consequence a caller cannot see from the endpoint's own description.

## Counter-check

Restoring the pass-through turns four of the five new assertions red — the content assertion, the "not the envelope" assertion, the no-file distinction and the unexpected-shape abort. The fifth (the suffix) is independent of the handler, and correctly stays green.

## Verification

- `npx vitest run` → 982 tests, 77 files, all green
- `npx tsc --noEmit` → clean
- derived docs regenerated (the gate from #205 would otherwise catch them)
