### PR TITLE
docs(tools): state outright that exec_container returns no output

### DIFF
--- a/src/openapi/description-suffixes.ts
+++ b/src/openapi/description-suffixes.ts
@@ -47,7 +47,30 @@ const RETURNS_THE_FILE_VERBATIM =
   'you specifically need the file itself. If you only need to know WHICH keys exist, say so ' +
   'and read the key names rather than printing the response.';
 
+/**
+ * `exec_container` does not execute anything the caller can name, and its result cannot be
+ * read back over REST. Verified against the 1.0.42 handler: the exec instance is created with
+ * `cmd: [shell]` — the shell and nothing else, there is no command parameter — and the
+ * response is an exec id plus Docker connection coordinates so a browser terminal can attach
+ * to the daemon directly. The stream never passes through Dockhand's HTTP API, and no other
+ * upstream endpoint runs a command and returns its output (`createExec` has exactly two
+ * call sites there).
+ *
+ * The endpoint's own summary does say "return its ID plus the Docker connection info for a
+ * terminal WebSocket", but a tool named exec_container invites the attempt anyway — so the
+ * dead end is stated outright, along with what to reach for instead. Reported as #195 by a
+ * user who went looking for the output and found none.
+ */
+const EXEC_RETURNS_NO_OUTPUT =
+  'IMPORTANT: this does NOT run a command and cannot return output. It only opens an ' +
+  'interactive shell session for a client that can attach a terminal — there is no command ' +
+  'parameter, and the stream does not travel over the REST API, so no follow-up call can ' +
+  'retrieve results. Do not retry expecting output. For what a container already produced use ' +
+  'get_container_logs; for state on disk use list_container_files and ' +
+  'get_container_file_content; for running processes use get_container_top.';
+
 export const TOOL_DESCRIPTION_SUFFIXES: Readonly<Record<string, string>> = {
+  exec_container: EXEC_RETURNS_NO_OUTPUT,
   get_stack_env_raw: RETURNS_THE_FILE_VERBATIM,
   create_secret_provider: CONFIG_CARRIES_CREDENTIALS,
   update_secret_provider: CONFIG_CARRIES_CREDENTIALS,

--- a/tests/description-crossrefs.test.ts
+++ b/tests/description-crossrefs.test.ts
@@ -42,6 +42,12 @@ import { registerAllTools } from '../src/tools/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TOOLS_DIR = join(__dirname, '..', 'src', 'tools');
+/**
+ * Suffixes carry hand-written references too — the exec_container notice (#195) points at
+ * three other tools — and they reach clients exactly like a `.describe()` string does. Left
+ * unscanned, this file would be a blind spot of precisely the kind this test exists to close.
+ */
+const SUFFIXES_FILE = join(__dirname, '..', 'src', 'openapi', 'description-suffixes.ts');
 
 /** Every tool name the server actually registers. */
 function registeredToolNames(): Set<string> {
@@ -70,18 +76,33 @@ interface Reference {
 }
 
 /** Runs `scan` over every `.describe()` line in src/tools, skipping self-registrations. */
-function scanDescribeLines(scan: RegExp, keep: (name: string) => boolean): Reference[] {
+const toolSources = () =>
+  readdirSync(TOOLS_DIR)
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => ({ label: `src/tools/${f}`, path: join(TOOLS_DIR, f), describeOnly: true }));
+
+const suffixSource = {
+  label: 'src/openapi/description-suffixes.ts',
+  path: SUFFIXES_FILE,
+  describeOnly: false,
+};
+
+function scanDescribeLines(
+  scan: RegExp,
+  keep: (name: string) => boolean,
+  sources: { label: string; path: string; describeOnly: boolean }[],
+): Reference[] {
   const found: Reference[] = [];
-  for (const file of readdirSync(TOOLS_DIR).filter((f) => f.endsWith('.ts'))) {
-    const lines = readFileSync(join(TOOLS_DIR, file), 'utf-8').split('\n');
+  for (const { label, path, describeOnly } of sources) {
+    const lines = readFileSync(path, 'utf-8').split('\n');
     lines.forEach((line, i) => {
-      if (!line.includes('.describe(')) return;
+      if (describeOnly && !line.includes('.describe(')) return;
       for (const match of line.matchAll(scan)) {
         const tool = match[1].toLowerCase();
         // A tool's own registration line is a definition, not a reference.
         if (line.includes(`registerTool(server, '${tool}'`)) continue;
         if (!keep(tool)) continue;
-        found.push({ where: `src/tools/${file}:${i + 1}`, tool });
+        found.push({ where: `${label}:${i + 1}`, tool });
       }
     });
   }
@@ -92,8 +113,14 @@ const key = (r: Reference) => `${r.tool} (${r.where})`;
 
 describe('hand-written tool cross-references', () => {
   const registered = registeredToolNames();
-  const anchored = scanDescribeLines(CROSSREF, () => true);
-  const mentioned = scanDescribeLines(SNAKE_CASE, (name) => registered.has(name));
+  // Dangling-reference check covers BOTH files: a suffix reaches clients exactly like a
+  // `.describe()` string does.
+  const anchored = scanDescribeLines(CROSSREF, () => true, [...toolSources(), suffixSource]);
+  // The phrasing-coverage check stays on src/tools only. There, every registered tool name
+  // inside a `.describe()` string really is a reference. description-suffixes.ts also carries
+  // them as map KEYS and in explanatory prose ("`exec_container` does not execute…"), which
+  // are not references and would make this assertion demand an anchor for a definition.
+  const mentioned = scanDescribeLines(SNAKE_CASE, (name) => registered.has(name), toolSources());
 
   it('finds references to check (guards against the scan silently matching nothing)', () => {
     // A test that scans for violations passes trivially when its scan is broken. This asserts

--- a/tests/description-crossrefs.test.ts
+++ b/tests/description-crossrefs.test.ts
@@ -76,16 +76,38 @@ interface Reference {
 }
 
 /** Runs `scan` over every `.describe()` line in src/tools, skipping self-registrations. */
+/**
+ * Suffix VALUES are scanned differently from `.describe()` lines, for two reasons Codex found
+ * on #208:
+ *
+ *   1. They are multi-line string concatenations, so a line-by-line scan splits an anchor from
+ *      its target: `… produced use ' +` ends one line and `'get_container_logs; …` begins the
+ *      next. Two of the four references in the exec_container notice were invisible that way.
+ *   2. The anchor vocabulary does not fit this prose anyway — the get_stack_env_raw notice says
+ *      "Prefer get_stack_env", and "prefer" is not a cross-reference verb.
+ *
+ * So instead of anchoring, EVERY snake_case identifier inside a suffix's string literals must
+ * be a registered tool. Map keys and JSDoc are excluded for free, because only string literal
+ * contents are read. If a suffix ever needs a snake_case word that is not a tool, this fails
+ * loudly and the wording gets changed — that is the right trade for a file whose whole purpose
+ * is telling agents which tool to use instead.
+ */
+function suffixStringReferences(): Reference[] {
+  const source = readFileSync(SUFFIXES_FILE, 'utf-8');
+  const refs: Reference[] = [];
+  for (const match of source.matchAll(/'((?:[^'\\]|\\.)*)'/g)) {
+    const lineNo = source.slice(0, match.index).split('\n').length;
+    for (const id of match[1].matchAll(SNAKE_CASE)) {
+      refs.push({ where: `src/openapi/description-suffixes.ts:${lineNo}`, tool: id[1] });
+    }
+  }
+  return refs;
+}
+
 const toolSources = () =>
   readdirSync(TOOLS_DIR)
     .filter((f) => f.endsWith('.ts'))
     .map((f) => ({ label: `src/tools/${f}`, path: join(TOOLS_DIR, f), describeOnly: true }));
-
-const suffixSource = {
-  label: 'src/openapi/description-suffixes.ts',
-  path: SUFFIXES_FILE,
-  describeOnly: false,
-};
 
 function scanDescribeLines(
   scan: RegExp,
@@ -115,7 +137,7 @@ describe('hand-written tool cross-references', () => {
   const registered = registeredToolNames();
   // Dangling-reference check covers BOTH files: a suffix reaches clients exactly like a
   // `.describe()` string does.
-  const anchored = scanDescribeLines(CROSSREF, () => true, [...toolSources(), suffixSource]);
+  const anchored = [...scanDescribeLines(CROSSREF, () => true, toolSources()), ...suffixStringReferences()];
   // The phrasing-coverage check stays on src/tools only. There, every registered tool name
   // inside a `.describe()` string really is a reference. description-suffixes.ts also carries
   // them as map KEYS and in explanatory prose ("`exec_container` does not execute…"), which

--- a/tests/secret-providers.test.ts
+++ b/tests/secret-providers.test.ts
@@ -161,3 +161,29 @@ describe('operator-safety suffix', () => {
     expect(description).not.toBe('No description available.');
   });
 });
+
+describe('exec_container limitation notice (#195)', () => {
+  it('states outright that it runs nothing and returns no output', () => {
+    const description = describeTool('exec_container');
+
+    expect(description).toMatch(/does NOT run a command/);
+    expect(description).toMatch(/cannot return output/i);
+    expect(description).toMatch(/do not retry expecting output/i);
+  });
+
+  it('names the tools that do serve the underlying need', () => {
+    const description = describeTool('exec_container');
+
+    // A dead end without an alternative just moves the guesswork one step along.
+    expect(description).toMatch(/get_container_logs/);
+    expect(description).toMatch(/get_container_file_content/);
+    expect(description).toMatch(/get_container_top/);
+  });
+
+  it('keeps the spec-derived description alongside the notice', () => {
+    const description = describeTool('exec_container');
+
+    expect(description).toMatch(/exec instance/i);
+    expect(description.indexOf('IMPORTANT')).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Refs #195.

## Verified, not inferred

The reporter says `exec_container` returns a session handle instead of output. Correct — and the conclusion is stronger than "the mapping is wrong". From the 1.0.42 handler:

```ts
const exec = await createExec({
  containerId,
  cmd: [shell],        // the shell, and nothing else
  user,
  envId
});
return json({ execId: exec.Id, connectionInfo: { type, host, port } });
```

1. **There is no command to run.** The endpoint takes `shell` and `user`; no parameter anywhere carries a command. "Run `ls -la` and give me the output" cannot be expressed here at all.
2. **The output never travels over REST.** The response hands back Docker connection coordinates so a browser terminal attaches to the daemon directly. The stream does not pass through Dockhand's HTTP API.

`createExec` has exactly two call sites upstream (`containers/[id]/exec`, `containers/[id]/shells`), so no other endpoint serves the need either.

So our tool mirrors the endpoint faithfully; the endpoint cannot serve what a caller wants from something named `exec_container`. That distinction decides the fix — a wrong request shape would be repairable here, this is not.

## What this does

The tool keeps its spec-derived description and gains a note saying it executes nothing, that no output is retrievable, and **what to reach for instead** — `get_container_logs`, `list_container_files` / `get_container_file_content`, `get_container_top`. A dead end without an alternative just moves the guesswork one step along.

Not removed: creating an exec session is legitimately useful for a client that *can* attach a terminal, and the MCP is not the only consumer.

## The guard needed widening first

The cross-reference test from #204 scanned `src/tools/*.ts` only. This commit adds three tool references in `description-suffixes.ts` — a file the guard did not look at. Left as-is it would have introduced exactly the class of dangling reference the guard exists to catch, in its blind spot.

The two assertions are now scoped differently, on purpose:

| Assertion | Scope | Why |
|---|---|---|
| every referenced tool is registered | both files | a suffix reaches clients exactly like a `.describe()` string |
| every phrasing is recognised | `src/tools` only | the suffixes file carries tool names as map **keys** and in explanatory prose — definitions, not references |

Without that split the coverage assertion would demand a cross-reference anchor for `exec_container:` in its own map entry.

**Counter-check:** pointing a suffix at a nonexistent tool turns the guard red with name and line.

## Verification

- `npx vitest run` → 985 tests, 77 files, all green
- `npm run api:validate` → exit 0
