### PR TITLE
feat: make LOG_LEVEL real, add an access log CrowdSec can parse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,5 +39,10 @@ MCP_PORT=8080
 #   openssl rand -hex 32
 #MCP_AUTH_TOKEN=CHANGE_ME
 
-# Log Level (optional, default: info)
+# Log level: error, warn, info or debug. debug adds one line per Dockhand request
+# (method, endpoint template, status, duration) and never logs a value.
 LOG_LEVEL=info
+
+# Addresses or CIDRs allowed to set X-Forwarded-For / X-Real-IP. Required when this
+# server runs behind a reverse proxy — see "Securing the server with CrowdSec".
+# TRUSTED_PROXIES=10.0.0.0/8, 100.64.0.0/10

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,16 @@ WORKDIR /app
 ARG MCP_SERVER_VERSION="0.0.0-dev"
 ARG MCP_GIT_SHA="unknown"
 ARG MCP_BUILD_DATE="unknown"
-ENV MCP_SERVER_VERSION=$MCP_SERVER_VERSION \
+# NODE_ENV=production is load-bearing, not cosmetic. Express reads it once at
+# startup (application.js: `process.env.NODE_ENV || 'development'`) and passes the
+# result to finalhandler, which serialises `err.stack` into the response body for
+# any value other than 'production'. Because express.json() is registered ahead of
+# the bearer guard (deliberately, so rejected requests still produce an access
+# line), a malformed body from an UNAUTHENTICATED caller reaches finalhandler
+# without ever meeting the guard — and returned a full stack trace with container
+# paths and dependency line offsets. Found by the security audit, 2026-08-18.
+ENV NODE_ENV=production \
+    MCP_SERVER_VERSION=$MCP_SERVER_VERSION \
     MCP_GIT_SHA=$MCP_GIT_SHA \
     MCP_BUILD_DATE=$MCP_BUILD_DATE
 RUN addgroup -g 1001 mcp && adduser -u 1001 -G mcp -D mcp

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ DOCKHAND_URL=https://your-server.com DOCKHAND_USERNAME=admin DOCKHAND_PASSWORD=s
 | `MCP_ALLOWED_HOSTS` | No | *(unset — Host check disabled)* | Comma-separated `Host` header allowlist for `/mcp` (DNS-rebinding protection). **Opt-in**: unset means no Host check at all (pre-existing behavior, so existing deployments aren't broken by an update). Recommended once you set it up — see [Securing the transport](#securing-the-transport) |
 | `MCP_ALLOWED_ORIGINS` | No | *(unset — Origin check disabled)* | Comma-separated `Origin` header allowlist for `/mcp`. Opt-in, same as above. Only enforced when a caller actually sends an `Origin` header at all (non-browser MCP clients typically don't) |
 | `MCP_AUTH_TOKEN` | No | *(unset — endpoint unauthenticated)* | Shared secret required as `Authorization: Bearer <token>` on every `/mcp` request. Opt-in; recommended once the endpoint is reachable beyond your own loopback — see [Securing the transport](#securing-the-transport) |
-| `LOG_LEVEL` | No | `info` | Log level |
+| `LOG_LEVEL` | No | `info` | `error`, `warn`, `info` or `debug`. `debug` adds one line per Dockhand request (method, endpoint template, status, duration) — never a path segment or a parameter value. An unrecognised value warns and falls back to `info`. |
+| `TRUSTED_PROXIES` | No | _(empty)_ | Comma-separated addresses or CIDRs allowed to set `X-Forwarded-For` / `X-Real-IP`, e.g. `10.0.0.0/8, 100.64.0.0/10`. Empty means the headers are ignored and the peer address is used. |
 
 ### Securing the transport
 
@@ -119,6 +120,56 @@ MCP_ALLOWED_HOSTS=dock-mcp.internal.example.com
 #MCP_ALLOWED_HOSTS=100.100.50.40:8222
 MCP_AUTH_TOKEN=<a long random secret, e.g. `openssl rand -hex 32`>
 ```
+
+## Securing the server with CrowdSec
+
+The server writes an nginx-format access line to **stdout** for every request,
+including the ones it rejects, while the structured application log goes to
+**stderr**. CrowdSec parses the access lines with its stock collections — no custom
+parser required.
+
+Add an acquisition file on the host running your CrowdSec agent:
+
+```yaml
+source: docker
+container_name:
+  - mcp-dockhand
+labels:
+  type: docker
+  program: nginx-mcp
+```
+
+**Both labels are required, and neither fails loudly if you forget it.**
+`type: docker` enables `crowdsecurity/docker-logs`, which unwraps Docker's JSON
+envelope. `program: nginx-mcp` enables `crowdsecurity/nginx-logs`, which matches on
+`program` starting with `nginx` — the `-mcp` suffix keeps this source distinguishable
+from your other nginx sources. With one label missing the chain simply produces
+nothing, and nothing reports it.
+
+Once wired up, the stock scenarios apply:
+
+| Scenario | What it means here |
+|---|---|
+| `LePresidente/http-generic-401-bf` | Repeated `401` on `/mcp` — someone is guessing `MCP_AUTH_TOKEN` |
+| `crowdsecurity/http-dos-swithcing-ua` | Request floods with rotating user agents |
+
+A `403` is worth watching too: it means a request failed the `MCP_ALLOWED_HOSTS` or
+`MCP_ALLOWED_ORIGINS` check, which is what a DNS-rebinding attempt looks like from
+here.
+
+> **Set `TRUSTED_PROXIES` before you enable this.**
+> Behind a reverse proxy every request arrives from the proxy's address. Without
+> `TRUSTED_PROXIES` that address is what gets logged — so the first ban CrowdSec
+> issues takes out the proxy, and with it every user behind it. Set it to the
+> address or subnet your proxy talks from.
+>
+> The setting is equally deliberate in the other direction: the forwarding headers
+> are only honoured from a peer on that list. Trusting them unconditionally would let
+> any direct caller name an arbitrary third party and have them banned.
+
+**One expected side effect:** the structured JSON lines share the container's log
+stream and carry the same `program` label, so they fail the nginx pattern and count
+as `unparsed` in `cscli metrics`. That is noise, not a fault — no alert, no decision.
 
 ## MCP Client Configuration
 
@@ -548,6 +599,14 @@ The server uses session-based cookie authentication. It automatically:
 - Stores the session cookie in memory
 - Re-authenticates on 401 responses
 - Handles session timeout (24h)
+
+### Troubleshooting
+
+Start with `LOG_LEVEL=debug`. Every Dockhand request then appears with its endpoint,
+status code and duration, and every line of a single call shares one `call`
+identifier — `grep` for it to get the whole sequence. The `req` identifier ties those
+lines back to the access line that started them, and `sid` covers everything one
+client did across its whole session.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ A `403` is worth watching too: it means a request failed the `MCP_ALLOWED_HOSTS`
 `MCP_ALLOWED_ORIGINS` check, which is what a DNS-rebinding attempt looks like from
 here.
 
+> **The stock 401 scenario only counts `POST`.** Its filter is
+> `evt.Parsed.verb == 'POST'` — one literal, not a list. This server serves `POST`, `GET`
+> and `DELETE` on `/mcp`, and the bearer check runs ahead of all three, so a wrong token
+> on `GET /mcp` or `DELETE /mcp` returns `401` exactly like `POST` does — and
+> `LePresidente/http-generic-401-bf` never counts those. Someone guessing
+> `MCP_AUTH_TOKEN` over `GET /mcp` is invisible to it.
+>
+> This is a property of the upstream scenario, shared with every nginx deployment that
+> uses it — not something this server's log format can fix. To close it, add a local
+> scenario that drops the `verb` filter, or matches the three methods this server
+> answers on. Until then, treat the row above as "repeated `401` on **`POST`** `/mcp`".
+
 > **Set `TRUSTED_PROXIES` before you enable this.**
 > Behind a reverse proxy every request arrives from the proxy's address. Without
 > `TRUSTED_PROXIES` that address is what gets logged — so the first ban CrowdSec

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "express": "^5.1.0",
+        "pino": "^9",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -1221,6 +1222,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -2808,6 +2815,15 @@
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/before-after-hook": {
@@ -7533,6 +7549,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7828,6 +7853,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -7903,6 +7974,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -7956,6 +8043,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.3.0",
@@ -8080,6 +8173,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
@@ -8178,6 +8280,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8717,6 +8828,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9032,6 +9152,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/through2": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "express": "^5.1.0",
+    "pino": "^9",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -5,7 +5,7 @@
 
 import type { DockhandConfig, SessionInfo } from '../types/dockhand.js';
 import { describeLoginFailure, normalizeBaseUrl } from '../utils/url.js';
-import { logger } from '../utils/logger.js';
+import { log } from '../utils/log-context.js';
 
 const SESSION_TIMEOUT_MS = 23 * 60 * 60 * 1000; // 23h (conservative, actual is 24h)
 
@@ -59,7 +59,13 @@ export class SessionManager {
       // written to stderr/docker logs on its own. Logged here at 'error' —
       // the most restrictive level — so a failed login is always diagnosable
       // from `docker logs` no matter what LOG_LEVEL is set to. See Issue #116.
-      logger.error(
+      //
+      // Through log() rather than the bare logger so it carries req/sid/call/tool
+      // when a request is what triggered it. This is the line Issue #116 is about:
+      // without them an operator sees 'tool failed' with a call id and 'login
+      // failed' with nothing to join it to, and has to match the two up by
+      // timestamp.
+      log().error(
         { component: 'session', user: this.config.username, status: response.status, detail },
         'login failed',
       );
@@ -103,7 +109,7 @@ export class SessionManager {
       expiresAt: Date.now() + SESSION_TIMEOUT_MS,
     };
 
-    logger.info({ component: 'session', user: this.config.username }, 'logged in to Dockhand');
+    log().info({ component: 'session', user: this.config.username }, 'logged in to Dockhand');
   }
 
   /**
@@ -121,7 +127,7 @@ export class SessionManager {
    */
   invalidate(): void {
     this.session = null;
-    logger.info({ component: 'session' }, 'session invalidated, will re-login on next request');
+    log().info({ component: 'session' }, 'session invalidated, will re-login on next request');
   }
 
   /**

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -38,16 +38,7 @@ export class SessionManager {
   private async performLogin(): Promise<void> {
     const url = `${normalizeBaseUrl(this.config.url)}/api/auth/login`;
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        username: this.config.username,
-        password: this.config.password,
-        provider: 'local',
-      }),
-      redirect: 'manual',
-    });
+    const response = await this.loggedLoginFetch(url);
 
     // Read body once and cache it to avoid double-read errors
     const responseBody = await response.text().catch(() => '');
@@ -110,6 +101,65 @@ export class SessionManager {
     };
 
     log().info({ component: 'session', user: this.config.username }, 'logged in to Dockhand');
+  }
+
+  /**
+   * The login is the one request to Dockhand that does not go through
+   * DockhandClient.loggedFetch — SessionManager holds no client, it is what the client
+   * is built on. So it was the one request with no debug line: at LOG_LEVEL=debug
+   * against an unreachable Dockhand an operator saw the tool failure and not a single
+   * component:"client" line, for the exact request Issue #116 is about.
+   *
+   * Same shape as loggedFetch, not the same function: component, method, route, status
+   * and duration on success; a warn carrying only the exception's NAME when the call
+   * never got that far (that path is the interesting one — an unreachable host throws
+   * rather than answering).
+   *
+   * `route` is a constant. loggedFetch derives it from the call context or truncates a
+   * caller-supplied path to two segments; here the path is fixed at the one call site
+   * above, and /api/auth is what that truncation would produce. Nothing derived from
+   * the URL, the body or the credentials is passed to the logger at all — which is
+   * what keeps the debug level's no-values guarantee true with a second call site
+   * (tests/no-console.test.ts allowlists this file for exactly that reason).
+   */
+  private async loggedLoginFetch(url: string): Promise<Response> {
+    const started = Date.now();
+    const route = '/api/auth';
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username: this.config.username,
+          password: this.config.password,
+          provider: 'local',
+        }),
+        redirect: 'manual',
+      });
+    } catch (error) {
+      // `err: { type }` and no message, mirroring the client: an exception name is
+      // bounded to the DOM/Node vocabulary (TypeError, TimeoutError, ...), the message
+      // is free text from an exception this code did not construct.
+      log().warn(
+        {
+          component: 'client',
+          method: 'POST',
+          route,
+          ms: Date.now() - started,
+          err: { type: error instanceof Error ? error.name : 'UnknownError' },
+        },
+        'dockhand request failed',
+      );
+      throw error;
+    }
+
+    log().debug(
+      { component: 'client', method: 'POST', route, status: response.status, ms: Date.now() - started },
+      'dockhand request',
+    );
+    return response;
   }
 
   /**

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -5,6 +5,7 @@
 
 import type { DockhandConfig, SessionInfo } from '../types/dockhand.js';
 import { describeLoginFailure, normalizeBaseUrl } from '../utils/url.js';
+import { logger } from '../utils/logger.js';
 
 const SESSION_TIMEOUT_MS = 23 * 60 * 60 * 1000; // 23h (conservative, actual is 24h)
 
@@ -55,11 +56,13 @@ export class SessionManager {
       const detail = describeLoginFailure(response.status, response.headers.get('location'), responseBody, response.statusText);
       // Fail loud: a login failure only ever surfaces to the caller as a
       // structured MCP tool error (src/utils/tool-helper.ts), which is never
-      // written to stderr/docker logs on its own. Log it here unconditionally
-      // (no LOG_LEVEL gate — the server doesn't implement log levels at all)
-      // so a failed login is always diagnosable from `docker logs`. See
-      // Issue #116.
-      console.error(`[session] Login failed for ${this.config.username}: HTTP ${response.status} — ${detail}`);
+      // written to stderr/docker logs on its own. Logged here at 'error' —
+      // the most restrictive level — so a failed login is always diagnosable
+      // from `docker logs` no matter what LOG_LEVEL is set to. See Issue #116.
+      logger.error(
+        { component: 'session', user: this.config.username, status: response.status, detail },
+        'login failed',
+      );
       throw new Error(`Dockhand login failed (HTTP ${response.status}): ${detail}`);
     }
 
@@ -100,7 +103,7 @@ export class SessionManager {
       expiresAt: Date.now() + SESSION_TIMEOUT_MS,
     };
 
-    console.error(`[session] Logged in to Dockhand as ${this.config.username}`);
+    logger.info({ component: 'session', user: this.config.username }, 'logged in to Dockhand');
   }
 
   /**
@@ -118,7 +121,7 @@ export class SessionManager {
    */
   invalidate(): void {
     this.session = null;
-    console.error('[session] Session invalidated, will re-login on next request');
+    logger.info({ component: 'session' }, 'session invalidated, will re-login on next request');
   }
 
   /**

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -215,7 +215,7 @@ export class DockhandClient {
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
       // Fix round 3, Item B: redact any URL query string BEFORE this message reaches
-      // ANY of its consumers — console.error (docker logs), errorResponse (the calling
+      // ANY of its consumers — log().error (docker logs), errorResponse (the calling
       // MCP client), and recordError/get_runtime_stats (see src/utils/redact.ts's own
       // doc comment for the full rationale — a query param can carry a secret, e.g.
       // trigger_git_webhook's `?secret=<value>`).
@@ -262,7 +262,7 @@ export class DockhandClient {
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
       // Fix round 3, Item B: redact any URL query string BEFORE this message reaches
-      // ANY of its consumers — console.error (docker logs), errorResponse (the calling
+      // ANY of its consumers — log().error (docker logs), errorResponse (the calling
       // MCP client), and recordError/get_runtime_stats (see src/utils/redact.ts's own
       // doc comment for the full rationale — a query param can carry a secret, e.g.
       // trigger_git_webhook's `?secret=<value>`).

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -13,9 +13,11 @@ import { log, currentLogContext } from '../utils/log-context.js';
 const SSE_TIMEOUT_MS = 300_000;
 
 /**
- * Fallback for calls made outside a tool context (login, self-check): the first two
- * path segments. Coarse on purpose — it is enough to tell /api/auth from /api/stacks
- * and short enough that it cannot contain an identifier.
+ * Fallback for calls made outside a tool context (login, self-check) and for any tool
+ * with no `TOOL_ENDPOINT_MAP` entry — the latter arrives with caller-supplied path
+ * parameters already substituted into `pathname`, same as the former. The first two
+ * path segments are coarse on purpose — enough to tell /api/auth from /api/stacks and
+ * short enough that it cannot contain an identifier.
  */
 function coarseRoute(pathname: string): string {
   const segments = pathname.split('/').filter(Boolean).slice(0, 2);
@@ -196,7 +198,11 @@ export class DockhandClient {
    * politeness: `url` carries stack names, container ids and — for
    * trigger_git_webhook — a secret in the query string. There is deliberately no code
    * path here that can write a value, rather than a filter that has to keep up with
-   * every parameter a future tool introduces.
+   * every parameter a future tool introduces. That is exact for the context-supplied
+   * route; for the `coarseRoute()` fallback it is a truncation argument instead — two
+   * path segments are short enough that no identifier fits, even though the segments
+   * themselves come from the same caller-supplied `pathname` that `url` would expose
+   * in full.
    */
   private async loggedFetch(method: string, url: string, init: RequestInit): Promise<Response> {
     const started = Date.now();
@@ -219,13 +225,20 @@ export class DockhandClient {
       );
       return response;
     } catch (error) {
+      // No `message` field: it is free text from an exception this code did not
+      // construct, and the one field in this file that would not be structurally
+      // value-free. `error.name` is bounded to the DOM/Node exception vocabulary
+      // (TypeError, TimeoutError, AbortError, ...) and — unlike the previous
+      // hardcoded 'NetworkError' — actually reflects what AbortSignal.timeout()
+      // throws when the SSE timeout fires.
       log().warn(
         {
           component: 'client',
           method,
           route,
+          ...(query.length ? { query } : {}),
           ms: Date.now() - started,
-          err: { type: 'NetworkError', message: error instanceof Error ? error.message : 'unknown' },
+          err: { type: error instanceof Error ? error.name : 'UnknownError' },
         },
         'dockhand request failed',
       );

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -7,9 +7,20 @@ import { SessionManager } from '../auth/session.js';
 import type { DockhandConfig, SSEResult } from '../types/dockhand.js';
 import { normalizeBaseUrl } from '../utils/url.js';
 import { redactQueryStrings } from '../utils/redact.js';
+import { log, currentLogContext } from '../utils/log-context.js';
 
 /** Timeout for SSE streaming responses (5 minutes). */
 const SSE_TIMEOUT_MS = 300_000;
+
+/**
+ * Fallback for calls made outside a tool context (login, self-check): the first two
+ * path segments. Coarse on purpose — it is enough to tell /api/auth from /api/stacks
+ * and short enough that it cannot contain an identifier.
+ */
+function coarseRoute(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean).slice(0, 2);
+  return `/${segments.join('/')}`;
+}
 
 export class DockhandClient {
   private session: SessionManager;
@@ -115,7 +126,7 @@ export class DockhandClient {
       headers['Content-Type'] = 'application/json';
     }
 
-    const response = await fetch(url, {
+    const response = await this.loggedFetch('POST', url, {
       method: 'POST',
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -127,7 +138,7 @@ export class DockhandClient {
       // Retry once after re-login
       const retryCookie = await this.session.getCookie();
       headers['Cookie'] = retryCookie;
-      const retryResponse = await fetch(url, {
+      const retryResponse = await this.loggedFetch('POST', url, {
         method: 'POST',
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -152,7 +163,7 @@ export class DockhandClient {
       'Content-Type': 'application/json',
     };
 
-    const response = await fetch(url, {
+    const response = await this.loggedFetch('PUT', url, {
       method: 'PUT',
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -163,7 +174,7 @@ export class DockhandClient {
       this.session.invalidate();
       const retryCookie = await this.session.getCookie();
       headers['Cookie'] = retryCookie;
-      const retryResponse = await fetch(url, {
+      const retryResponse = await this.loggedFetch('PUT', url, {
         method: 'PUT',
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -176,6 +187,51 @@ export class DockhandClient {
   }
 
   // --- Private helpers ---
+
+  /**
+   * The single place this client talks to the network, so the single place a debug
+   * line belongs.
+   *
+   * It logs the endpoint TEMPLATE from the call context, never `url`. That is not
+   * politeness: `url` carries stack names, container ids and — for
+   * trigger_git_webhook — a secret in the query string. There is deliberately no code
+   * path here that can write a value, rather than a filter that has to keep up with
+   * every parameter a future tool introduces.
+   */
+  private async loggedFetch(method: string, url: string, init: RequestInit): Promise<Response> {
+    const started = Date.now();
+    const parsed = new URL(url);
+    const route = currentLogContext().route ?? coarseRoute(parsed.pathname);
+    const query = [...parsed.searchParams.keys()];
+
+    try {
+      const response = await fetch(url, init);
+      log().debug(
+        {
+          component: 'client',
+          method,
+          route,
+          ...(query.length ? { query } : {}),
+          status: response.status,
+          ms: Date.now() - started,
+        },
+        'dockhand request',
+      );
+      return response;
+    } catch (error) {
+      log().warn(
+        {
+          component: 'client',
+          method,
+          route,
+          ms: Date.now() - started,
+          err: { type: 'NetworkError', message: error instanceof Error ? error.message : 'unknown' },
+        },
+        'dockhand request failed',
+      );
+      throw error;
+    }
+  }
 
   private buildUrl(path: string, params?: Record<string, string | number | undefined>): string {
     const url = new URL(path, this.baseUrl);
@@ -203,13 +259,13 @@ export class DockhandClient {
     const cookie = await this.session.getCookie();
     const headers: Record<string, string> = { 'Cookie': cookie, ...extraHeaders };
 
-    let response = await fetch(url, { method, headers, body });
+    let response = await this.loggedFetch(method, url, { method, headers, body });
 
     if (response.status === 401) {
       this.session.invalidate();
       const retryCookie = await this.session.getCookie();
       headers['Cookie'] = retryCookie;
-      response = await fetch(url, { method, headers, body });
+      response = await this.loggedFetch(method, url, { method, headers, body });
     }
 
     if (!response.ok) {
@@ -241,7 +297,7 @@ export class DockhandClient {
       headers['Content-Type'] = 'application/json';
     }
 
-    let response = await fetch(url, {
+    let response = await this.loggedFetch(method, url, {
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -252,7 +308,7 @@ export class DockhandClient {
       this.session.invalidate();
       const retryCookie = await this.session.getCookie();
       headers['Cookie'] = retryCookie;
-      response = await fetch(url, {
+      response = await this.loggedFetch(method, url, {
         method,
         headers,
         body: body !== undefined ? JSON.stringify(body) : undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,7 @@ function getEnvOrThrow(name: string): string {
   if (!value) {
     logger.error(
       { component: 'config', variable: name },
-      `Environment variable ${name} is required but not set. ` +
-        'Copy .env.example to .env and fill in your Dockhand credentials.',
+      'required environment variable is not set — copy .env.example to .env and fill in your Dockhand credentials',
     );
     process.exit(1);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,16 @@
  */
 
 import { createServer } from './server.js';
+import { logger } from './utils/logger.js';
 
 function getEnvOrThrow(name: string): string {
   const value = process.env[name];
   if (!value) {
-    console.error(`[config] ERROR: Environment variable ${name} is required but not set.`);
-    console.error('[config] Copy .env.example to .env and fill in your Dockhand credentials.');
+    logger.error(
+      { component: 'config', variable: name },
+      `Environment variable ${name} is required but not set. ` +
+        'Copy .env.example to .env and fill in your Dockhand credentials.',
+    );
     process.exit(1);
   }
   return value;
@@ -27,12 +31,17 @@ const config = {
   host: process.env['MCP_HOST'] || '0.0.0.0',
 };
 
-console.error('[config] Starting MCP Dockhand server...');
-console.error(`[config] Dockhand URL: ${config.dockhand.url}`);
-console.error(`[config] Dockhand User: ${config.dockhand.username}`);
-console.error(`[config] MCP Port: ${config.port}`);
+logger.info(
+  {
+    component: 'config',
+    dockhandUrl: config.dockhand.url,
+    dockhandUser: config.dockhand.username,
+    port: config.port,
+  },
+  'starting MCP Dockhand server',
+);
 
-createServer(config).catch((error) => {
-  console.error('[fatal] Failed to start server:', error);
+createServer(config).catch((error: unknown) => {
+  logger.error({ component: 'server', err: error }, 'failed to start server');
   process.exit(1);
 });

--- a/src/openapi/describe-tool.ts
+++ b/src/openapi/describe-tool.ts
@@ -21,6 +21,7 @@ import { toolEndpoint, endpointToTool } from './tool-endpoint.js';
 import { specOperation } from './spec-loader.js';
 import { TOOL_DESCRIPTION_OVERRIDES } from './description-overrides.js';
 import { TOOL_DESCRIPTION_SUFFIXES } from './description-suffixes.js';
+import { logger } from '../utils/logger.js';
 
 /** Appends the tool's operator-safety note, when it has one. See description-suffixes.ts. */
 function withSuffix(name: string, description: string): string {
@@ -36,15 +37,17 @@ export function describeTool(name: string): string {
 
   const endpoint = toolEndpoint(name);
   if (!endpoint) {
-    console.error(
-      `[describe-tool] No endpoint registry entry for tool "${name}" — using fallback description.`
+    logger.warn(
+      { component: 'openapi', tool: name },
+      'no endpoint registry entry for tool — using fallback description',
     );
   }
 
   const op = specOperation(endpoint);
   if (endpoint && !op) {
-    console.error(
-      `[describe-tool] Tool "${name}" maps to ${endpoint.method} ${endpoint.path}, but that operation was not found in the spec — using fallback description.`
+    logger.warn(
+      { component: 'openapi', tool: name, method: endpoint.method, path: endpoint.path },
+      'tool endpoint not found in spec — using fallback description',
     );
   }
 

--- a/src/openapi/spec-loader.ts
+++ b/src/openapi/spec-loader.ts
@@ -23,6 +23,7 @@ import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { OpenApiOperation } from './derive-description.js';
 import type { ToolEndpointEntry } from './tool-endpoint-map.js';
+import { logger } from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -47,8 +48,10 @@ function loadSpec(): OpenApiSpec | null {
 
   if (!existsSync(SPEC_FILE)) {
     if (!loggedMissing) {
-      console.error(
-        `[openapi] Spec file not found at ${SPEC_FILE} — tool descriptions will use the fallback text. Run \`node scripts/fetch-openapi.mjs\` (dev) or check the Docker image build (prod).`
+      logger.warn(
+        { component: 'openapi', specFile: SPEC_FILE },
+        'spec file not found — tool descriptions will use the fallback text. ' +
+          'Run `node scripts/fetch-openapi.mjs` (dev) or check the Docker image build (prod).',
       );
       loggedMissing = true;
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import {
   selectOldestIdleSession,
 } from './session-lifecycle.js';
 import type { DockhandConfig } from './types/dockhand.js';
+import { logger } from './utils/logger.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
 
@@ -59,13 +60,12 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
   const security = getTransportSecurityConfig(config.port);
   const hostOriginEnforced = isHostOriginEnforcementActive(security);
   if (!hostOriginEnforced && !security.authToken) {
-    console.error(
-      '[security] WARNING: /mcp has no Host/Origin allowlist (MCP_ALLOWED_HOSTS) and no bearer token ' +
-        '(MCP_AUTH_TOKEN) configured — it accepts requests from any reachable client with no checks at all.',
-    );
-    console.error(
-      '[security] This is the compatible default. Set MCP_ALLOWED_HOSTS (DNS-rebinding protection) and ' +
-        'MCP_AUTH_TOKEN ("Authorization: Bearer <token>") once this endpoint is reachable beyond loopback.',
+    logger.warn(
+      { component: 'security' },
+      '/mcp has no Host/Origin allowlist (MCP_ALLOWED_HOSTS) and no bearer token (MCP_AUTH_TOKEN) ' +
+        'configured — it accepts requests from any reachable client with no checks at all. This is the ' +
+        'compatible default; set MCP_ALLOWED_HOSTS (DNS-rebinding protection) and MCP_AUTH_TOKEN ' +
+        '("Authorization: Bearer <token>") once this endpoint is reachable beyond loopback.',
     );
   }
   const app = express();
@@ -124,7 +124,10 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
       if (lifecycle.maxSessions !== 0 && sessions.size + pendingSessions >= lifecycle.maxSessions) {
         const candidate = selectOldestIdleSession(sessions);
         if (!candidate) return false;
-        console.error(`[session] Capacity ${lifecycle.maxSessions} reached; evicting idle session ${candidate}`);
+        logger.warn(
+          { component: 'session', sid: candidate, maxSessions: lifecycle.maxSessions },
+          'capacity reached; evicting idle session',
+        );
         await removeSession(candidate, 'capacity eviction');
       }
 
@@ -149,7 +152,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
       for (const [sessionId, entry] of sessions) {
         if (entry.activeRequests !== 0) continue;
         if (now - entry.lastActivity > lifecycle.inactivityTimeoutMs) {
-          console.error(`[session] Session ${sessionId} timed out after inactivity`);
+          logger.info({ component: 'session', sid: sessionId }, 'session timed out after inactivity');
           await removeSession(sessionId, 'inactivity timeout');
         }
       }
@@ -217,7 +220,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
             // session must not be a candidate for capacity eviction (see
             // selectOldestIdleSession / reserveSessionSlot).
             beginFoundingSession(sessions, id, { server: server!, transport: transport! });
-            console.error(`[session] New session ${id} (${sessions.size} active)`);
+            logger.info({ component: 'session', sid: id, active: sessions.size }, 'session created');
           },
         });
 
@@ -225,7 +228,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
           const sid = [...sessions.entries()].find(([, entry]) => entry.transport === transport)?.[0];
           if (sid) {
             sessions.delete(sid);
-            console.error(`[session] Session ${sid} transport closed (${sessions.size} active)`);
+            logger.info({ component: 'session', sid, active: sessions.size }, 'session transport closed');
           }
         };
 
@@ -254,7 +257,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
         releasePendingSessionSlot();
       }
     } catch (error) {
-      console.error('[server] Error handling MCP request:', error);
+      logger.error({ component: 'server', err: error }, 'error handling MCP request');
       if (!res.headersSent) {
         res.status(500).json({ error: 'Internal server error' });
       }
@@ -300,12 +303,24 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
   const host = config.host || '0.0.0.0';
   return await new Promise<HttpServer>((resolve) => {
     const httpServer = app.listen(config.port, host, () => {
-      console.error(`[server] MCP Dockhand server v${pkg.version} listening on ${host}:${config.port}`);
-      console.error(`[server] Dockhand URL: ${config.dockhand.url}`);
-      console.error(`[server] Health: http://localhost:${config.port}/health`);
-      console.error(`[server] MCP endpoint: http://localhost:${config.port}/mcp`);
-      console.error(
-        `[session] Lifecycle ttl=${lifecycle.inactivityTimeoutMs / 1000}s cleanup=${lifecycle.cleanupIntervalMs / 1000}s max=${lifecycle.maxSessions === 0 ? 'unlimited' : lifecycle.maxSessions}`,
+      logger.info(
+        {
+          component: 'server',
+          version: pkg.version,
+          host,
+          port: config.port,
+          dockhandUrl: config.dockhand.url,
+        },
+        'MCP Dockhand server listening',
+      );
+      logger.info(
+        {
+          component: 'session',
+          ttlSeconds: lifecycle.inactivityTimeoutMs / 1000,
+          cleanupIntervalSeconds: lifecycle.cleanupIntervalMs / 1000,
+          maxSessions: lifecycle.maxSessions === 0 ? 'unlimited' : lifecycle.maxSessions,
+        },
+        'session lifecycle configured',
       );
       resolve(httpServer);
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,7 +71,6 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
     );
   }
   const app = express();
-  app.use(express.json());
 
   const trustedProxies = parseTrustedProxies(process.env['TRUSTED_PROXIES']);
   for (const warning of trustedProxies.warnings) {
@@ -82,6 +81,14 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
   // an access line: a 401 on /mcp means someone is guessing the token, a 403
   // means a DNS-rebinding attempt, and both are the lines an operator most wants.
   app.use(createAccessLogMiddleware(trustedProxies));
+
+  // And ahead of express.json() for the same reason, which is less obvious: a body
+  // parser rejects a malformed or oversized payload by calling next(err), and that
+  // skips every remaining non-error middleware. Registered the other way round, this
+  // middleware never runs for such a request at all — so it never attaches its
+  // res.on('finish') handler, and a 400 or a 413 produces no access line whatsoever.
+  // Malformed-payload probing is exactly what CrowdSec is here to see.
+  app.use(express.json());
 
   const sessions = new Map<string, SessionEntry>();
   let pendingSessions = 0;

--- a/src/server.ts
+++ b/src/server.ts
@@ -310,6 +310,8 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
           host,
           port: config.port,
           dockhandUrl: config.dockhand.url,
+          health: `http://localhost:${config.port}/health`,
+          mcp: `http://localhost:${config.port}/mcp`,
         },
         'MCP Dockhand server listening',
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,8 @@ import {
 } from './session-lifecycle.js';
 import type { DockhandConfig } from './types/dockhand.js';
 import { logger } from './utils/logger.js';
+import { createAccessLogMiddleware } from './utils/access-log-middleware.js';
+import { parseTrustedProxies } from './utils/client-ip.js';
 
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
 
@@ -70,6 +72,16 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
   }
   const app = express();
   app.use(express.json());
+
+  const trustedProxies = parseTrustedProxies(process.env['TRUSTED_PROXIES']);
+  for (const warning of trustedProxies.warnings) {
+    logger.warn({ component: 'config' }, warning);
+  }
+  // Registered ahead of the Host/Origin and bearer guards below (deliberately —
+  // see the comment at their registration) so a rejected request still produces
+  // an access line: a 401 on /mcp means someone is guessing the token, a 403
+  // means a DNS-rebinding attempt, and both are the lines an operator most wants.
+  app.use(createAccessLogMiddleware(trustedProxies));
 
   const sessions = new Map<string, SessionEntry>();
   let pendingSessions = 0;
@@ -312,6 +324,8 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
           dockhandUrl: config.dockhand.url,
           health: `http://localhost:${config.port}/health`,
           mcp: `http://localhost:${config.port}/mcp`,
+          logLevel: logger.level,
+          trustedProxies: trustedProxies.isEmpty ? 'none' : 'configured',
         },
         'MCP Dockhand server listening',
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import {
 } from './session-lifecycle.js';
 import type { DockhandConfig } from './types/dockhand.js';
 import { logger } from './utils/logger.js';
+import { extendLogContext, log } from './utils/log-context.js';
 import { createAccessLogMiddleware } from './utils/access-log-middleware.js';
 import { parseTrustedProxies } from './utils/client-ip.js';
 
@@ -143,7 +144,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
       if (lifecycle.maxSessions !== 0 && sessions.size + pendingSessions >= lifecycle.maxSessions) {
         const candidate = selectOldestIdleSession(sessions);
         if (!candidate) return false;
-        logger.warn(
+        log().warn(
           { component: 'session', sid: candidate, maxSessions: lifecycle.maxSessions },
           'capacity reached; evicting idle session',
         );
@@ -239,7 +240,12 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
             // session must not be a candidate for capacity eviction (see
             // selectOldestIdleSession / reserveSessionSlot).
             beginFoundingSession(sessions, id, { server: server!, transport: transport! });
-            logger.info({ component: 'session', sid: id, active: sessions.size }, 'session created');
+            // The founding request arrives without an mcp-session-id header, so its
+            // access line and every line it logs would read sid=- while being the
+            // request that created the session. Backfilling it here ties the two
+            // together: the access line is written on 'finish', long after this runs.
+            extendLogContext({ sid: id });
+            log().info({ component: 'session', sid: id, active: sessions.size }, 'session created');
           },
         });
 
@@ -247,7 +253,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
           const sid = [...sessions.entries()].find(([, entry]) => entry.transport === transport)?.[0];
           if (sid) {
             sessions.delete(sid);
-            logger.info({ component: 'session', sid, active: sessions.size }, 'session transport closed');
+            log().info({ component: 'session', sid, active: sessions.size }, 'session transport closed');
           }
         };
 
@@ -276,7 +282,7 @@ export async function createServer(config: ServerConfig): Promise<HttpServer> {
         releasePendingSessionSlot();
       }
     } catch (error) {
-      logger.error({ component: 'server', err: error }, 'error handling MCP request');
+      log().error({ component: 'server', err: error }, 'error handling MCP request');
       if (!res.headersSent) {
         res.status(500).json({ error: 'Internal server error' });
       }

--- a/src/session-lifecycle.ts
+++ b/src/session-lifecycle.ts
@@ -1,3 +1,5 @@
+import { logger } from './utils/logger.js';
+
 export interface SessionLifecycleConfig {
   inactivityTimeoutMs: number;
   cleanupIntervalMs: number;
@@ -148,12 +150,12 @@ export async function removeSessionEntry<T extends ManagedSessionEntry>(
   try {
     await entry.server.close();
   } catch (error) {
-    console.error(`[session] Error closing server for ${id}:`, error);
+    logger.error({ component: 'session', sid: id, err: error }, 'error closing server');
     try {
       await entry.transport.close?.();
     } catch {
       // Best-effort fallback only.
     }
   }
-  console.error(`[session] Removed session ${id} (${reason}; ${sessions.size} active)`);
+  logger.info({ component: 'session', sid: id, reason, active: sessions.size }, 'session removed');
 }

--- a/src/session-lifecycle.ts
+++ b/src/session-lifecycle.ts
@@ -1,4 +1,7 @@
-import { logger } from './utils/logger.js';
+// log() and not the bare logger: removal is reached both from a DELETE /mcp request
+// (where req/sid/call belong on the line) and from the cleanup interval (where there
+// is no request context and log() falls back to the plain logger unchanged).
+import { log } from './utils/log-context.js';
 
 export interface SessionLifecycleConfig {
   inactivityTimeoutMs: number;
@@ -150,12 +153,12 @@ export async function removeSessionEntry<T extends ManagedSessionEntry>(
   try {
     await entry.server.close();
   } catch (error) {
-    logger.error({ component: 'session', sid: id, err: error }, 'error closing server');
+    log().error({ component: 'session', sid: id, err: error }, 'error closing server');
     try {
       await entry.transport.close?.();
     } catch {
       // Best-effort fallback only.
     }
   }
-  logger.info({ component: 'session', sid: id, reason, active: sessions.size }, 'session removed');
+  log().info({ component: 'session', sid: id, reason, active: sessions.size }, 'session removed');
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -26,6 +26,7 @@ import { registerLabelTools } from './labels.js';
 import { registerPreferenceTools } from './preferences.js';
 import { registerSecretProviderTools } from './secret-providers.js';
 import { registerMetaTools } from './meta.js';
+import { logger } from '../utils/logger.js';
 
 export function registerAllTools(server: McpServer, client: DockhandClient): void {
   registerContainerTools(server, client);
@@ -51,5 +52,5 @@ export function registerAllTools(server: McpServer, client: DockhandClient): voi
   registerSecretProviderTools(server, client);
   registerMetaTools(server, client);
 
-  console.error('[tools] All Dockhand tools registered');
+  logger.info({ component: 'tools' }, 'all Dockhand tools registered');
 }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -12,6 +12,7 @@ import { TOOL_ENDPOINT_MAP, type ToolEndpointEntry } from '../openapi/tool-endpo
 import { PINNED_DOCKHAND_OPENAPI_COMMIT } from '../openapi/pinned.js';
 import { specInfoVersion } from '../openapi/spec-loader.js';
 import { getStatsSnapshot } from '../utils/runtime-stats.js';
+import { log } from '../utils/log-context.js';
 import { encodePath } from '../utils/encode-path.js';
 
 export interface ServerInfo {
@@ -646,16 +647,18 @@ function hasNamedCookie(setCookieHeaders: readonly string[], name: string): bool
 }
 
 export async function attemptRawLogin(baseUrl: string): Promise<LoginProbeResult> {
-  const response = await fetch(`${baseUrl}/api/auth/login`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      username: process.env['DOCKHAND_USERNAME'],
-      password: process.env['DOCKHAND_PASSWORD'],
-      provider: 'local',
+  const response = await loggedProbe('POST', '/api/auth', () =>
+    fetch(`${baseUrl}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username: process.env['DOCKHAND_USERNAME'],
+        password: process.env['DOCKHAND_PASSWORD'],
+        provider: 'local',
+      }),
+      redirect: 'manual',
     }),
-    redirect: 'manual',
-  });
+  );
 
   const statusCode = response.status;
   if (statusCode !== 200) {
@@ -716,8 +719,42 @@ const HEALTH_CHECK_TIMEOUT_MS = 5_000;
  * timeout — matching `runSelfCheck()`'s `probeHealth` contract, where any throw means
  * `dockhandReachable: false`.
  */
+/**
+ * Wrap a raw diagnostic fetch in the same one-line-per-request debug log that
+ * DockhandClient.loggedFetch and SessionManager.performLogin emit — self_check and
+ * validate_config bypass the client, so without this their health and credential
+ * probes (the very exchanges that matter when a diagnostic reports a failure) would
+ * be the only Dockhand requests LOG_LEVEL=debug never shows.
+ *
+ * `route` is a caller-supplied constant, never derived from the URL: the two call
+ * sites are fixed (/api/health, /api/auth), so no value can reach the line. On a
+ * throw (unreachable host, timeout) it logs a warn carrying only the exception NAME,
+ * never the URL, body or credentials.
+ */
+async function loggedProbe(
+  method: string,
+  route: string,
+  run: () => Promise<Response>,
+): Promise<Response> {
+  const started = Date.now();
+  try {
+    const response = await run();
+    log().debug({ component: 'client', method, route, status: response.status, ms: Date.now() - started }, 'dockhand request');
+    return response;
+  } catch (error) {
+    log().warn(
+      { component: 'client', method, route, ms: Date.now() - started, err: { type: error instanceof Error ? error.name : 'UnknownError' } },
+      'dockhand request failed',
+    );
+    throw error;
+  }
+}
+
 export async function probeRawHealth(baseUrl: string): Promise<void> {
-  const response = await withTimeout(fetch(`${baseUrl}/api/health`), HEALTH_CHECK_TIMEOUT_MS);
+  const response = await withTimeout(
+    loggedProbe('GET', '/api/health', () => fetch(`${baseUrl}/api/health`)),
+    HEALTH_CHECK_TIMEOUT_MS,
+  );
   if (!response.ok) {
     throw new Error(`Dockhand health check failed: GET ${baseUrl}/api/health returned ${response.status}`);
   }

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -751,9 +751,12 @@ async function loggedProbe(
 }
 
 export async function probeRawHealth(baseUrl: string): Promise<void> {
-  const response = await withTimeout(
-    loggedProbe('GET', '/api/health', () => fetch(`${baseUrl}/api/health`)),
-    HEALTH_CHECK_TIMEOUT_MS,
+  // withTimeout INSIDE loggedProbe, not around it: a timeout must reject within
+  // loggedProbe's try/catch so it is logged as the request's failure. Wrapping the
+  // other way round let a timeout escape unlogged, and a late-resolving fetch then
+  // emitted a success line after self_check had already reported Dockhand down.
+  const response = await loggedProbe('GET', '/api/health', () =>
+    withTimeout(fetch(`${baseUrl}/api/health`), HEALTH_CHECK_TIMEOUT_MS),
   );
   if (!response.ok) {
     throw new Error(`Dockhand health check failed: GET ${baseUrl}/api/health returned ${response.status}`);

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -581,7 +581,7 @@ export interface LoginProbeResult {
  * `credentialsValid`.
  *
  * Deliberately NOT `SessionManager.login()` (src/auth/session.ts): that method
- * `console.error`s the configured username on failure and throws rather than
+ * logs the configured username at 'error' on failure and throws rather than
  * resolving to a result value — useful for its own job (diagnosable auto-relogin
  * failures in `docker logs`, Issue #116), wrong for this one. Two self-help tools
  * need the outcome as a plain value, not a side effect or an exception, and neither

--- a/src/utils/access-log-middleware.ts
+++ b/src/utils/access-log-middleware.ts
@@ -43,6 +43,13 @@ export function createAccessLogMiddleware(
     const emit = (): void => {
       if (written) return;
       written = true;
+      // res.writableFinished is the authoritative "the response completed" signal: true
+      // only after 'finish'. A 'close' that fires without it is a client that hung up
+      // mid-stream (routine for SSE), where res.statusCode is still its default 200 —
+      // logging that as success would let a disconnect flood look like normal traffic to
+      // CrowdSec. Report nginx's 499 (client closed connection) instead, which the nginx
+      // parser understands.
+      const status = res.writableFinished ? res.statusCode : 499;
       write(
         formatAccessLine({
           ip,
@@ -50,7 +57,7 @@ export function createAccessLogMiddleware(
           method: req.method,
           path: req.originalUrl ?? req.url,
           httpVersion: req.httpVersion,
-          status: res.statusCode,
+          status,
           bytes: Number(res.getHeader('content-length') ?? 0),
           referer: header(req, 'referer'),
           userAgent: header(req, 'user-agent'),

--- a/src/utils/access-log-middleware.ts
+++ b/src/utils/access-log-middleware.ts
@@ -30,7 +30,6 @@ export function createAccessLogMiddleware(
     // at emit time rather than a captured local is what puts that id on the access
     // line of the request that created the session.
     const context: LogContext = { req: randomUUID(), sid: header(req, 'mcp-session-id') };
-    const startedAt = new Date();
 
     const ip = resolveClientIp({
       peer: req.socket?.remoteAddress,
@@ -50,10 +49,14 @@ export function createAccessLogMiddleware(
       // CrowdSec. Report nginx's 499 (client closed connection) instead, which the nginx
       // parser understands.
       const status = res.writableFinished ? res.statusCode : 499;
+      // Timestamp at emit, not at request start: the line is written on finish/close,
+      // and for a long-lived SSE stream that can be minutes later. CrowdSec's nginx
+      // parser consumes this timestamp for its time-windowed scenarios, so it must
+      // reflect when the event reaches the log, not when the request began. Codex #209.
       write(
         formatAccessLine({
           ip,
-          time: startedAt,
+          time: new Date(),
           method: req.method,
           path: req.originalUrl ?? req.url,
           httpVersion: req.httpVersion,

--- a/src/utils/access-log-middleware.ts
+++ b/src/utils/access-log-middleware.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'node:crypto';
 import type { Request, RequestHandler, Response } from 'express';
 import { formatAccessLine } from './access-log.js';
 import { resolveClientIp, type TrustedProxies } from './client-ip.js';
-import { runWithLogContext } from './log-context.js';
+import { runWithLogContext, type LogContext } from './log-context.js';
 
 function header(req: Request, name: string): string | undefined {
   const value = req.headers[name];
@@ -23,8 +23,13 @@ export function createAccessLogMiddleware(
   write: (line: string) => void = (line) => process.stdout.write(`${line}\n`),
 ): RequestHandler {
   return (req: Request, res: Response, next) => {
-    const requestId = randomUUID();
-    const sessionId = header(req, 'mcp-session-id');
+    // This object is the log context for the whole request (see runWithLogContext:
+    // it is stored, not copied). The founding request of a session arrives without
+    // an mcp-session-id header — the id does not exist yet — and server.ts backfills
+    // it here via extendLogContext once the handshake produces one. Reading `context`
+    // at emit time rather than a captured local is what puts that id on the access
+    // line of the request that created the session.
+    const context: LogContext = { req: randomUUID(), sid: header(req, 'mcp-session-id') };
     const startedAt = new Date();
 
     const ip = resolveClientIp({
@@ -49,8 +54,8 @@ export function createAccessLogMiddleware(
           bytes: Number(res.getHeader('content-length') ?? 0),
           referer: header(req, 'referer'),
           userAgent: header(req, 'user-agent'),
-          req: requestId,
-          sid: sessionId,
+          req: context.req,
+          sid: context.sid,
         }),
       );
     };
@@ -60,6 +65,6 @@ export function createAccessLogMiddleware(
     res.on('finish', emit);
     res.on('close', emit);
 
-    runWithLogContext({ req: requestId, sid: sessionId }, () => next());
+    runWithLogContext(context, () => next());
   };
 }

--- a/src/utils/access-log-middleware.ts
+++ b/src/utils/access-log-middleware.ts
@@ -1,0 +1,65 @@
+/**
+ * Opens the request context and closes it with an access line.
+ *
+ * Registered ahead of the Host/Origin and bearer guards on purpose: a rejected
+ * request is the one worth seeing. 401 on /mcp means someone is guessing the token,
+ * 403 means a DNS-rebinding attempt. A middleware sitting after the guards would
+ * observe neither.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Request, RequestHandler, Response } from 'express';
+import { formatAccessLine } from './access-log.js';
+import { resolveClientIp, type TrustedProxies } from './client-ip.js';
+import { runWithLogContext } from './log-context.js';
+
+function header(req: Request, name: string): string | undefined {
+  const value = req.headers[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function createAccessLogMiddleware(
+  trusted: TrustedProxies,
+  write: (line: string) => void = (line) => process.stdout.write(`${line}\n`),
+): RequestHandler {
+  return (req: Request, res: Response, next) => {
+    const requestId = randomUUID();
+    const sessionId = header(req, 'mcp-session-id');
+    const startedAt = new Date();
+
+    const ip = resolveClientIp({
+      peer: req.socket?.remoteAddress,
+      forwardedFor: header(req, 'x-forwarded-for'),
+      realIp: header(req, 'x-real-ip'),
+      trusted,
+    });
+
+    let written = false;
+    const emit = (): void => {
+      if (written) return;
+      written = true;
+      write(
+        formatAccessLine({
+          ip,
+          time: startedAt,
+          method: req.method,
+          path: req.originalUrl ?? req.url,
+          httpVersion: req.httpVersion,
+          status: res.statusCode,
+          bytes: Number(res.getHeader('content-length') ?? 0),
+          referer: header(req, 'referer'),
+          userAgent: header(req, 'user-agent'),
+          req: requestId,
+          sid: sessionId,
+        }),
+      );
+    };
+
+    // 'finish' covers a completed response; 'close' catches a client that hung up
+    // mid-stream (SSE deploys do that routinely). The guard keeps it at one line.
+    res.on('finish', emit);
+    res.on('close', emit);
+
+    runWithLogContext({ req: requestId, sid: sessionId }, () => next());
+  };
+}

--- a/src/utils/access-log.ts
+++ b/src/utils/access-log.ts
@@ -67,6 +67,30 @@ function quoted(value: string | undefined): string {
 }
 
 /**
+ * Both correlation fields are UUIDs by contract, so anything else is not a value to
+ * be cleaned up — it is a value that was never ours.
+ *
+ * `sid` comes straight from the caller-supplied `mcp-session-id` header, and unlike
+ * referer and user-agent it is written BARE: no quotes to escape into, nothing to
+ * bound it. Without this it can put arbitrary printable text, unbalanced quotes and a
+ * plausible-looking second `req=`/`sid=` pair into the tail of a line CrowdSec reads,
+ * and an ~8 KB header makes an ~8 KB line. A whole forged LINE stays out of reach for
+ * a different reason — Node's HTTP parser rejects CR and LF in a header value — but
+ * that is the parser's guarantee, not this function's.
+ *
+ * Rejected rather than stripped, deliberately. A mangled value still LOOKS like an
+ * identifier, so it would send whoever greps for it after a session that never
+ * existed; `-` says plainly that nothing usable arrived. The cap is on top of the
+ * character rule because 64 valid characters in a row are just as unhelpful.
+ */
+const IDENTIFIER = new RegExp('^[A-Za-z0-9-]{1,64}$');
+
+function identifierOrDash(value: string | undefined): string {
+  if (value === undefined) return '-';
+  return IDENTIFIER.test(value) ? value : '-';
+}
+
+/**
  * `status`/`bytes` reach a `%{NUMBER}` grok field. A non-finite value (the realistic
  * path: a multi-value header collapsing to an array before it's coerced) would print
  * the literal text "NaN" there and break parsing for that line.
@@ -90,7 +114,7 @@ export function formatAccessLine(fields: AccessLogFields): string {
     `${quoted(fields.referer)} ${quoted(fields.userAgent)}`;
 
   if (fields.req !== undefined || fields.sid !== undefined) {
-    line += ` req=${fields.req ?? '-'} sid=${fields.sid ?? '-'}`;
+    line += ` req=${identifierOrDash(fields.req)} sid=${identifierOrDash(fields.sid)}`;
   }
 
   return line;

--- a/src/utils/access-log.ts
+++ b/src/utils/access-log.ts
@@ -19,6 +19,11 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 // the source stays readable in a diff.
 const CONTROL_CHARS = new RegExp('[\\x00-\\x1f\\x7f]', 'g');
 
+// Everything `%{WORD}` (`\b\w+\b`) cannot match. See wordSafeMethod().
+const NON_WORD_CHARS = new RegExp('[^A-Za-z0-9_]', 'g');
+
+const UTF8 = new TextEncoder();
+
 export interface AccessLogFields {
   ip: string;
   time: Date;
@@ -43,27 +48,84 @@ function formatTime(at: Date): string {
   );
 }
 
-/** Strips C0 control characters and DEL — the one substitution every field gets. */
+/**
+ * Strips C0 control characters and DEL. Only the unquoted `ip` field still needs
+ * this — inside a quoted field a control character is encoded rather than removed
+ * (see escapeLikeNginx), which is both lossless and safe.
+ */
 function stripControlChars(value: string): string {
   return value.replace(CONTROL_CHARS, ' ');
 }
 
+/** nginx writes `\xNN` with uppercase hex; matching it keeps the two comparable. */
+function hexEscape(byte: number): string {
+  return `\\x${byte.toString(16).toUpperCase().padStart(2, '0')}`;
+}
+
 /**
- * A user agent or referer is attacker-controlled. Without the control-character strip
- * a newline in one ends the line and starts a forged one in a stream CrowdSec reads.
+ * Escapes a field the way nginx itself does, because that is the only escaping the
+ * consumer understands.
  *
- * Backslashes are escaped BEFORE quotes, not after. Escaping only the quote leaves a
- * pre-existing backslash untouched, so a value ending in `\"` becomes `\\"` in the
- * output; grok's `QUOTEDSTRING` reads `\\` as one escaped backslash and then treats
- * the quote that follows as the field's real, unescaped close — the field ends one
- * character early and everything after it is misread as content outside the quotes.
- * Escaping the backslash first turns that same input into `\\\"`, which the same
- * parser reads back as backslash-then-quote: the field closes in the right place.
+ * crowdsecurity/nginx-logs reads every quoted field with `%{NOTDQUOTE}`, which is
+ * defined as `[^"]*`. It has no concept of an escape sequence: the first raw `"`
+ * inside a field is the field's end, full stop, and a `\"` is a backslash followed
+ * by that end. A line carrying one does not parse at all — confirmed with
+ * `cscli explain` against the live LAPI, where a referer of `"` makes the whole line
+ * a parser failure while the same line with `\x22` parses green. A request that does
+ * not parse produces no event, no bucket and no decision: one header would have taken
+ * its sender out of CrowdSec entirely.
+ *
+ * That is not a gap in the parser. Real nginx never emits a raw quote inside a field,
+ * so the parser never needed to handle one: ngx_http_log_module escapes `"` as `\x22`,
+ * `\` as `\x5C`, and every C0 control character, DEL and byte >= 0x80 as `\xNN`.
+ * Emitting the same thing keeps every field bounded by construction.
+ *
+ * Note what that makes moot: there is no backslash-ordering question here, because no
+ * raw quote is ever written for a backslash to interact with. An earlier version of
+ * this file reasoned carefully about that ordering — correctly, but for grok's
+ * `QUOTEDSTRING`, which is not the rule this consumer applies.
  */
+function escapeLikeNginx(value: string): string {
+  let out = '';
+  for (const char of value) {
+    const code = char.codePointAt(0) as number;
+
+    if (code === 0x22 || code === 0x5c || code < 0x20 || code === 0x7f) {
+      out += hexEscape(code);
+    } else if (code <= 0x7e) {
+      out += char;
+    } else if (code <= 0xff) {
+      // Node decodes header bytes as latin-1, so a code unit in this range IS the byte
+      // that arrived on the wire — the same one nginx would have escaped.
+      out += hexEscape(code);
+    } else {
+      // Not reachable from an HTTP header, but a direct caller can hand us one. nginx
+      // escapes bytes, so encode the character the way the wire would have carried it.
+      for (const byte of UTF8.encode(char)) out += hexEscape(byte);
+    }
+  }
+  return out;
+}
+
 function quoted(value: string | undefined): string {
   if (!value) return '"-"';
-  const safe = stripControlChars(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return `"${safe}"`;
+  return `"${escapeLikeNginx(value)}"`;
+}
+
+/**
+ * The verb reaches `%{WORD}` in the grok, which is `\b\w+\b` and cannot match a
+ * hyphen. `M-SEARCH` is the one method in Node's `http.METHODS` that contains one, and
+ * llhttp rejects arbitrary custom verbs, so that single method is the whole exposure —
+ * but it is enough: verified against the live LAPI, such a line still parses, yet
+ * `LePresidente/http-generic-401-bf` does not fire for it. Repeated 401s on that verb
+ * are then invisible to the bruteforce scenario while `401` versus `404` still answers
+ * whether a token was right.
+ *
+ * Replaced rather than encoded, deliberately: `M\x2DSEARCH` fails just the same,
+ * because `%{WORD}` still cannot reach the space that follows.
+ */
+function wordSafeMethod(method: string): string {
+  return method.replace(NON_WORD_CHARS, '_');
 }
 
 /**
@@ -101,7 +163,7 @@ function finiteOrZero(value: number): number {
 
 export function formatAccessLine(fields: AccessLogFields): string {
   const target = fields.path.split('?')[0];
-  const request = quoted(`${fields.method} ${target} HTTP/${fields.httpVersion}`);
+  const request = quoted(`${wordSafeMethod(fields.method)} ${target} HTTP/${fields.httpVersion}`);
 
   // nginx never quotes this field and CrowdSec's grok expects it bare, so it isn't
   // run through quoted() — but a newline in it is still cheap to strip here rather

--- a/src/utils/access-log.ts
+++ b/src/utils/access-log.ts
@@ -43,23 +43,51 @@ function formatTime(at: Date): string {
   );
 }
 
+/** Strips C0 control characters and DEL — the one substitution every field gets. */
+function stripControlChars(value: string): string {
+  return value.replace(CONTROL_CHARS, ' ');
+}
+
 /**
- * A user agent or referer is attacker-controlled. Without this a newline in one ends
- * the line and starts a forged one in a stream CrowdSec reads.
+ * A user agent or referer is attacker-controlled. Without the control-character strip
+ * a newline in one ends the line and starts a forged one in a stream CrowdSec reads.
+ *
+ * Backslashes are escaped BEFORE quotes, not after. Escaping only the quote leaves a
+ * pre-existing backslash untouched, so a value ending in `\"` becomes `\\"` in the
+ * output; grok's `QUOTEDSTRING` reads `\\` as one escaped backslash and then treats
+ * the quote that follows as the field's real, unescaped close — the field ends one
+ * character early and everything after it is misread as content outside the quotes.
+ * Escaping the backslash first turns that same input into `\\\"`, which the same
+ * parser reads back as backslash-then-quote: the field closes in the right place.
  */
 function quoted(value: string | undefined): string {
   if (!value) return '"-"';
-  const safe = value.replace(CONTROL_CHARS, ' ').replace(/"/g, '\\"');
+  const safe = stripControlChars(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   return `"${safe}"`;
+}
+
+/**
+ * `status`/`bytes` reach a `%{NUMBER}` grok field. A non-finite value (the realistic
+ * path: a multi-value header collapsing to an array before it's coerced) would print
+ * the literal text "NaN" there and break parsing for that line.
+ */
+function finiteOrZero(value: number): number {
+  return Number.isFinite(value) ? value : 0;
 }
 
 export function formatAccessLine(fields: AccessLogFields): string {
   const target = fields.path.split('?')[0];
   const request = quoted(`${fields.method} ${target} HTTP/${fields.httpVersion}`);
 
+  // nginx never quotes this field and CrowdSec's grok expects it bare, so it isn't
+  // run through quoted() — but a newline in it is still cheap to strip here rather
+  // than trust that resolveClientIp() (Task 4) never hands one back.
+  const ip = stripControlChars(fields.ip);
+
   let line =
-    `${fields.ip} - - [${formatTime(fields.time)}] ${request} ` +
-    `${fields.status} ${fields.bytes} ${quoted(fields.referer)} ${quoted(fields.userAgent)}`;
+    `${ip} - - [${formatTime(fields.time)}] ${request} ` +
+    `${finiteOrZero(fields.status)} ${finiteOrZero(fields.bytes)} ` +
+    `${quoted(fields.referer)} ${quoted(fields.userAgent)}`;
 
   if (fields.req !== undefined || fields.sid !== undefined) {
     line += ` req=${fields.req ?? '-'} sid=${fields.sid ?? '-'}`;

--- a/src/utils/access-log.ts
+++ b/src/utils/access-log.ts
@@ -1,0 +1,69 @@
+/**
+ * nginx "combined" access lines on stdout.
+ *
+ * Why this format and not JSON: crowdsecurity/nginx-logs already parses it, so an
+ * operator gets bruteforce detection, GeoIP enrichment and the standard HTTP
+ * scenarios by adding an acquisition file — no custom parser to write and keep
+ * working. Verified end to end with `cscli explain` against the live LAPI.
+ *
+ * The two appended fields (req=, sid=) are tolerated by the grok — checked with a
+ * plain line, with a trailing duration and with two full UUIDs, all parsing green.
+ * They are what ties an access line to the structured log on stderr. The suffix is
+ * only appended when at least one of the two is present, so a line with neither
+ * stays byte-for-byte the plain combined format that was verified against CrowdSec.
+ */
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+// C0 control characters plus DEL. Written with hex escapes rather than raw bytes so
+// the source stays readable in a diff.
+const CONTROL_CHARS = new RegExp('[\\x00-\\x1f\\x7f]', 'g');
+
+export interface AccessLogFields {
+  ip: string;
+  time: Date;
+  method: string;
+  /** May arrive with a query string; it is stripped before it is written. */
+  path: string;
+  httpVersion: string;
+  status: number;
+  bytes: number;
+  referer?: string;
+  userAgent?: string;
+  req?: string;
+  sid?: string;
+}
+
+/** nginx $time_local, always UTC so the line is unambiguous wherever it is read. */
+function formatTime(at: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${pad(at.getUTCDate())}/${MONTHS[at.getUTCMonth()]}/${at.getUTCFullYear()}:` +
+    `${pad(at.getUTCHours())}:${pad(at.getUTCMinutes())}:${pad(at.getUTCSeconds())} +0000`
+  );
+}
+
+/**
+ * A user agent or referer is attacker-controlled. Without this a newline in one ends
+ * the line and starts a forged one in a stream CrowdSec reads.
+ */
+function quoted(value: string | undefined): string {
+  if (!value) return '"-"';
+  const safe = value.replace(CONTROL_CHARS, ' ').replace(/"/g, '\\"');
+  return `"${safe}"`;
+}
+
+export function formatAccessLine(fields: AccessLogFields): string {
+  const target = fields.path.split('?')[0];
+  const request = quoted(`${fields.method} ${target} HTTP/${fields.httpVersion}`);
+
+  let line =
+    `${fields.ip} - - [${formatTime(fields.time)}] ${request} ` +
+    `${fields.status} ${fields.bytes} ${quoted(fields.referer)} ${quoted(fields.userAgent)}`;
+
+  if (fields.req !== undefined || fields.sid !== undefined) {
+    line += ` req=${fields.req ?? '-'} sid=${fields.sid ?? '-'}`;
+  }
+
+  return line;
+}

--- a/src/utils/access-log.ts
+++ b/src/utils/access-log.ts
@@ -113,13 +113,20 @@ function quoted(value: string | undefined): string {
 }
 
 /**
- * The verb reaches `%{WORD}` in the grok, which is `\b\w+\b` and cannot match a
- * hyphen. `M-SEARCH` is the one method in Node's `http.METHODS` that contains one, and
- * llhttp rejects arbitrary custom verbs, so that single method is the whole exposure —
- * but it is enough: verified against the live LAPI, such a line still parses, yet
- * `LePresidente/http-generic-401-bf` does not fire for it. Repeated 401s on that verb
- * are then invisible to the bruteforce scenario while `401` versus `404` still answers
- * whether a token was right.
+ * The verb reaches `%{WORD}` in the grok, which is `\b\w+\b` and cannot match a hyphen.
+ * `M-SEARCH` is the one method in Node's `http.METHODS` that contains one, and llhttp
+ * rejects arbitrary custom verbs, so that single method is the whole exposure.
+ *
+ * What it is worth depends on the hub version, which is exactly why it is done here.
+ * A compiled grok harness failed to parse an `M-SEARCH` line at all — the whole line,
+ * every field lost. The hub installed on our own LAPI parses it fine. Mapping the verb
+ * into `[A-Za-z0-9_]` keeps the line parseable either way, instead of depending on the
+ * consumer's version being the lenient one.
+ *
+ * It does NOT affect scenario matching, and an earlier version of this comment claimed
+ * it did. The stock scenario filters on `evt.Parsed.verb == 'POST'` — a single literal,
+ * not a verb list — so every non-POST method escapes it regardless of how the line is
+ * written. No log encoding can change that; see the README for what does.
  *
  * Replaced rather than encoded, deliberately: `M\x2DSEARCH` fails just the same,
  * because `%{WORD}` still cannot reach the space that follows.

--- a/src/utils/client-ip.ts
+++ b/src/utils/client-ip.ts
@@ -29,6 +29,13 @@ function normalizeAddress(address: string): string {
   return mapped ? mapped[1] : trimmed;
 }
 
+function isValidAddress(address: string): boolean {
+  return isIPv4(address) || isIPv6(address);
+}
+
+/** Only a bare, in-range decimal prefix is accepted — never trust Number()'s leniency. */
+const DECIMAL_PREFIX = /^\d+$/;
+
 export function parseTrustedProxies(raw: string | undefined): TrustedProxies {
   const warnings: string[] = [];
   const list = new BlockList();
@@ -48,7 +55,19 @@ export function parseTrustedProxies(raw: string | undefined): TrustedProxies {
       if (prefix === undefined) {
         list.addAddress(normalized, family);
       } else {
-        list.addSubnet(normalized, Number(prefix), family);
+        // Number('') === 0 and Number('0x10') === 16 — a naive Number(prefix) would
+        // silently accept a truncated CIDR as "/0" (trust everyone) or a hex spelling
+        // as a valid prefix. Only a bare decimal string is a legitimate prefix; /0
+        // itself stays legitimate when it is written that way deliberately.
+        if (!DECIMAL_PREFIX.test(prefix)) {
+          throw new Error(`invalid prefix "${prefix}"`);
+        }
+        const prefixLength = Number(prefix);
+        const maxPrefix = family === 'ipv4' ? 32 : 128;
+        if (prefixLength > maxPrefix) {
+          throw new Error(`prefix ${prefixLength} exceeds ${maxPrefix} for ${family}`);
+        }
+        list.addSubnet(normalized, prefixLength, family);
       }
       count += 1;
     } catch {
@@ -83,15 +102,22 @@ export function resolveClientIp({ peer, forwardedFor, realIp, trusted }: ClientI
   if (forwardedFor) {
     const chain = forwardedFor.split(',').map(normalizeAddress).filter(Boolean);
     // Walk right to left: the rightmost entry this proxy added is the closest hop.
-    // The first one that is not itself a trusted proxy is the client.
+    // The first VALID address that is not itself a trusted proxy is the client. A
+    // malformed entry (a proxy's literal "unknown", a stray "host:port") must be
+    // skipped rather than returned — it would corrupt the field CrowdSec bans from.
     for (let i = chain.length - 1; i >= 0; i -= 1) {
-      if (!trusted.contains(chain[i])) return chain[i];
+      const candidate = chain[i];
+      if (isValidAddress(candidate) && !trusted.contains(candidate)) return candidate;
     }
-    // Every hop was trusted — report the outermost rather than inventing one.
-    return chain[0] ?? direct;
+    // Every hop was either trusted or malformed. Report the outermost VALID one
+    // rather than inventing an address; if none is valid, fall back to the peer.
+    return chain.find(isValidAddress) ?? direct;
   }
 
-  if (realIp) return normalizeAddress(realIp);
+  if (realIp) {
+    const normalizedRealIp = normalizeAddress(realIp);
+    return isValidAddress(normalizedRealIp) ? normalizedRealIp : direct;
+  }
 
   return direct;
 }

--- a/src/utils/client-ip.ts
+++ b/src/utils/client-ip.ts
@@ -42,7 +42,16 @@ export function parseTrustedProxies(raw: string | undefined): TrustedProxies {
   let count = 0;
 
   for (const entry of (raw ?? '').split(',').map((e) => e.trim()).filter(Boolean)) {
-    const [address, prefix] = entry.split('/');
+    // Exactly one or zero slashes. `10.0.0.0/8/garbage` would otherwise destructure to
+    // `10.0.0.0` + `8` and silently drop the rest, trusting a /8 the operator never wrote.
+    // This setting decides which peers may set client-IP headers, so a malformed entry
+    // must fail closed with the warning, not resolve to a parsed subnet.
+    const parts = entry.split('/');
+    if (parts.length > 2) {
+      warnings.push(`TRUSTED_PROXIES entry "${entry}" is not a valid address or subnet — ignored.`);
+      continue;
+    }
+    const [address, prefix] = parts;
     const normalized = normalizeAddress(address);
     const family = isIPv4(normalized) ? 'ipv4' : isIPv6(normalized) ? 'ipv6' : undefined;
 

--- a/src/utils/client-ip.ts
+++ b/src/utils/client-ip.ts
@@ -1,0 +1,97 @@
+/**
+ * Resolves the address to attribute a request to.
+ *
+ * Behind a reverse proxy every request arrives from the proxy. Logging that address
+ * is not merely unhelpful — a CrowdSec decision taken on it bans the proxy, and with
+ * it everyone behind it. So the forwarding headers have to be read.
+ *
+ * But only from a peer that is allowed to set them. Trusting them unconditionally
+ * would turn this server into a way for any direct caller to get an arbitrary third
+ * party banned. TRUSTED_PROXIES is what makes the difference, which is also why an
+ * unset value means "trust nobody" rather than "trust everybody".
+ *
+ * Uses node:net BlockList for subnet matching — correct IPv4/IPv6 handling without a
+ * dependency.
+ */
+
+import { BlockList, isIPv4, isIPv6 } from 'node:net';
+
+export interface TrustedProxies {
+  isEmpty: boolean;
+  contains(address: string): boolean;
+  warnings: string[];
+}
+
+/** Node reports IPv4 peers as ::ffff:a.b.c.d on a dual-stack listener. */
+function normalizeAddress(address: string): string {
+  const trimmed = address.trim();
+  const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(trimmed);
+  return mapped ? mapped[1] : trimmed;
+}
+
+export function parseTrustedProxies(raw: string | undefined): TrustedProxies {
+  const warnings: string[] = [];
+  const list = new BlockList();
+  let count = 0;
+
+  for (const entry of (raw ?? '').split(',').map((e) => e.trim()).filter(Boolean)) {
+    const [address, prefix] = entry.split('/');
+    const normalized = normalizeAddress(address);
+    const family = isIPv4(normalized) ? 'ipv4' : isIPv6(normalized) ? 'ipv6' : undefined;
+
+    if (!family) {
+      warnings.push(`TRUSTED_PROXIES entry "${entry}" is not a valid address or subnet — ignored.`);
+      continue;
+    }
+
+    try {
+      if (prefix === undefined) {
+        list.addAddress(normalized, family);
+      } else {
+        list.addSubnet(normalized, Number(prefix), family);
+      }
+      count += 1;
+    } catch {
+      warnings.push(`TRUSTED_PROXIES entry "${entry}" is not a valid address or subnet — ignored.`);
+    }
+  }
+
+  return {
+    isEmpty: count === 0,
+    warnings,
+    contains(address: string): boolean {
+      if (count === 0) return false;
+      const normalized = normalizeAddress(address);
+      const family = isIPv4(normalized) ? 'ipv4' : isIPv6(normalized) ? 'ipv6' : undefined;
+      if (!family) return false;
+      return list.check(normalized, family);
+    },
+  };
+}
+
+export interface ClientIpInput {
+  peer: string | undefined;
+  forwardedFor: string | undefined;
+  realIp: string | undefined;
+  trusted: TrustedProxies;
+}
+
+export function resolveClientIp({ peer, forwardedFor, realIp, trusted }: ClientIpInput): string {
+  const direct = peer ? normalizeAddress(peer) : '-';
+  if (direct === '-' || !trusted.contains(direct)) return direct;
+
+  if (forwardedFor) {
+    const chain = forwardedFor.split(',').map(normalizeAddress).filter(Boolean);
+    // Walk right to left: the rightmost entry this proxy added is the closest hop.
+    // The first one that is not itself a trusted proxy is the client.
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      if (!trusted.contains(chain[i])) return chain[i];
+    }
+    // Every hop was trusted — report the outermost rather than inventing one.
+    return chain[0] ?? direct;
+  }
+
+  if (realIp) return normalizeAddress(realIp);
+
+  return direct;
+}

--- a/src/utils/log-context.ts
+++ b/src/utils/log-context.ts
@@ -1,0 +1,52 @@
+/**
+ * Carries the correlation identifiers through the call without threading them
+ * through every signature.
+ *
+ * The alternative — adding a context parameter to DockhandClient.get/post/put/delete
+ * and to every tool callback — would touch every tool in the tree and would still be
+ * forgotten in the next one. AsyncLocalStorage keeps the plumbing in one file.
+ *
+ * The store is mutable per run so that a tool can add its own identifiers to the
+ * request-level context that already exists, without the caller having to know which
+ * fields a deeper layer will want.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { logger } from './logger.js';
+import type { Logger } from 'pino';
+
+export interface LogContext {
+  /** MCP session, from the mcp-session-id header. Spans many requests. */
+  sid?: string;
+  /** One HTTP request to this server. */
+  req?: string;
+  /** One tool invocation. Usually one per request, but a JSON-RPC batch can carry several. */
+  call?: string;
+  /** Name of the tool being invoked. */
+  tool?: string;
+  /** OpenAPI path template of the Dockhand endpoint — never a concrete path. */
+  route?: string;
+}
+
+const storage = new AsyncLocalStorage<LogContext>();
+
+export function runWithLogContext<T>(context: LogContext, fn: () => T): T {
+  return storage.run({ ...context }, fn);
+}
+
+export function extendLogContext(patch: Partial<LogContext>): void {
+  const store = storage.getStore();
+  if (!store) return;
+  Object.assign(store, patch);
+}
+
+export function currentLogContext(): LogContext {
+  return { ...(storage.getStore() ?? {}) };
+}
+
+/** The logger, bound to whatever context the current call is running in. */
+export function log(): Logger {
+  const context = storage.getStore();
+  if (!context) return logger;
+  return logger.child(context);
+}

--- a/src/utils/log-context.ts
+++ b/src/utils/log-context.ts
@@ -30,8 +30,20 @@ export interface LogContext {
 
 const storage = new AsyncLocalStorage<LogContext>();
 
+/**
+ * The given object BECOMES the store — it is not copied. That is what makes a later
+ * extendLogContext() visible to whoever opened the context, which the access-log
+ * middleware depends on: it learns the session id only after the MCP handshake has
+ * run, and writes its line later still, from a res.on('finish') listener that has no
+ * reliable context of its own. Holding the object is deterministic; reaching back
+ * into AsyncLocalStorage from an event listener would work by accident at best.
+ *
+ * The invariant that keeps runs isolated is therefore at the call sites: each one
+ * passes a fresh object per run (a literal or a spread), never a shared or reused
+ * one. Both callers in src/ do; tests/log-context.test.ts pins both halves.
+ */
 export function runWithLogContext<T>(context: LogContext, fn: () => T): T {
-  return storage.run({ ...context }, fn);
+  return storage.run(context, fn);
 }
 
 export function extendLogContext(patch: Partial<LogContext>): void {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,71 @@
+/**
+ * The single pino instance for the whole server.
+ *
+ * Why stderr: the Streamable HTTP transport does not use stdout as a protocol
+ * channel (unlike a stdio MCP server), so stdout is free — and this server uses it
+ * for the nginx-formatted access log (see src/utils/access-log.ts). Keeping the two
+ * apart lets CrowdSec parse one stream without tripping over the other.
+ *
+ * Why sync: src/index.ts calls process.exit(1) immediately after logging a fatal
+ * configuration error. With an async destination that line can be lost in the exit,
+ * which would make the most important message the server ever writes the one least
+ * likely to arrive.
+ *
+ * Why no `silent`: the Issue #116 fix depends on the login-failure line always being
+ * written. Supporting a level that suppresses everything would hand that guarantee
+ * back to whoever sets an environment variable.
+ */
+
+import pino from 'pino';
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+const SUPPORTED: readonly LogLevel[] = ['error', 'warn', 'info', 'debug'];
+const DEFAULT_LEVEL: LogLevel = 'info';
+
+export interface ResolvedLogLevel {
+  level: LogLevel;
+  /** Set when the configured value was not usable; caller logs it once at startup. */
+  warning?: string;
+}
+
+export function resolveLogLevel(raw: string | undefined): ResolvedLogLevel {
+  if (raw === undefined || raw.trim() === '') return { level: DEFAULT_LEVEL };
+
+  const normalized = raw.trim().toLowerCase();
+  if ((SUPPORTED as readonly string[]).includes(normalized)) {
+    return { level: normalized as LogLevel };
+  }
+
+  return {
+    level: DEFAULT_LEVEL,
+    warning:
+      `LOG_LEVEL="${raw}" is not a supported level — falling back to ${DEFAULT_LEVEL}. ` +
+      `Supported: ${SUPPORTED.join(', ')}.`,
+  };
+}
+
+const resolved = resolveLogLevel(process.env['LOG_LEVEL']);
+
+export const logger = pino(
+  {
+    level: resolved.level,
+    // pino writes numeric levels by default (30, 50). Nobody reading `docker logs`
+    // wants to translate those, so emit the word.
+    formatters: {
+      level: (label) => ({ level: label }),
+    },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    // Defence in depth only. The real guarantee is structural: nothing that could
+    // carry a value is ever handed to the logger (see src/client/dockhand-client.ts).
+    redact: {
+      paths: ['password', 'token', 'secret', 'config', 'authorization', 'cookie'],
+      censor: '[redacted]',
+    },
+  },
+  pino.destination({ fd: 2, sync: true }),
+);
+
+if (resolved.warning) {
+  logger.warn({ component: 'config' }, resolved.warning);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,13 +3,28 @@
  *
  * Why stderr: the Streamable HTTP transport does not use stdout as a protocol
  * channel (unlike a stdio MCP server), so stdout is free — and this server uses it
- * for the nginx-formatted access log (see src/utils/access-log.ts). Keeping the two
- * apart lets CrowdSec parse one stream without tripping over the other.
+ * for the nginx-formatted access log (see src/utils/access-log.ts). Under Docker's
+ * default json-file driver the two streams end up in the same log anyway, so the
+ * split is not what keeps CrowdSec from tripping over the structured lines: the grok
+ * match is (a JSON line simply does not match the combined format). What the split
+ * buys is a consumer outside Docker being able to take one channel without the other.
  *
  * Why sync: src/index.ts calls process.exit(1) immediately after logging a fatal
  * configuration error. With an async destination that line can be lost in the exit,
  * which would make the most important message the server ever writes the one least
  * likely to arrive.
+ *
+ * KNOWN TRADE-OFF, deliberately left as it is for now: fd 2 in a container is a pipe,
+ * so if the log consumer stalls and the 64 KB pipe buffer fills, fs.writeSync blocks —
+ * and this is a single-threaded server, so it would stop answering requests while
+ * waiting to write a log line. The narrower fix (async destination + an explicit
+ * flush before each process.exit) is correct in production but cannot be adopted
+ * without first rebuilding how the tests capture log output: with an async
+ * destination SonicBoom sends the first write through fs.write and only buffered ones
+ * through fs.writeSync, so the fs.writeSync spy that ten test files rely on becomes
+ * non-deterministic — and it fails by capturing nothing, which reads as "the code
+ * logged nothing" rather than as a broken test. Flushing before asserting does NOT
+ * repair that, which is what makes it a rebuild rather than a tweak.
  *
  * Why no `silent`: the Issue #116 fix depends on the login-failure line always being
  * written. Supporting a level that suppresses everything would hand that guarantee

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -5,7 +5,7 @@
  * query-string redaction) because the un-redacted `Dockhand API error: ${method} ${url}
  * returned …` message built by `DockhandClient` (src/client/dockhand-client.ts) reaches
  * THREE separate surfaces, not just the `get_runtime_stats` sink:
- *   1. `console.error(...)` in `registerTool()` (src/utils/tool-helper.ts) — ships
+ *   1. `log().error(...)` in `registerTool()` (src/utils/tool-helper.ts) — ships
  *      straight into `docker logs`.
  *   2. `errorResponse(message)` (same call site) — returned to the invoking MCP client.
  *   3. `recordError(tool, message)` (src/utils/runtime-stats.ts) — stored and later

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -68,8 +68,21 @@ export function registerTool<T extends ZodShape>(
           // structured MCP tool-error response — never written to
           // stderr/docker logs. Logged unconditionally so every tool failure
           // is diagnosable from container logs alone. See Issue #116.
+          // Siblings, deliberately not nested under `err`. pino applies its default
+          // error serializer to that key, and it treats ANY object carrying a
+          // `message` as error-like: it overwrites `type` with the constructor name
+          // and appends an empty `stack`. This line spent its whole life emitting
+          // "err":{"type":"Object","message":...,"stack":""} — the 'ToolError' label
+          // never once reached a log. (dockhand-client.ts escapes it only by having
+          // no `message` key; adding one there would break it the same way, which is
+          // reason enough not to hand this key a shape that has to stay lucky.)
           log().error(
-            { component: 'tools', ms: Date.now() - started, err: { type: 'ToolError', message } },
+            {
+              component: 'tools',
+              ms: Date.now() - started,
+              errType: 'ToolError',
+              errMessage: message,
+            },
             'tool failed',
           );
           recordError(name, message);

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -9,6 +9,7 @@ import type { z } from 'zod';
 import { jsonResponse, textResponse, errorResponse } from './response.js';
 import { describeTool } from '../openapi/describe-tool.js';
 import { recordCall, recordError } from './runtime-stats.js';
+import { log } from './log-context.js';
 
 // Re-export response helpers for convenience
 export { jsonResponse, textResponse, errorResponse };
@@ -47,9 +48,9 @@ export function registerTool<T extends ZodShape>(
       // Fail loud: a thrown error here (e.g. a lazily-triggered Dockhand
       // login failure) would otherwise only ever reach the caller as a
       // structured MCP tool-error response — never written to
-      // stderr/docker logs. Log it unconditionally so every tool failure
+      // stderr/docker logs. Logged unconditionally so every tool failure
       // is diagnosable from container logs alone. See Issue #116.
-      console.error(`[tool:${name}] ${message}`);
+      log().error({ component: 'tools', tool: name, err: { type: 'ToolError', message } }, 'tool failed');
       recordError(name, message);
       return errorResponse(message);
     }

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -6,10 +6,12 @@
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { z } from 'zod';
+import { randomUUID } from 'node:crypto';
 import { jsonResponse, textResponse, errorResponse } from './response.js';
 import { describeTool } from '../openapi/describe-tool.js';
 import { recordCall, recordError } from './runtime-stats.js';
-import { log } from './log-context.js';
+import { runWithLogContext, log, currentLogContext } from './log-context.js';
+import { TOOL_ENDPOINT_MAP } from '../openapi/tool-endpoint-map.js';
 
 // Re-export response helpers for convenience
 export { jsonResponse, textResponse, errorResponse };
@@ -41,19 +43,40 @@ export function registerTool<T extends ZodShape>(
   /* eslint-disable @typescript-eslint/no-explicit-any */
   (server as any).tool(name, description, schema, async (args: any) => {
     recordCall(name);
-    try {
-      return await callback(args);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      // Fail loud: a thrown error here (e.g. a lazily-triggered Dockhand
-      // login failure) would otherwise only ever reach the caller as a
-      // structured MCP tool-error response — never written to
-      // stderr/docker logs. Logged unconditionally so every tool failure
-      // is diagnosable from container logs alone. See Issue #116.
-      log().error({ component: 'tools', tool: name, err: { type: 'ToolError', message } }, 'tool failed');
-      recordError(name, message);
-      return errorResponse(message);
-    }
+    const outer = currentLogContext();
+    const started = Date.now();
+
+    return runWithLogContext(
+      {
+        ...outer,
+        call: randomUUID(),
+        tool: name,
+        // The template, never the concrete path: this is what keeps a stack name or a
+        // container id out of every debug line the client below will write.
+        route: TOOL_ENDPOINT_MAP[name]?.path,
+      },
+      async () => {
+        log().info({ component: 'tools' }, 'start');
+        try {
+          const result = await callback(args);
+          log().info({ component: 'tools', ms: Date.now() - started }, 'ok');
+          return result;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          // Fail loud: a thrown error here (e.g. a lazily-triggered Dockhand
+          // login failure) would otherwise only ever reach the caller as a
+          // structured MCP tool-error response — never written to
+          // stderr/docker logs. Logged unconditionally so every tool failure
+          // is diagnosable from container logs alone. See Issue #116.
+          log().error(
+            { component: 'tools', ms: Date.now() - started, err: { type: 'ToolError', message } },
+            'tool failed',
+          );
+          recordError(name, message);
+          return errorResponse(message);
+        }
+      },
+    );
   });
   /* eslint-enable @typescript-eslint/no-explicit-any */
 }

--- a/tests/access-log-middleware.test.ts
+++ b/tests/access-log-middleware.test.ts
@@ -24,9 +24,19 @@ function fakeReq(overrides: Record<string, unknown> = {}) {
 function fakeRes() {
   const res = new EventEmitter() as EventEmitter & {
     statusCode: number;
+    writableFinished: boolean;
     getHeader: (name: string) => unknown;
   };
   res.statusCode = 200;
+  // Node sets writableFinished true before it emits 'finish'; mirror that so a plain
+  // res.emit('finish') in a test reflects a completed response, while a 'close' without
+  // a prior 'finish' leaves it false — the aborted case.
+  res.writableFinished = false;
+  const rawEmit = res.emit.bind(res);
+  res.emit = ((event: string | symbol, ...args: unknown[]) => {
+    if (event === 'finish') res.writableFinished = true;
+    return rawEmit(event, ...args);
+  }) as typeof res.emit;
   res.getHeader = () => undefined;
   return res;
 }
@@ -91,6 +101,36 @@ describe('access log middleware', () => {
     res.emit('finish');
 
     expect(lines[0].startsWith('203.0.113.9 ')).toBe(true);
+  });
+
+  it('logs an aborted mid-stream close as 499, not as the default 200', () => {
+    // A client hanging up before the response finishes fires 'close' without 'finish',
+    // and res.statusCode is still 200. Logging that as success would let a disconnect
+    // flood look like normal traffic to CrowdSec. Codex #209.
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+    const res = fakeRes();
+
+    middleware(fakeReq(), res as never, () => {});
+    res.emit('close'); // no prior 'finish' -> aborted
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('"POST /mcp HTTP/1.1" 499');
+  });
+
+  it('keeps the real status when the response finished, even if close follows', () => {
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+    const res = fakeRes();
+
+    middleware(fakeReq(), res as never, () => {});
+    res.statusCode = 200;
+    res.emit('finish');
+    res.emit('close');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('"POST /mcp HTTP/1.1" 200');
+    expect(lines[0]).not.toContain(' 499');
   });
 
   it('writes exactly one line even if the socket also closes', () => {

--- a/tests/access-log-middleware.test.ts
+++ b/tests/access-log-middleware.test.ts
@@ -4,7 +4,7 @@
  * the token, 403 means a DNS-rebinding attempt — and a middleware registered after
  * the guards would never run for either.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { createAccessLogMiddleware } from '../src/utils/access-log-middleware.js';
 import { parseTrustedProxies } from '../src/utils/client-ip.js';
@@ -101,6 +101,28 @@ describe('access log middleware', () => {
     res.emit('finish');
 
     expect(lines[0].startsWith('203.0.113.9 ')).toBe(true);
+  });
+
+  it('stamps the line with the emit time, not the request start time', () => {
+    // A long-lived SSE stream is written on close, minutes after it began. CrowdSec
+    // reads this timestamp for its time-windowed scenarios, so it must be the emit
+    // time. Codex #209.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-08-18T05:00:00Z'));
+      const lines: string[] = [];
+      const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+      const res = fakeRes();
+
+      middleware(fakeReq(), res as never, () => {});
+      vi.setSystemTime(new Date('2026-08-18T05:07:00Z')); // seven minutes later
+      res.emit('finish');
+
+      expect(lines[0]).toContain('[18/Aug/2026:05:07:00 +0000]');
+      expect(lines[0]).not.toContain('05:00:00');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('logs an aborted mid-stream close as 499, not as the default 200', () => {

--- a/tests/access-log-middleware.test.ts
+++ b/tests/access-log-middleware.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The middleware has to sit BEFORE the Host/Origin and bearer guards. A rejected
+ * request is the one an operator most wants to see — 401 means someone is guessing
+ * the token, 403 means a DNS-rebinding attempt — and a middleware registered after
+ * the guards would never run for either.
+ */
+import { describe, it, expect } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { createAccessLogMiddleware } from '../src/utils/access-log-middleware.js';
+import { parseTrustedProxies } from '../src/utils/client-ip.js';
+import { currentLogContext } from '../src/utils/log-context.js';
+
+function fakeReq(overrides: Record<string, unknown> = {}) {
+  return {
+    method: 'POST',
+    originalUrl: '/mcp',
+    httpVersion: '1.1',
+    headers: {},
+    socket: { remoteAddress: '203.0.113.9' },
+    ...overrides,
+  } as never;
+}
+
+function fakeRes() {
+  const res = new EventEmitter() as EventEmitter & {
+    statusCode: number;
+    getHeader: (name: string) => unknown;
+  };
+  res.statusCode = 200;
+  res.getHeader = () => undefined;
+  return res;
+}
+
+describe('access log middleware', () => {
+  it('writes one line when the response finishes', () => {
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+    const res = fakeRes();
+
+    middleware(fakeReq(), res as never, () => {});
+    expect(lines).toHaveLength(0); // nothing yet — the status is not known until the end
+
+    res.statusCode = 401;
+    res.emit('finish');
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('203.0.113.9');
+    expect(lines[0]).toContain('"POST /mcp HTTP/1.1" 401');
+  });
+
+  it('establishes a request context the rest of the call can see', () => {
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), () => {});
+    let seen: ReturnType<typeof currentLogContext> | undefined;
+
+    middleware(fakeReq({ headers: { 'mcp-session-id': 'sess-1' } }), fakeRes() as never, () => {
+      seen = currentLogContext();
+    });
+
+    expect(seen?.sid).toBe('sess-1');
+    expect(seen?.req).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  it('puts the same request id on the access line and in the context', () => {
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+    const res = fakeRes();
+    let contextReq = '';
+
+    middleware(fakeReq(), res as never, () => {
+      contextReq = currentLogContext().req ?? '';
+    });
+    res.emit('finish');
+
+    expect(contextReq).not.toBe('');
+    expect(lines[0]).toContain(`req=${contextReq}`);
+  });
+
+  it('honours a forwarding header from a trusted peer', () => {
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies('10.0.0.0/8'), (l) => lines.push(l));
+    const res = fakeRes();
+
+    middleware(
+      fakeReq({
+        socket: { remoteAddress: '10.0.0.5' },
+        headers: { 'x-forwarded-for': '203.0.113.9' },
+      }),
+      res as never,
+      () => {},
+    );
+    res.emit('finish');
+
+    expect(lines[0].startsWith('203.0.113.9 ')).toBe(true);
+  });
+
+  it('writes exactly one line even if the socket also closes', () => {
+    const lines: string[] = [];
+    const middleware = createAccessLogMiddleware(parseTrustedProxies(undefined), (l) => lines.push(l));
+    const res = fakeRes();
+
+    middleware(fakeReq(), res as never, () => {});
+    res.emit('finish');
+    res.emit('close');
+
+    expect(lines).toHaveLength(1);
+  });
+});

--- a/tests/access-log-ordering-e2e.test.ts
+++ b/tests/access-log-ordering-e2e.test.ts
@@ -26,7 +26,7 @@ const DUMMY_DOCKHAND: ServerConfig['dockhand'] = {
 
 let httpServer: HttpServer | undefined;
 
-function postToMcp(port: number): Promise<{ statusCode: number }> {
+function postToMcp(port: number, body = '{}'): Promise<{ statusCode: number }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
       {
@@ -43,7 +43,7 @@ function postToMcp(port: number): Promise<{ statusCode: number }> {
       },
     );
     req.on('error', reject);
-    req.end('{}');
+    req.end(body);
   });
 }
 
@@ -72,6 +72,31 @@ describe('access-log middleware ordering (regression)', () => {
 
     expect(res.statusCode).toBe(401);
     const accessLines = written.filter((line) => line.includes('"POST /mcp HTTP/1.1" 401'));
+    expect(accessLines.length).toBeGreaterThan(0);
+  });
+
+  // The bearer-guard case above only pins the access log against the two guards. It
+  // says nothing about express.json(), which sits earlier in the chain and rejects a
+  // malformed body by calling next(err) -- that skips every non-error middleware, so
+  // an access-log middleware registered after the body parser never even gets to
+  // attach its res.on('finish') handler and writes NOTHING for the request. The 400
+  // still goes out, so this fails silently in exactly the way the test above was
+  // written to prevent, and the suite is green with the body parser on either side
+  // of the access log until this test exists.
+  it('writes an access line for a body-parser 400 rejection', async () => {
+    const written: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    httpServer = await createServer({ dockhand: DUMMY_DOCKHAND, port: TEST_PORT, host: '127.0.0.1' });
+
+    const res = await postToMcp(TEST_PORT, '{bad:1}');
+    spy.mockRestore();
+
+    expect(res.statusCode).toBe(400);
+    const accessLines = written.filter((line) => line.includes('"POST /mcp HTTP/1.1" 400'));
     expect(accessLines.length).toBeGreaterThan(0);
   });
 });

--- a/tests/access-log-ordering-e2e.test.ts
+++ b/tests/access-log-ordering-e2e.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+import { createServer } from '../src/server.js';
+import type { ServerConfig } from '../src/server.js';
+
+// Regression test for the registration order in src/server.ts: the access-log
+// middleware MUST run before the Host/Origin and bearer guards. That ordering is
+// the whole point of the task that introduced it (see the comment at its
+// registration) and fails SILENTLY if it regresses -- a middleware registered
+// after the guards would still return the correct 401, but no access line would
+// ever be written for it, and nothing here would go red without this test. The
+// middleware's own unit tests (access-log-middleware.test.ts) never touch
+// server.ts's registration order at all.
+//
+// This exercises the real Express app end-to-end (no mocked req/res), on a fixed
+// loopback port, the same pattern as tests/transport-security-e2e.test.ts.
+
+const TEST_PORT = 48299;
+
+const DUMMY_DOCKHAND: ServerConfig['dockhand'] = {
+  url: 'http://dockhand.invalid',
+  username: 'dummy',
+  password: 'dummy',
+};
+
+let httpServer: HttpServer | undefined;
+
+function postToMcp(port: number): Promise<{ statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/mcp',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Connection: 'close' },
+        agent: false,
+      },
+      (res) => {
+        res.on('data', () => {});
+        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }));
+      },
+    );
+    req.on('error', reject);
+    req.end('{}');
+  });
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+    httpServer = undefined;
+  }
+});
+
+describe('access-log middleware ordering (regression)', () => {
+  it('writes an access line for a bearer-guard 401 rejection', async () => {
+    const written: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    vi.stubEnv('MCP_AUTH_TOKEN', 'top-secret-token');
+    httpServer = await createServer({ dockhand: DUMMY_DOCKHAND, port: TEST_PORT, host: '127.0.0.1' });
+
+    const res = await postToMcp(TEST_PORT);
+    spy.mockRestore();
+
+    expect(res.statusCode).toBe(401);
+    const accessLines = written.filter((line) => line.includes('"POST /mcp HTTP/1.1" 401'));
+    expect(accessLines.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -76,6 +76,52 @@ describe('formatAccessLine', () => {
     expect(line).toContain('req=r-1 sid=-');
   });
 
+  // `sid` is the one field an outsider controls in full (the mcp-session-id header)
+  // and the one written without quotes. Nothing bounds it but this rule, so each of
+  // these was a way to write chosen text into the tail of a line CrowdSec reads.
+  describe('rejects a session identifier that is not one', () => {
+    function sessionField(sid: string): string {
+      const line = formatAccessLine({
+        ip: '203.0.113.9', time: AT, method: 'POST', path: '/mcp', httpVersion: '1.1',
+        status: 200, bytes: 1, req: '7c1e94a2-3f8b-4d21-9e5c-1a2b3c4d5e6f', sid,
+      });
+      return line.slice(line.indexOf(' sid=') + ' sid='.length);
+    }
+
+    it('rejects a quote, which would otherwise unbalance the quoted fields before it', () => {
+      expect(sessionField('a"b')).toBe('-');
+    });
+
+    it('rejects a space, the separator every field in the line is delimited by', () => {
+      expect(sessionField('a b')).toBe('-');
+    });
+
+    it('rejects a value longer than any identifier, so a large header cannot inflate the line', () => {
+      expect(sessionField('a'.repeat(65))).toBe('-');
+      // The boundary itself stays usable -- this is a cap, not a UUID-only rule.
+      expect(sessionField('a'.repeat(64))).toBe('a'.repeat(64));
+    });
+
+    it('rejects the full forged suffix, which is what the three rules above are for', () => {
+      // Exactly the header value that was demonstrated to append a plausible second
+      // req=/sid= pair to the end of an otherwise well-formed line.
+      const line = formatAccessLine({
+        ip: '203.0.113.9', time: AT, method: 'POST', path: '/mcp', httpVersion: '1.1',
+        status: 200, bytes: 0, req: '7c1e94a2-3f8b-4d21-9e5c-1a2b3c4d5e6f',
+        sid: 'x" 200 0 "-" "-" req=FORGED sid=deadbeef',
+      });
+
+      expect(line).not.toContain('FORGED');
+      expect(line.endsWith(' req=7c1e94a2-3f8b-4d21-9e5c-1a2b3c4d5e6f sid=-')).toBe(true);
+    });
+
+    it('keeps a real session identifier untouched', () => {
+      expect(sessionField('b3f0a1de-77c4-4f0a-8b9d-2e1f0a9c8b77')).toBe(
+        'b3f0a1de-77c4-4f0a-8b9d-2e1f0a9c8b77',
+      );
+    });
+  });
+
   it('never carries a query string', () => {
     // A logged query is a logged value. Our own endpoints take no parameters, so
     // dropping it costs nothing and removes a leak path that would otherwise be one

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -11,27 +11,32 @@ import { formatAccessLine } from '../src/utils/access-log.js';
 const AT = new Date(Date.UTC(2026, 7, 17, 20, 44, 1));
 
 /**
- * Mirrors the grok QUOTEDSTRING rule `"(?:\\.|[^"\\])*"`: the only escape the parser
- * understands is "backslash followed by any one character", consumed as a pair. This
- * decodes a quoted field starting at `start` (the opening quote) exactly the way
- * nginx-logs would, so a test can assert that what comes out the other end of
- * CrowdSec's parser is the original, unmangled value — not just that our own escaping
- * looks plausible.
+ * Splits a line the way the consumer does.
+ *
+ * The expectations in this file are derived from crowdsecurity/nginx-logs, NOT from
+ * grok's `QUOTEDSTRING`. nginx-logs reads each quoted field with `%{NOTDQUOTE}`,
+ * defined as `[^"]*` — it has no escape sequence of any kind, so a `"` character is a
+ * field boundary and nothing else, and a `\"` is a backslash followed by the end of
+ * the field. An earlier version of this file asserted against `QUOTEDSTRING` and its
+ * `\\.`-style escapes; that parser is not the one reading these lines, and a value
+ * written for it makes the line fail to parse entirely (confirmed against the live
+ * LAPI). What we emit instead is nginx's own convention: `"` -> `\x22`, `\` -> `\x5C`,
+ * and each C0 control character, DEL and byte >= 0x80 -> `\xNN`, uppercase hex.
+ *
+ * Because no field content may contain a raw quote, splitting on `"` is exactly how
+ * the parser sees the line: an extra piece means we emitted a boundary we did not mean.
  */
-function decodeQuotedField(text: string, start: number): string {
-  let i = start + 1;
-  let out = '';
-  while (i < text.length) {
-    if (text[i] === '\\' && i + 1 < text.length) {
-      out += text[i + 1];
-      i += 2;
-      continue;
-    }
-    if (text[i] === '"') return out;
-    out += text[i];
-    i += 1;
-  }
-  throw new Error('unterminated quoted field in test fixture');
+function quotedFields(line: string): { request: string; referer: string; userAgent: string } {
+  const pieces = line.split('"');
+  expect(pieces).toHaveLength(7);
+  return { request: pieces[1], referer: pieces[3], userAgent: pieces[5] };
+}
+
+function lineWith(overrides: Partial<Parameters<typeof formatAccessLine>[0]>): string {
+  return formatAccessLine({
+    ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
+    status: 200, bytes: 2, ...overrides,
+  });
 }
 
 describe('formatAccessLine', () => {
@@ -139,50 +144,92 @@ describe('formatAccessLine', () => {
   it('cannot be used to forge a second log line', () => {
     // A user agent is attacker-controlled. A newline in it would end the line and
     // start one of the attacker's choosing, in a stream a security tool reads.
-    const line = formatAccessLine({
-      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
-      status: 200, bytes: 2,
+    const line = lineWith({
       userAgent: 'evil\n1.2.3.4 - - [17/Aug/2026:20:44:01 +0000] "GET / HTTP/1.1" 200 0 "-" "forged"',
     });
 
     expect(line.split('\n')).toHaveLength(1);
-    expect(line).not.toContain('forged"');
+    // The newline survives as its encoding rather than being replaced, and every quote
+    // in the forged remainder is encoded too — so the whole payload stays inside the
+    // one user-agent field the parser sees, instead of ending it early.
+    expect(quotedFields(line).userAgent).toContain('evil\\x0A1.2.3.4');
+    expect(quotedFields(line).userAgent.endsWith('\\x22forged\\x22')).toBe(true);
   });
 
-  it('escapes a quote in the user agent rather than closing the field early', () => {
-    const line = formatAccessLine({
-      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
-      status: 200, bytes: 2, userAgent: 'we"ird',
+  /**
+   * Each case here is a value that, written the way this file used to write it, made
+   * the line unparseable for crowdsecurity/nginx-logs — which means no event, no
+   * bucket and no decision for the request that carried it.
+   */
+  describe('encodes a quoted field the way nginx does, because NOTDQUOTE has no escapes', () => {
+    it('encodes a quote in the user agent instead of emitting a raw or backslashed one', () => {
+      const line = lineWith({ userAgent: 'a"b' });
+
+      expect(quotedFields(line).userAgent).toBe('a\\x22b');
+      // The old form. `\"` is not an escape to this parser — it is a backslash and
+      // then the end of the field, one character early.
+      expect(line).not.toContain('\\"');
     });
 
-    expect(line.endsWith('"we\\"ird"')).toBe(true);
+    it('encodes a quote in the referer, the field the finding was demonstrated on', () => {
+      const line = lineWith({ referer: 'ev"il' });
+
+      expect(quotedFields(line).referer).toBe('ev\\x22il');
+    });
+
+    it('encodes a lone quote, the one-character header that removed a caller from CrowdSec', () => {
+      const line = lineWith({ referer: '"' });
+
+      expect(quotedFields(line).referer).toBe('\\x22');
+    });
+
+    it('encodes a backslash, so it can never pair with anything to look like an escape', () => {
+      const line = lineWith({ referer: 'back\\slash' });
+
+      expect(quotedFields(line).referer).toBe('back\\x5Cslash');
+    });
+
+    it('encodes a control character rather than replacing it, which is lossless and still safe', () => {
+      const line = lineWith({
+        userAgent: `a${String.fromCharCode(0x01)}b${String.fromCharCode(0x7f)}c`,
+      });
+
+      expect(quotedFields(line).userAgent).toBe('a\\x01b\\x7Fc');
+    });
+
+    it('encodes a byte above 0x7f, which nginx escapes and a log reader should not have to guess at', () => {
+      // Node decodes header bytes as latin-1, so this code unit IS the wire byte.
+      const line = lineWith({ userAgent: `caf${String.fromCharCode(0xe9)}` });
+
+      expect(quotedFields(line).userAgent).toBe('caf\\xE9');
+    });
+
+    it('leaves ordinary printable text exactly as it arrived', () => {
+      const line = lineWith({ userAgent: "Mozilla/5.0 (X11; Linux x86_64) 'quoted' ~ok~" });
+
+      expect(quotedFields(line).userAgent).toBe("Mozilla/5.0 (X11; Linux x86_64) 'quoted' ~ok~");
+    });
   });
 
-  it('escapes a pre-existing backslash before escaping a quote, so grok cannot desync the field', () => {
-    // A naive "escape the quote" pass leaves an existing backslash alone. Grok's
-    // QUOTEDSTRING then reads that backslash paired with the escaped quote's own
-    // backslash as ONE escaped-backslash sequence, and treats the quote that follows
-    // as the field's real, unescaped close — ending the field one character early.
-    // Decoding with the same rule the parser uses is the only check that catches that.
-    const ua = 'trailing backslash then quote: \\"';
-    const line = formatAccessLine({
-      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
-      status: 200, bytes: 2, userAgent: ua,
-    });
+  it('makes the request method match %{WORD}, which cannot reach past a hyphen', () => {
+    // M-SEARCH is the only method in Node's http.METHODS containing a character that
+    // `\b\w+\b` cannot match. Verified against the live LAPI: such a line still parses,
+    // but LePresidente/http-generic-401-bf never fires for it — so repeated 401s on
+    // this verb would be invisible to the bruteforce scenario while still answering
+    // whether a guessed token was right. Replaced rather than encoded: `M\x2DSEARCH`
+    // fails just the same, because %{WORD} still cannot reach the space that follows.
+    const line = lineWith({ method: 'M-SEARCH', path: '/mcp', status: 401 });
 
-    const boundary = line.lastIndexOf('"-" "');
-    expect(boundary).toBeGreaterThan(-1);
-    const uaFieldStart = boundary + '"-" "'.length - 1;
-    expect(decodeQuotedField(line, uaFieldStart)).toBe(ua);
+    expect(quotedFields(line).request).toBe('M_SEARCH /mcp HTTP/1.1');
   });
 
   it('strips a newline from the ip field, which nginx never quotes', () => {
     // The ip field is interpolated unquoted (nginx doesn't quote it either, and
-    // CrowdSec's grok expects it bare) — but a newline in it is still the one thing
-    // cheap enough to defend against here, rather than trusting a caller's guarantee
-    // that it never hands one back. Unquoted also means an attacker's injected text
-    // still lands, verbatim, inside the single resulting line — that's expected and
-    // is not what this test is about; the only real defense is against a second line.
+    // CrowdSec's grok expects it bare) — so it gets the strip, not the encoding: a
+    // `\x0A` there would be text inside a field the parser expects to hold an address.
+    // Unquoted also means an attacker's injected text still lands, verbatim, inside
+    // the single resulting line — that's expected and is not what this test is about;
+    // the only real defense is against a second line.
     const line = formatAccessLine({
       ip: '203.0.113.9\n1.2.3.4 - - [17/Aug/2026:20:44:01 +0000] "GET / HTTP/1.1" 200 0 "-" "forged"',
       time: AT, method: 'GET', path: '/health', httpVersion: '1.1', status: 200, bytes: 2,
@@ -192,10 +239,7 @@ describe('formatAccessLine', () => {
   });
 
   it('never prints NaN for status or bytes', () => {
-    const line = formatAccessLine({
-      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
-      status: Number.NaN, bytes: Number.NaN,
-    });
+    const line = lineWith({ status: Number.NaN, bytes: Number.NaN });
 
     expect(line).not.toContain('NaN');
   });

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -10,6 +10,30 @@ import { formatAccessLine } from '../src/utils/access-log.js';
 
 const AT = new Date(Date.UTC(2026, 7, 17, 20, 44, 1));
 
+/**
+ * Mirrors the grok QUOTEDSTRING rule `"(?:\\.|[^"\\])*"`: the only escape the parser
+ * understands is "backslash followed by any one character", consumed as a pair. This
+ * decodes a quoted field starting at `start` (the opening quote) exactly the way
+ * nginx-logs would, so a test can assert that what comes out the other end of
+ * CrowdSec's parser is the original, unmangled value — not just that our own escaping
+ * looks plausible.
+ */
+function decodeQuotedField(text: string, start: number): string {
+  let i = start + 1;
+  let out = '';
+  while (i < text.length) {
+    if (text[i] === '\\' && i + 1 < text.length) {
+      out += text[i + 1];
+      i += 2;
+      continue;
+    }
+    if (text[i] === '"') return out;
+    out += text[i];
+    i += 1;
+  }
+  throw new Error('unterminated quoted field in test fixture');
+}
+
 describe('formatAccessLine', () => {
   it('produces the exact combined format verified against CrowdSec', () => {
     expect(
@@ -86,5 +110,47 @@ describe('formatAccessLine', () => {
     });
 
     expect(line.endsWith('"we\\"ird"')).toBe(true);
+  });
+
+  it('escapes a pre-existing backslash before escaping a quote, so grok cannot desync the field', () => {
+    // A naive "escape the quote" pass leaves an existing backslash alone. Grok's
+    // QUOTEDSTRING then reads that backslash paired with the escaped quote's own
+    // backslash as ONE escaped-backslash sequence, and treats the quote that follows
+    // as the field's real, unescaped close — ending the field one character early.
+    // Decoding with the same rule the parser uses is the only check that catches that.
+    const ua = 'trailing backslash then quote: \\"';
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
+      status: 200, bytes: 2, userAgent: ua,
+    });
+
+    const boundary = line.lastIndexOf('"-" "');
+    expect(boundary).toBeGreaterThan(-1);
+    const uaFieldStart = boundary + '"-" "'.length - 1;
+    expect(decodeQuotedField(line, uaFieldStart)).toBe(ua);
+  });
+
+  it('strips a newline from the ip field, which nginx never quotes', () => {
+    // The ip field is interpolated unquoted (nginx doesn't quote it either, and
+    // CrowdSec's grok expects it bare) — but a newline in it is still the one thing
+    // cheap enough to defend against here, rather than trusting a caller's guarantee
+    // that it never hands one back. Unquoted also means an attacker's injected text
+    // still lands, verbatim, inside the single resulting line — that's expected and
+    // is not what this test is about; the only real defense is against a second line.
+    const line = formatAccessLine({
+      ip: '203.0.113.9\n1.2.3.4 - - [17/Aug/2026:20:44:01 +0000] "GET / HTTP/1.1" 200 0 "-" "forged"',
+      time: AT, method: 'GET', path: '/health', httpVersion: '1.1', status: 200, bytes: 2,
+    });
+
+    expect(line.split('\n')).toHaveLength(1);
+  });
+
+  it('never prints NaN for status or bytes', () => {
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
+      status: Number.NaN, bytes: Number.NaN,
+    });
+
+    expect(line).not.toContain('NaN');
   });
 });

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -213,11 +213,14 @@ describe('formatAccessLine', () => {
 
   it('makes the request method match %{WORD}, which cannot reach past a hyphen', () => {
     // M-SEARCH is the only method in Node's http.METHODS containing a character that
-    // `\b\w+\b` cannot match. Verified against the live LAPI: such a line still parses,
-    // but LePresidente/http-generic-401-bf never fires for it — so repeated 401s on
-    // this verb would be invisible to the bruteforce scenario while still answering
-    // whether a guessed token was right. Replaced rather than encoded: `M\x2DSEARCH`
+    // `\b\w+\b` cannot match. Whether that costs anything depends on the hub version: a
+    // compiled grok harness failed to parse such a line at all, while the hub on our own
+    // LAPI parses it. This keeps the line parseable either way rather than relying on
+    // the consumer being the lenient one. Replaced rather than encoded: `M\x2DSEARCH`
     // fails just the same, because %{WORD} still cannot reach the space that follows.
+    //
+    // It does NOT make the 401 bruteforce scenario fire — that filters on
+    // `evt.Parsed.verb == 'POST'`, so every non-POST verb escapes it whatever we write.
     const line = lineWith({ method: 'M-SEARCH', path: '/mcp', status: 401 });
 
     expect(quotedFields(line).request).toBe('M_SEARCH /mcp HTTP/1.1');

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The format is not a matter of taste: it is what crowdsecurity/nginx-logs parses.
+ * The expected string below is the exact line that was verified against the live
+ * LAPI with `cscli explain` — docker-logs -> nginx-logs -> geoip -> the 401
+ * bruteforce scenario. If a change here breaks that shape, CrowdSec stops seeing
+ * this server without anything failing loudly.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatAccessLine } from '../src/utils/access-log.js';
+
+const AT = new Date(Date.UTC(2026, 7, 17, 20, 44, 1));
+
+describe('formatAccessLine', () => {
+  it('produces the exact combined format verified against CrowdSec', () => {
+    expect(
+      formatAccessLine({
+        ip: '203.0.113.9',
+        time: AT,
+        method: 'POST',
+        path: '/mcp',
+        httpVersion: '1.1',
+        status: 401,
+        bytes: 27,
+        userAgent: 'curl/8.5',
+      }),
+    ).toBe('203.0.113.9 - - [17/Aug/2026:20:44:01 +0000] "POST /mcp HTTP/1.1" 401 27 "-" "curl/8.5"');
+  });
+
+  it('appends the correlation identifiers when present', () => {
+    const line = formatAccessLine({
+      ip: '203.0.113.9',
+      time: AT,
+      method: 'POST',
+      path: '/mcp',
+      httpVersion: '1.1',
+      status: 200,
+      bytes: 412,
+      userAgent: 'claude-connector/1.0',
+      req: '7c1e94a2-3f8b-4d21-9e5c-1a2b3c4d5e6f',
+      sid: 'b3f0a1de-77c4-4f0a-8b9d-2e1f0a9c8b77',
+    });
+
+    expect(line).toContain('"claude-connector/1.0" req=7c1e94a2-3f8b-4d21-9e5c-1a2b3c4d5e6f sid=b3f0a1de-77c4-4f0a-8b9d-2e1f0a9c8b77');
+  });
+
+  it('writes a dash for a missing session', () => {
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'POST', path: '/mcp', httpVersion: '1.1',
+      status: 200, bytes: 1, req: 'r-1',
+    });
+
+    expect(line).toContain('req=r-1 sid=-');
+  });
+
+  it('never carries a query string', () => {
+    // A logged query is a logged value. Our own endpoints take no parameters, so
+    // dropping it costs nothing and removes a leak path that would otherwise be one
+    // careless caller away.
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'POST', path: '/mcp?secret=hunter2',
+      httpVersion: '1.1', status: 200, bytes: 1,
+    });
+
+    expect(line).not.toContain('hunter2');
+    expect(line).not.toContain('secret');
+    expect(line).toContain('"POST /mcp HTTP/1.1"');
+  });
+
+  it('cannot be used to forge a second log line', () => {
+    // A user agent is attacker-controlled. A newline in it would end the line and
+    // start one of the attacker's choosing, in a stream a security tool reads.
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
+      status: 200, bytes: 2,
+      userAgent: 'evil\n1.2.3.4 - - [17/Aug/2026:20:44:01 +0000] "GET / HTTP/1.1" 200 0 "-" "forged"',
+    });
+
+    expect(line.split('\n')).toHaveLength(1);
+    expect(line).not.toContain('forged"');
+  });
+
+  it('escapes a quote in the user agent rather than closing the field early', () => {
+    const line = formatAccessLine({
+      ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
+      status: 200, bytes: 2, userAgent: 'we"ird',
+    });
+
+    expect(line.endsWith('"we\\"ird"')).toBe(true);
+  });
+});

--- a/tests/client-debug-logging.test.ts
+++ b/tests/client-debug-logging.test.ts
@@ -115,4 +115,40 @@ describe('client debug logging', () => {
 
     expect(debugLines()).toHaveLength(0);
   });
+
+  it('logs a network failure at warn without leaking the URL, and still throws', async () => {
+    // Every other test uses mockResolvedValue, so fetch never rejects and this branch
+    // never runs — meaning the secret guarantee on the warn line was, until this test,
+    // held by review alone, not by a test. The wrapper's catch block is the only place
+    // in the file this can be exercised.
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('fetch failed'));
+
+    const instance = await client();
+    await expect(instance.get('/api/stacks/paperless/env/raw')).rejects.toThrow('fetch failed');
+
+    const [line] = debugLines();
+    expect(line.level).toBe('warn');
+    expect(line.route).toBe('/api/stacks');
+    expect(line.err.type).toBe('TypeError');
+    expect(JSON.stringify(line)).not.toContain('paperless');
+  });
+
+  it('logs the 401 retry as its own line with the same route', async () => {
+    // The whole point of one shared wrapper instead of patching each of the eight
+    // call sites individually: a retry after a 401 shows up as a second, independent
+    // line — which is exactly what you want to see when debugging an auth problem.
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+      );
+
+    const instance = await client();
+    await instance.get('/api/stacks');
+
+    const lines = debugLines();
+    expect(lines).toHaveLength(2);
+    expect(lines.map((l) => l.status)).toEqual([401, 200]);
+    expect(lines[0].route).toBe(lines[1].route);
+  });
 });

--- a/tests/client-debug-logging.test.ts
+++ b/tests/client-debug-logging.test.ts
@@ -1,0 +1,118 @@
+/**
+ * This is the file the whole "structural, not a filter list" argument rests on. The
+ * client is the only place that ever holds a concrete URL, and it must never write
+ * one.
+ *
+ * The webhook case is not hypothetical: trigger_git_webhook puts its secret in the
+ * query string, which is exactly why src/utils/redact.ts exists for error messages.
+ * A debug line that logged the URL would reopen that hole at a second surface.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+
+describe('client debug logging', () => {
+  let written: string[];
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env['LOG_LEVEL'] = 'debug';
+    written = [];
+    // NOT process.stderr.write: pino.destination({ fd: 2, sync: true }) is a SonicBoom
+    // stream that calls fs.writeSync(fd, ...) directly and never touches
+    // process.stderr.write, so a spy there captures nothing and the test reads as
+    // "the logger wrote nothing" no matter what it wrote. Verified against Task 1's
+    // logger while implementing Task 3. Spy on the DEFAULT import — a namespace
+    // import is a frozen ESM object and vi.spyOn cannot replace a property on it.
+    vi.spyOn(fs, 'writeSync').mockImplementation((_fd: unknown, chunk: unknown) => {
+      const text = String(chunk);
+      written.push(text);
+      // SonicBoom reads this as the number of bytes it released from its internal
+      // buffer. Returning 0 while data was actually captured makes it believe
+      // nothing was written and retry the same buffer forever — an infinite loop
+      // that OOMs the worker in a test that otherwise does almost nothing. Bit the
+      // Task 7 implementer on its first run; reproduced here on the first run of
+      // this file before this fix.
+      return Buffer.byteLength(text);
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+  });
+
+  afterEach(() => {
+    delete process.env['LOG_LEVEL'];
+    vi.restoreAllMocks();
+  });
+
+  async function client() {
+    const { DockhandClient } = await import('../src/client/dockhand-client.js');
+    const instance = new DockhandClient({
+      url: 'https://dockhand.example',
+      username: 'svc',
+      password: 'pw',
+    });
+    // The session manager would try to log in first; hand it a cookie.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (instance as any).session = { getCookie: async () => 'session=x', invalidate: () => {} };
+    return instance;
+  }
+
+  function debugLines() {
+    const joined = written.join('').trim();
+    // written stays empty when the level filter suppresses every debug call — no
+    // fs.writeSync happens at all, so there is nothing to split/parse.
+    if (!joined) return [];
+    return joined
+      .split('\n')
+      .map((l) => JSON.parse(l))
+      .filter((l) => l.component === 'client');
+  }
+
+  it('logs the method, status and duration', async () => {
+    const instance = await client();
+    await instance.get('/api/stacks');
+
+    const [line] = debugLines();
+    expect(line.level).toBe('debug');
+    expect(line.method).toBe('GET');
+    expect(line.status).toBe(200);
+    expect(typeof line.ms).toBe('number');
+  });
+
+  it('never writes a query value, only the parameter names', async () => {
+    const instance = await client();
+    await instance.post('/api/git/webhook/42', undefined, { secret: 'hunter2', env: 'prod' });
+
+    const serialised = JSON.stringify(debugLines());
+    expect(serialised).not.toContain('hunter2');
+    expect(serialised).not.toContain('prod');
+    expect(debugLines()[0].query.sort()).toEqual(['env', 'secret']);
+  });
+
+  it('never writes the concrete path', async () => {
+    const instance = await client();
+    await instance.get('/api/stacks/paperless/env/raw');
+
+    const serialised = JSON.stringify(debugLines());
+    expect(serialised).not.toContain('paperless');
+  });
+
+  it('falls back to a coarse template outside a tool context', async () => {
+    // Login and self-check calls run without a tool context, so there is no entry in
+    // TOOL_ENDPOINT_MAP to consult. Two segments is enough to tell auth from stacks
+    // and cannot contain an identifier.
+    const instance = await client();
+    await instance.get('/api/stacks/paperless/env/raw');
+
+    expect(debugLines()[0].route).toBe('/api/stacks');
+  });
+
+  it('says nothing at all at info level', async () => {
+    process.env['LOG_LEVEL'] = 'info';
+    vi.resetModules();
+    const instance = await client();
+    await instance.get('/api/stacks');
+
+    expect(debugLines()).toHaveLength(0);
+  });
+});

--- a/tests/client-ip.test.ts
+++ b/tests/client-ip.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Behind Pangolin every request arrives from the proxy, so without this the access
+ * log names the proxy for every client — and a CrowdSec decision on that address
+ * would lock out everyone at once.
+ *
+ * The headers are only trustworthy when the peer is. Honouring them unconditionally
+ * would hand any direct caller a way to get an arbitrary third party banned.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseTrustedProxies, resolveClientIp } from '../src/utils/client-ip.js';
+
+const NONE = parseTrustedProxies(undefined);
+const PROXY = parseTrustedProxies('10.0.0.0/8, 100.64.0.0/10');
+
+describe('parseTrustedProxies', () => {
+  it('treats an unset value as trusting nobody', () => {
+    expect(NONE.isEmpty).toBe(true);
+  });
+
+  it('accepts a bare address as a single host', () => {
+    const trusted = parseTrustedProxies('192.0.2.7');
+    expect(trusted.isEmpty).toBe(false);
+    expect(trusted.contains('192.0.2.7')).toBe(true);
+    expect(trusted.contains('192.0.2.8')).toBe(false);
+  });
+
+  it('ignores an unparsable entry instead of throwing', () => {
+    // Starting is more important than a perfect list; the warning tells the operator.
+    const trusted = parseTrustedProxies('10.0.0.0/8, not-an-address');
+    expect(trusted.contains('10.1.2.3')).toBe(true);
+    expect(trusted.warnings).toHaveLength(1);
+    expect(trusted.warnings[0]).toMatch(/not-an-address/);
+  });
+});
+
+describe('resolveClientIp', () => {
+  it('uses the peer when no proxy is trusted', () => {
+    expect(
+      resolveClientIp({
+        peer: '203.0.113.9',
+        forwardedFor: '198.51.100.1',
+        realIp: '198.51.100.2',
+        trusted: NONE,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('ignores headers from an untrusted peer', () => {
+    // The spoofing case. A direct caller must not be able to name someone else.
+    expect(
+      resolveClientIp({
+        peer: '203.0.113.9',
+        forwardedFor: '8.8.8.8',
+        realIp: '8.8.4.4',
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('takes the rightmost untrusted entry of X-Forwarded-For', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: '203.0.113.9, 10.0.0.9',
+        realIp: undefined,
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('falls back to X-Real-IP when there is no X-Forwarded-For', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: undefined,
+        realIp: '203.0.113.9',
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('prefers X-Forwarded-For over X-Real-IP when both are present', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: '203.0.113.9',
+        realIp: '198.51.100.1',
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('keeps the proxy address when the whole chain is trusted', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: '10.0.0.7, 10.0.0.9',
+        realIp: undefined,
+        trusted: PROXY,
+      }),
+    ).toBe('10.0.0.7');
+  });
+
+  it('normalises an IPv4-mapped IPv6 peer', () => {
+    // Node hands out ::ffff:10.0.0.5 on a dual-stack listener; without this the
+    // address never matches an IPv4 subnet and the headers are silently ignored.
+    expect(
+      resolveClientIp({
+        peer: '::ffff:10.0.0.5',
+        forwardedFor: '203.0.113.9',
+        realIp: undefined,
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('reports a dash when there is no peer at all', () => {
+    expect(
+      resolveClientIp({ peer: undefined, forwardedFor: undefined, realIp: undefined, trusted: NONE }),
+    ).toBe('-');
+  });
+});

--- a/tests/client-ip.test.ts
+++ b/tests/client-ip.test.ts
@@ -56,6 +56,16 @@ describe('parseTrustedProxies', () => {
     expect(trusted.warnings).toHaveLength(1);
   });
 
+  it('rejects an entry with extra slash components instead of trusting the parsed subnet', () => {
+    // 10.0.0.0/8/garbage must not resolve to /8 — a dropped third component would trust a
+    // 16.7M-address subnet the operator never wrote. Codex #209.
+    const trusted = parseTrustedProxies('10.0.0.0/8/garbage');
+    expect(trusted.isEmpty).toBe(true);
+    expect(trusted.contains('10.1.2.3')).toBe(false);
+    expect(trusted.warnings).toHaveLength(1);
+    expect(trusted.warnings[0]).toMatch(/10\.0\.0\.0\/8\/garbage/);
+  });
+
   it('accepts an explicit /0 as a deliberate trust-everything subnet', () => {
     // /0 is a legitimate, deliberate choice — only the malformed spelling (a missing
     // or non-digit prefix) is rejected, not the value zero itself.

--- a/tests/client-ip.test.ts
+++ b/tests/client-ip.test.ts
@@ -31,6 +31,39 @@ describe('parseTrustedProxies', () => {
     expect(trusted.warnings).toHaveLength(1);
     expect(trusted.warnings[0]).toMatch(/not-an-address/);
   });
+
+  it('rejects a trailing-slash entry instead of matching every address', () => {
+    // Number('') === 0, not NaN — without a digit check this becomes a /0 that
+    // trusts the entire internet, silently turning "trust nobody" into "trust everybody".
+    const trusted = parseTrustedProxies('10.0.0.0/');
+    expect(trusted.isEmpty).toBe(true);
+    expect(trusted.contains('8.8.8.8')).toBe(false);
+    expect(trusted.contains('255.255.255.255')).toBe(false);
+    expect(trusted.warnings).toHaveLength(1);
+    expect(trusted.warnings[0]).toMatch(/10\.0\.0\.0\//);
+  });
+
+  it('rejects a hex-looking prefix instead of silently truncating it', () => {
+    // Number('0x10') === 16 — a non-decimal spelling must not be accepted as a prefix.
+    const trusted = parseTrustedProxies('10.0.0.0/0x10');
+    expect(trusted.isEmpty).toBe(true);
+    expect(trusted.warnings).toHaveLength(1);
+  });
+
+  it('rejects a prefix outside the address family range', () => {
+    const trusted = parseTrustedProxies('10.0.0.0/33');
+    expect(trusted.isEmpty).toBe(true);
+    expect(trusted.warnings).toHaveLength(1);
+  });
+
+  it('accepts an explicit /0 as a deliberate trust-everything subnet', () => {
+    // /0 is a legitimate, deliberate choice — only the malformed spelling (a missing
+    // or non-digit prefix) is rejected, not the value zero itself.
+    const trusted = parseTrustedProxies('0.0.0.0/0');
+    expect(trusted.isEmpty).toBe(false);
+    expect(trusted.warnings).toHaveLength(0);
+    expect(trusted.contains('8.8.8.8')).toBe(true);
+  });
 });
 
 describe('resolveClientIp', () => {
@@ -118,5 +151,40 @@ describe('resolveClientIp', () => {
     expect(
       resolveClientIp({ peer: undefined, forwardedFor: undefined, realIp: undefined, trusted: NONE }),
     ).toBe('-');
+  });
+
+  it('falls back to the peer when X-Forwarded-For is unparsable', () => {
+    // Some proxies emit the literal "unknown". It must never be logged as if it were
+    // the client — that would corrupt the exact field CrowdSec parses bans from.
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: 'unknown',
+        realIp: undefined,
+        trusted: PROXY,
+      }),
+    ).toBe('10.0.0.5');
+  });
+
+  it('skips a malformed entry and keeps walking left for a valid one', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: '203.0.113.9, 1.2.3.4:5678',
+        realIp: undefined,
+        trusted: PROXY,
+      }),
+    ).toBe('203.0.113.9');
+  });
+
+  it('falls back to the peer when X-Real-IP is unparsable', () => {
+    expect(
+      resolveClientIp({
+        peer: '10.0.0.5',
+        forwardedFor: undefined,
+        realIp: 'unknown',
+        trusted: PROXY,
+      }),
+    ).toBe('10.0.0.5');
   });
 });

--- a/tests/describe-tool.test.ts
+++ b/tests/describe-tool.test.ts
@@ -8,6 +8,24 @@
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { describeTool } from '../src/openapi/describe-tool.js';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
+
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
 
 describe('describeTool', () => {
   afterEach(() => {
@@ -31,19 +49,21 @@ describe('describeTool', () => {
   });
 
   it('falls back to a non-empty default and logs an advisory for a tool with no registry entry', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const description = describeTool('get_prometheus_metrics');
     expect(description.length).toBeGreaterThan(0);
-    expect(errorSpy).toHaveBeenCalled();
-    const logged = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(written.length).toBeGreaterThan(0);
+    const logged = written.join('\n');
     expect(logged).toContain('get_prometheus_metrics');
+    restore();
   });
 
   it('falls back to a non-empty default and logs an advisory for a name that is not a known tool', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const description = describeTool('totally_made_up_tool_name');
     expect(description.length).toBeGreaterThan(0);
-    expect(errorSpy).toHaveBeenCalled();
+    expect(written.length).toBeGreaterThan(0);
+    restore();
   });
 
   describe('description overrides (P3 Final Fix Wave, Finding 1, Refs #57)', () => {

--- a/tests/founding-session-correlation.test.ts
+++ b/tests/founding-session-correlation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The request that CREATES a session is the one request that cannot carry an
+ * mcp-session-id header — the id does not exist yet when the header would have been
+ * sent. Its access line therefore read `sid=-`, and it is the single most interesting
+ * line in the session's life: everything the client does afterwards is joinable by
+ * sid, except the handshake that started it.
+ *
+ * The id is known by the time the line is written (the access line goes out on
+ * 'finish', long after onsessioninitialized has run), so the fix is to backfill the
+ * request context there. This exercises the real Express app end to end with a real
+ * MCP initialize, the same pattern as tests/access-log-ordering-e2e.test.ts.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import http from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+import { createServer } from '../src/server.js';
+import type { ServerConfig } from '../src/server.js';
+
+const TEST_PORT = 48301;
+
+const DUMMY_DOCKHAND: ServerConfig['dockhand'] = {
+  url: 'http://dockhand.invalid',
+  username: 'dummy',
+  password: 'dummy',
+};
+
+const INITIALIZE = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 'access-log-correlation-test', version: '1.0.0' },
+  },
+});
+
+let httpServer: HttpServer | undefined;
+
+function initializeSession(port: number): Promise<{ statusCode: number; sessionId?: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: '/mcp',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // Both types: the transport refuses a POST that cannot accept an SSE reply.
+          Accept: 'application/json, text/event-stream',
+          Connection: 'close',
+        },
+        agent: false,
+      },
+      (res) => {
+        res.on('data', () => {});
+        res.on('end', () =>
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            sessionId: res.headers['mcp-session-id'] as string | undefined,
+          }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.end(INITIALIZE);
+  });
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (httpServer) {
+    await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+    httpServer = undefined;
+  }
+});
+
+describe('founding request correlation', () => {
+  it('writes the created session id on the access line of the request that created it', async () => {
+    const written: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+
+    httpServer = await createServer({ dockhand: DUMMY_DOCKHAND, port: TEST_PORT, host: '127.0.0.1' });
+    const res = await initializeSession(TEST_PORT);
+    spy.mockRestore();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.sessionId).toBeTruthy();
+
+    const accessLine = written.find((line) => line.includes('"POST /mcp HTTP/1.1" 200'));
+    expect(accessLine).toBeDefined();
+    // Against the id the server actually handed back, not merely "something that is
+    // not a dash": a wrong id would be worse than none.
+    expect(accessLine).toContain(`sid=${res.sessionId}`);
+  });
+});

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -3,9 +3,7 @@
  * other's identifiers. That is the whole reason for AsyncLocalStorage over a module
  * variable, so it is the thing worth testing.
  */
-import { describe, it, expect, vi } from 'vitest';
-import pino from 'pino';
-import { Transform } from 'stream';
+import { describe, it, expect } from 'vitest';
 import {
   runWithLogContext,
   extendLogContext,
@@ -72,7 +70,7 @@ describe('log context', () => {
     });
 
     it('binds context fields to the child logger', () => {
-      let boundLogger: any;
+      let boundLogger;
 
       runWithLogContext({ req: 'r1', sid: 's1', call: 'c1' }, () => {
         boundLogger = log();
@@ -94,7 +92,7 @@ describe('log context', () => {
     });
 
     it('binds extended context fields to the child logger', () => {
-      let boundLogger: any;
+      let boundLogger;
 
       runWithLogContext({ req: 'r1' }, () => {
         extendLogContext({ call: 'c1', tool: 'list_stacks' });

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -53,6 +53,22 @@ describe('log context', () => {
     expect(seen.sort()).toEqual(['r1/c1', 'r2/c2']);
   });
 
+  // The access-log middleware holds the object it opened the context with and reads it
+  // back when the response finishes, because that is the only deterministic way for it
+  // to learn a session id that did not exist when the request arrived. That works only
+  // if the store IS the given object rather than a copy of it — with a copy the
+  // backfill lands somewhere the caller can never see, and the access line silently
+  // keeps saying sid=-.
+  it('makes a backfill visible to whoever opened the context', () => {
+    const context = { req: 'r1' };
+
+    runWithLogContext(context, () => {
+      extendLogContext({ sid: 's-created-later' });
+    });
+
+    expect(context).toEqual({ req: 'r1', sid: 's-created-later' });
+  });
+
   it('does not leak a nested extension back into the outer context', () => {
     runWithLogContext({ req: 'outer' }, () => {
       runWithLogContext({ req: 'inner' }, () => {

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -3,13 +3,16 @@
  * other's identifiers. That is the whole reason for AsyncLocalStorage over a module
  * variable, so it is the thing worth testing.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import pino from 'pino';
+import { Transform } from 'stream';
 import {
   runWithLogContext,
   extendLogContext,
   currentLogContext,
   log,
 } from '../src/utils/log-context.js';
+import { logger } from '../src/utils/logger.js';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -63,49 +66,46 @@ describe('log context', () => {
 
   describe('log()', () => {
     it('returns the base logger outside any context', () => {
-      const logger = log();
-      expect(logger).toBeDefined();
-      // Outside context, currentLogContext() is empty
+      const returnedLogger = log();
+      expect(returnedLogger).toBe(logger);
       expect(currentLogContext()).toEqual({});
-      // Verify logger.info is callable
-      expect(logger.info).toBeDefined();
-      expect(typeof logger.info).toBe('function');
     });
 
-    it('returns a context-bound child logger inside runWithLogContext', () => {
-      const outsideLogger = log();
-      let insideLogger: any;
+    it('binds context fields to the child logger', () => {
+      let boundLogger: any;
 
-      runWithLogContext({ req: 'r1', call: 'c1' }, () => {
-        insideLogger = log();
-        // Inside context, should be a different logger instance (child)
-        expect(insideLogger).not.toBe(outsideLogger);
+      runWithLogContext({ req: 'r1', sid: 's1', call: 'c1' }, () => {
+        boundLogger = log();
       });
 
-      // Both loggers should be defined and different instances
-      expect(outsideLogger).toBeDefined();
-      expect(insideLogger).toBeDefined();
-      expect(outsideLogger).not.toBe(insideLogger);
+      // Outside context, log() returns the base logger
+      const unboundLogger = log();
+      expect(unboundLogger).toBe(logger);
+
+      // Inside context, log() returns a child logger with bindings
+      expect(boundLogger).not.toBe(logger);
+
+      // Pino stores bindings in the child logger
+      const bindings = boundLogger.bindings?.();
+      expect(bindings).toBeDefined();
+      expect(bindings?.req).toBe('r1');
+      expect(bindings?.sid).toBe('s1');
+      expect(bindings?.call).toBe('c1');
     });
 
-    it('child logger emits context bindings', () => {
-      const outsideLogger = log();
-      let insideLogger1: any;
-      let insideLogger2: any;
+    it('binds extended context fields to the child logger', () => {
+      let boundLogger: any;
 
-      runWithLogContext({ req: 'r1', call: 'c1' }, () => {
-        insideLogger1 = log();
-        insideLogger2 = log();
-        // Both inside calls should create child loggers (different instances each time)
-        expect(insideLogger1).not.toBe(outsideLogger);
-        expect(insideLogger2).not.toBe(outsideLogger);
+      runWithLogContext({ req: 'r1' }, () => {
+        extendLogContext({ call: 'c1', tool: 'list_stacks' });
+        boundLogger = log();
       });
 
-      // Verify that inside context loggers are different from outside
-      expect(insideLogger1).toBeDefined();
-      expect(insideLogger2).toBeDefined();
-      expect(insideLogger1).not.toBe(outsideLogger);
-      expect(insideLogger2).not.toBe(outsideLogger);
+      // Pino stores bindings in the child logger
+      const bindings = boundLogger.bindings?.();
+      expect(bindings?.req).toBe('r1');
+      expect(bindings?.call).toBe('c1');
+      expect(bindings?.tool).toBe('list_stacks');
     });
   });
 

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Correlation only works if two calls in flight at the same time cannot see each
+ * other's identifiers. That is the whole reason for AsyncLocalStorage over a module
+ * variable, so it is the thing worth testing.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  runWithLogContext,
+  extendLogContext,
+  currentLogContext,
+} from '../src/utils/log-context.js';
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('log context', () => {
+  it('is empty outside any request', () => {
+    expect(currentLogContext()).toEqual({});
+  });
+
+  it('exposes what was put in', () => {
+    runWithLogContext({ req: 'r1', sid: 's1' }, () => {
+      expect(currentLogContext()).toEqual({ req: 'r1', sid: 's1' });
+    });
+  });
+
+  it('extends without losing what was already there', () => {
+    runWithLogContext({ req: 'r1' }, () => {
+      extendLogContext({ call: 'c1', tool: 'list_stacks' });
+      expect(currentLogContext()).toEqual({ req: 'r1', call: 'c1', tool: 'list_stacks' });
+    });
+  });
+
+  it('keeps two concurrent calls apart across await points', async () => {
+    const seen: string[] = [];
+
+    const one = runWithLogContext({ req: 'r1' }, async () => {
+      await tick();
+      extendLogContext({ call: 'c1' });
+      await tick();
+      seen.push(`${currentLogContext().req}/${currentLogContext().call}`);
+    });
+
+    const two = runWithLogContext({ req: 'r2' }, async () => {
+      extendLogContext({ call: 'c2' });
+      await tick();
+      seen.push(`${currentLogContext().req}/${currentLogContext().call}`);
+    });
+
+    await Promise.all([one, two]);
+
+    expect(seen.sort()).toEqual(['r1/c1', 'r2/c2']);
+  });
+
+  it('does not leak a nested extension back into the outer context', () => {
+    runWithLogContext({ req: 'outer' }, () => {
+      runWithLogContext({ req: 'inner' }, () => {
+        extendLogContext({ call: 'nested' });
+      });
+      expect(currentLogContext()).toEqual({ req: 'outer' });
+    });
+  });
+});

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -3,11 +3,12 @@
  * other's identifiers. That is the whole reason for AsyncLocalStorage over a module
  * variable, so it is the thing worth testing.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   runWithLogContext,
   extendLogContext,
   currentLogContext,
+  log,
 } from '../src/utils/log-context.js';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -57,6 +58,67 @@ describe('log context', () => {
         extendLogContext({ call: 'nested' });
       });
       expect(currentLogContext()).toEqual({ req: 'outer' });
+    });
+  });
+
+  describe('log()', () => {
+    it('returns the base logger outside any context', () => {
+      const logger = log();
+      expect(logger).toBeDefined();
+      // Outside context, currentLogContext() is empty
+      expect(currentLogContext()).toEqual({});
+      // Verify logger.info is callable
+      expect(logger.info).toBeDefined();
+      expect(typeof logger.info).toBe('function');
+    });
+
+    it('returns a context-bound child logger inside runWithLogContext', () => {
+      const outsideLogger = log();
+      let insideLogger: any;
+
+      runWithLogContext({ req: 'r1', call: 'c1' }, () => {
+        insideLogger = log();
+        // Inside context, should be a different logger instance (child)
+        expect(insideLogger).not.toBe(outsideLogger);
+      });
+
+      // Both loggers should be defined and different instances
+      expect(outsideLogger).toBeDefined();
+      expect(insideLogger).toBeDefined();
+      expect(outsideLogger).not.toBe(insideLogger);
+    });
+
+    it('child logger emits context bindings', () => {
+      const outsideLogger = log();
+      let insideLogger1: any;
+      let insideLogger2: any;
+
+      runWithLogContext({ req: 'r1', call: 'c1' }, () => {
+        insideLogger1 = log();
+        insideLogger2 = log();
+        // Both inside calls should create child loggers (different instances each time)
+        expect(insideLogger1).not.toBe(outsideLogger);
+        expect(insideLogger2).not.toBe(outsideLogger);
+      });
+
+      // Verify that inside context loggers are different from outside
+      expect(insideLogger1).toBeDefined();
+      expect(insideLogger2).toBeDefined();
+      expect(insideLogger1).not.toBe(outsideLogger);
+      expect(insideLogger2).not.toBe(outsideLogger);
+    });
+  });
+
+  describe('extendLogContext()', () => {
+    it('does not throw when called outside any context', () => {
+      expect(() => {
+        extendLogContext({ call: 'c1' });
+      }).not.toThrow();
+    });
+
+    it('leaves currentLogContext empty when called outside any context', () => {
+      extendLogContext({ call: 'c1', tool: 'list_stacks' });
+      expect(currentLogContext()).toEqual({});
     });
   });
 });

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The logger is the one place LOG_LEVEL becomes real. Issue #116 shipped a README
+ * row for it while nothing in the code ever read the variable.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveLogLevel } from '../src/utils/logger.js';
+
+describe('resolveLogLevel', () => {
+  it('accepts the four supported levels', () => {
+    for (const level of ['error', 'warn', 'info', 'debug'] as const) {
+      expect(resolveLogLevel(level)).toEqual({ level });
+    }
+  });
+
+  it('defaults to info when unset', () => {
+    expect(resolveLogLevel(undefined)).toEqual({ level: 'info' });
+  });
+
+  it('is case-insensitive and ignores surrounding whitespace', () => {
+    expect(resolveLogLevel('  DEBUG ')).toEqual({ level: 'debug' });
+  });
+
+  it('falls back to info with a warning instead of exiting', () => {
+    // A typo in a compose file must never stop the server from starting.
+    const result = resolveLogLevel('lound');
+    expect(result.level).toBe('info');
+    expect(result.warning).toMatch(/lound/);
+    expect(result.warning).toMatch(/error, warn, info, debug/);
+  });
+
+  it('rejects silent', () => {
+    // Deliberate: the #116 fix depends on the login failure line ALWAYS being
+    // emitted. A silent level would make that guarantee defeasible again.
+    const result = resolveLogLevel('silent');
+    expect(result.level).toBe('info');
+    expect(result.warning).toMatch(/silent/);
+  });
+});

--- a/tests/login-failure-visibility.test.ts
+++ b/tests/login-failure-visibility.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Issue #116: a failing Dockhand login produced no output at all, so an operator saw
+ * a server that started fine and tools that failed for no stated reason.
+ *
+ * The fix logged it unconditionally, with a comment saying there was no LOG_LEVEL to
+ * gate it on. Now there is one — so the guarantee needs a test rather than a comment.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object in Node/vitest and vi.spyOn cannot redefine a property on it. The default
+// import resolves to Node's actual (mutable) CJS module.exports for 'fs'.
+import fs from 'node:fs';
+
+describe('login failure visibility at the most restrictive level', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env['LOG_LEVEL'] = 'error';
+  });
+
+  afterEach(() => {
+    delete process.env['LOG_LEVEL'];
+    vi.restoreAllMocks();
+  });
+
+  it('writes the login failure even when only errors are enabled', async () => {
+    const written: string[] = [];
+    // The logger (src/utils/logger.ts) writes via pino.destination({ fd: 2, sync: true })
+    // — SonicBoom, which calls fs.writeSync(fd, ...) directly rather than going through
+    // process.stderr.write. Mocking process.stderr.write here would leave `written` empty
+    // no matter what the logger does, so the interception has to sit at the fd-write layer
+    // pino actually uses.
+    vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+      if (fd === 2) {
+        const text = String(buffer);
+        written.push(text);
+        return Buffer.byteLength(text);
+      }
+      return 0;
+    });
+
+    const { SessionManager } = await import('../src/auth/session.js');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Invalid credentials', { status: 401, statusText: 'Unauthorized' }),
+    );
+
+    const manager = new SessionManager({
+      url: 'https://dockhand.example',
+      username: 'svc',
+      password: 'wrong',
+    });
+
+    await expect(manager.getCookie()).rejects.toThrow();
+
+    const line = written.join('');
+    expect(line).toMatch(/"level":"error"/);
+    expect(line).toMatch(/svc/);
+    expect(line).toMatch(/401/);
+    // The password must never be part of the diagnosis.
+    expect(line).not.toMatch(/wrong/);
+  });
+});

--- a/tests/login-failure-visibility.test.ts
+++ b/tests/login-failure-visibility.test.ts
@@ -11,6 +11,26 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // import resolves to Node's actual (mutable) CJS module.exports for 'fs'.
 import fs from 'node:fs';
 
+function captureStderr(): string[] {
+  const written: string[] = [];
+  // The logger (src/utils/logger.ts) writes via pino.destination({ fd: 2 }) — SonicBoom,
+  // which calls fs.writeSync(fd, ...) directly rather than going through
+  // process.stderr.write. Mocking process.stderr.write here would leave `written` empty
+  // no matter what the logger does, so the interception has to sit at the fd-write layer
+  // pino actually uses. The byte count in the return value matters: SonicBoom treats it
+  // as the number of bytes released and retries whatever it believes is still unwritten,
+  // so a hardcoded 0 spins forever.
+  vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return written;
+}
+
 describe('login failure visibility at the most restrictive level', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -57,5 +77,49 @@ describe('login failure visibility at the most restrictive level', () => {
     expect(line).toMatch(/401/);
     // The password must never be part of the diagnosis.
     expect(line).not.toMatch(/wrong/);
+  });
+
+  // Visible is not the same as usable. This line is the one Issue #116 exists for, and
+  // it was written through the bare logger while a request context existed — so an
+  // operator got 'tool failed' with req/sid/call/tool and 'login failed' with none of
+  // them, and had to join the two by timestamp. At LOG_LEVEL=error, where those are the
+  // only two lines that survive, that is the whole diagnosis.
+  it('carries the request correlation ids, so the failure can be joined to the call', async () => {
+    const written = captureStderr();
+
+    const { SessionManager } = await import('../src/auth/session.js');
+    const { runWithLogContext } = await import('../src/utils/log-context.js');
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Invalid credentials', { status: 401, statusText: 'Unauthorized' }),
+    );
+
+    const manager = new SessionManager({
+      url: 'https://dockhand.example',
+      username: 'svc',
+      password: 'wrong',
+    });
+
+    await runWithLogContext(
+      { req: 'req-1', sid: 'sid-1', call: 'call-1', tool: 'list_stacks' },
+      async () => {
+        await expect(manager.getCookie()).rejects.toThrow();
+      },
+    );
+
+    const entry = JSON.parse(
+      written
+        .join('')
+        .trim()
+        .split('\n')
+        .find((l) => l.includes('login failed'))!,
+    ) as Record<string, unknown>;
+
+    expect(entry).toMatchObject({
+      level: 'error',
+      req: 'req-1',
+      sid: 'sid-1',
+      call: 'call-1',
+      tool: 'list_stacks',
+    });
   });
 });

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -1,0 +1,59 @@
+/**
+ * console.error was the only output channel this server had — 30-odd call sites, all
+ * at the same effective level. Once they are gone, the way they come back is one new
+ * line in one new file, which no diff-scoped review would flag as a problem.
+ *
+ * So the rule gets a test rather than a convention.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const SRC = new URL('../src', import.meta.url).pathname;
+
+/**
+ * logger.ts may not use itself before it exists, so its own bootstrap is the one
+ * place a direct console call is legitimate. Keep this list at one entry.
+ */
+const ALLOWED = new Set(['utils/logger.ts']);
+
+function tsFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return tsFiles(full);
+    return full.endsWith('.ts') ? [full] : [];
+  });
+}
+
+describe('logging discipline', () => {
+  const files = tsFiles(SRC);
+
+  it('finds the source tree (guards against the scan matching nothing)', () => {
+    expect(files.length).toBeGreaterThan(30);
+  });
+
+  it('has no console.* call outside the logger bootstrap', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC, file);
+      if (ALLOWED.has(rel)) continue;
+
+      readFileSync(file, 'utf-8')
+        .split('\n')
+        .forEach((line, index) => {
+          // Skip comment lines: several files legitimately DISCUSS console.error in
+          // their doc comments (src/utils/redact.ts explains which surfaces an error
+          // message reaches). Matching those would force prose changes to satisfy a
+          // code rule.
+          const trimmed = line.trim();
+          if (trimmed.startsWith('*') || trimmed.startsWith('//')) return;
+          if (/\bconsole\.\w+\s*\(/.test(line)) {
+            offenders.push(`${rel}:${index + 1}`);
+          }
+        });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -39,11 +39,19 @@ const RULES: Rule[] = [
     // Nothing else enforced it. A `log().debug({ args: JSON.stringify(args) })` added
     // to any tool file ships every tool argument to `docker logs` at LOG_LEVEL=debug,
     // and the whole suite stays green — the same silent-regression shape as the
-    // console rule above, one level deeper. So the allowlist is the call site itself:
-    // a second one is a decision, not an accident, and has to be made here first.
-    what: '.debug() call outside the Dockhand client',
+    // console rule above, one level deeper. So the allowlist is the call sites
+    // themselves: a further one is a decision, not an accident, and has to be made
+    // here first.
+    //
+    // auth/session.ts is the second and was added that way: the login is the one
+    // request that cannot go through the client (the client is built on it), so it was
+    // the one request with no debug line — see the comment on loggedLoginFetch. It
+    // qualifies on the same terms as the first: every field it logs is a constant, a
+    // status code, a duration or an exception name. Nothing derived from a URL, a
+    // body or a credential is passed to the logger there.
+    what: '.debug() call outside the two audited call sites',
     pattern: /\.debug\s*\(/,
-    allowed: new Set(['client/dockhand-client.ts']),
+    allowed: new Set(['client/dockhand-client.ts', 'auth/session.ts']),
   },
   {
     // With console.* gone, this is the realistic way a direct write comes back: it is

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -3,7 +3,9 @@
  * at the same effective level. Once they are gone, the way they come back is one new
  * line in one new file, which no diff-scoped review would flag as a problem.
  *
- * So the rule gets a test rather than a convention.
+ * So the rules get a test rather than a convention. Each one is the same shape: a
+ * pattern that must not appear in src/ outside a named allowlist, checked line by
+ * line with comment lines skipped.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
@@ -11,11 +13,49 @@ import { join, relative } from 'node:path';
 
 const SRC = new URL('../src', import.meta.url).pathname;
 
-/**
- * logger.ts may not use itself before it exists, so its own bootstrap is the one
- * place a direct console call is legitimate. Keep this list at one entry.
- */
-const ALLOWED = new Set(['utils/logger.ts']);
+interface Rule {
+  /** Completes "has no ..." in the test name. */
+  what: string;
+  pattern: RegExp;
+  /** Paths relative to src/. Keep each list as short as its comment claims. */
+  allowed: Set<string>;
+}
+
+const RULES: Rule[] = [
+  {
+    // logger.ts may not use itself before it exists, so its own bootstrap is the one
+    // place a direct console call is legitimate. Keep this list at one entry.
+    what: 'console.* call outside the logger bootstrap',
+    pattern: /\bconsole\.\w+\s*\(/,
+    allowed: new Set(['utils/logger.ts']),
+  },
+  {
+    // The debug level is the one that carries detail, and this server's guarantee is
+    // that it still never carries a VALUE: no stack name, no container id, no secret
+    // from trigger_git_webhook's query string. That guarantee is structural — exactly
+    // one call site exists, in the single place this process talks to the network, and
+    // it logs the endpoint template from the call context rather than the URL.
+    //
+    // Nothing else enforced it. A `log().debug({ args: JSON.stringify(args) })` added
+    // to any tool file ships every tool argument to `docker logs` at LOG_LEVEL=debug,
+    // and the whole suite stays green — the same silent-regression shape as the
+    // console rule above, one level deeper. So the allowlist is the call site itself:
+    // a second one is a decision, not an accident, and has to be made here first.
+    what: '.debug() call outside the Dockhand client',
+    pattern: /\.debug\s*\(/,
+    allowed: new Set(['client/dockhand-client.ts']),
+  },
+  {
+    // With console.* gone, this is the realistic way a direct write comes back: it is
+    // what console.log is underneath, so it bypasses the logger just as completely
+    // while looking deliberate enough to survive a review. The access-log middleware
+    // is the one legitimate writer — stdout is its channel by design (see
+    // src/utils/logger.ts on why the two streams are split).
+    what: 'direct process.stdout/stderr write outside the access log',
+    pattern: /process\.(stdout|stderr)\.write\s*\(/,
+    allowed: new Set(['utils/access-log-middleware.ts']),
+  },
+];
 
 function tsFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -25,6 +65,31 @@ function tsFiles(dir: string): string[] {
   });
 }
 
+function offendersFor(files: string[], rule: Rule): string[] {
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const rel = relative(SRC, file);
+    if (rule.allowed.has(rel)) continue;
+
+    readFileSync(file, 'utf-8')
+      .split('\n')
+      .forEach((line, index) => {
+        // Skip comment lines: several files legitimately DISCUSS console.error in
+        // their doc comments (src/utils/redact.ts explains which surfaces an error
+        // message reaches). Matching those would force prose changes to satisfy a
+        // code rule.
+        const trimmed = line.trim();
+        if (trimmed.startsWith('*') || trimmed.startsWith('//')) return;
+        if (rule.pattern.test(line)) {
+          offenders.push(`${rel}:${index + 1}`);
+        }
+      });
+  }
+
+  return offenders;
+}
+
 describe('logging discipline', () => {
   const files = tsFiles(SRC);
 
@@ -32,28 +97,9 @@ describe('logging discipline', () => {
     expect(files.length).toBeGreaterThan(30);
   });
 
-  it('has no console.* call outside the logger bootstrap', () => {
-    const offenders: string[] = [];
-
-    for (const file of files) {
-      const rel = relative(SRC, file);
-      if (ALLOWED.has(rel)) continue;
-
-      readFileSync(file, 'utf-8')
-        .split('\n')
-        .forEach((line, index) => {
-          // Skip comment lines: several files legitimately DISCUSS console.error in
-          // their doc comments (src/utils/redact.ts explains which surfaces an error
-          // message reaches). Matching those would force prose changes to satisfy a
-          // code rule.
-          const trimmed = line.trim();
-          if (trimmed.startsWith('*') || trimmed.startsWith('//')) return;
-          if (/\bconsole\.\w+\s*\(/.test(line)) {
-            offenders.push(`${rel}:${index + 1}`);
-          }
-        });
-    }
-
-    expect(offenders).toEqual([]);
-  });
+  for (const rule of RULES) {
+    it(`has no ${rule.what}`, () => {
+      expect(offendersFor(files, rule)).toEqual([]);
+    });
+  }
 });

--- a/tests/no-console.test.ts
+++ b/tests/no-console.test.ts
@@ -49,9 +49,16 @@ const RULES: Rule[] = [
     // qualifies on the same terms as the first: every field it logs is a constant, a
     // status code, a duration or an exception name. Nothing derived from a URL, a
     // body or a credential is passed to the logger there.
-    what: '.debug() call outside the two audited call sites',
+    //
+    // tools/meta.ts is the third, on the same terms: self_check and validate_config
+    // probe /api/health and /api/auth with a bare fetch that cannot go through the
+    // client either, so those diagnostic exchanges had no debug line. loggedProbe()
+    // there logs only a constant route, method, status, duration and exception name —
+    // never the URL, the login body or the credentials (asserted in
+    // tests/tools/meta.probe-debug-logging.test.ts).
+    what: '.debug() call outside the three audited call sites',
     pattern: /\.debug\s*\(/,
-    allowed: new Set(['client/dockhand-client.ts', 'auth/session.ts']),
+    allowed: new Set(['client/dockhand-client.ts', 'auth/session.ts', 'tools/meta.ts']),
   },
   {
     // With console.* gone, this is the realistic way a direct write comes back: it is

--- a/tests/session-lifecycle.test.ts
+++ b/tests/session-lifecycle.test.ts
@@ -7,6 +7,24 @@ import {
   selectOldestIdleSession,
   type ManagedSessionEntry,
 } from '../src/session-lifecycle.js';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
+
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
 
 describe('session lifecycle configuration', () => {
   it('keeps the existing timeout defaults when no overrides are set', () => {
@@ -117,18 +135,20 @@ describe('removeSessionEntry (bug: DELETE-triggered cleanup never running)', () 
     // returns undefined and the whole cleanup silently no-ops.
     sessions.delete('deleted-by-client');
 
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { written, restore } = captureLoggerOutput();
     await removeSessionEntry(sessions, 'deleted-by-client', entry, 'client delete');
 
-    // Assert before mockRestore(): restoring also clears the recorded call
-    // history (mockRestore implies mockReset/mockClear), so checking after
-    // restoring would always see zero calls regardless of behaviour.
+    // Assert before restore(): restoring also detaches the mock, so checking
+    // after restoring would always see the same recorded calls regardless of
+    // behaviour going forward, but reading `written` first keeps the intent
+    // explicit and matches the original assert-then-restore ordering.
     expect(closeServer).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[session] Removed session deleted-by-client (client delete'),
-    );
+    const line = written.join('');
+    expect(line).toMatch(/"sid":"deleted-by-client"/);
+    expect(line).toMatch(/"reason":"client delete"/);
+    expect(line).toMatch(/"msg":"session removed"/);
 
-    errorSpy.mockRestore();
+    restore();
   });
 
   it('still removes/closes correctly on the normal path where the entry is still present in the map', async () => {
@@ -150,9 +170,9 @@ describe('removeSessionEntry (bug: DELETE-triggered cleanup never running)', () 
     const entry = fakeEntry({ server: { close: closeServer }, transport: { close: closeTransport } });
     sessions.set('racing-close', entry);
 
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const { restore } = captureLoggerOutput();
     await expect(removeSessionEntry(sessions, 'racing-close', entry, 'client delete')).resolves.toBeUndefined();
-    errorSpy.mockRestore();
+    restore();
 
     expect(closeTransport).toHaveBeenCalledTimes(1);
   });

--- a/tests/session-login-debug-logging.test.ts
+++ b/tests/session-login-debug-logging.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The login is the one Dockhand request that does not go through
+ * DockhandClient.loggedFetch, so it was the one request that produced no
+ * component:"client" line. At LOG_LEVEL=debug against an unreachable Dockhand an
+ * operator saw the tool failure and nothing else — no method, no status, no duration —
+ * for exactly the request Issue #116 is about.
+ *
+ * The interesting path is the one where fetch REJECTS: an unreachable host never
+ * produces a response, so a line written only on the response side would still leave
+ * that case silent.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+
+describe('login request logging', () => {
+  let written: string[];
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env['LOG_LEVEL'] = 'debug';
+    written = [];
+    // pino.destination({ fd: 2 }) is SonicBoom: it calls fs.writeSync(fd, ...) and
+    // never touches process.stderr.write, so the spy has to sit at the fd layer. The
+    // byte count in the return value is load-bearing — SonicBoom retries whatever it
+    // believes is still unwritten, so a hardcoded 0 spins forever.
+    vi.spyOn(fs, 'writeSync').mockImplementation((_fd: unknown, chunk: unknown) => {
+      const text = String(chunk);
+      written.push(text);
+      return Buffer.byteLength(text);
+    });
+  });
+
+  afterEach(() => {
+    delete process.env['LOG_LEVEL'];
+    vi.restoreAllMocks();
+  });
+
+  function clientLines(): Record<string, unknown>[] {
+    return written
+      .join('')
+      .trim()
+      .split('\n')
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((entry) => entry.component === 'client');
+  }
+
+  async function login(fetchImpl: () => Promise<Response>) {
+    const { SessionManager } = await import('../src/auth/session.js');
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fetchImpl as never);
+    const manager = new SessionManager({
+      url: 'https://dockhand.example',
+      username: 'svc',
+      password: 'p@ssw0rd-do-not-log-me',
+    });
+    return manager.getCookie();
+  }
+
+  it('logs the login exchange the way every other Dockhand request is logged', async () => {
+    await login(async () =>
+      new Response('{}', {
+        status: 200,
+        headers: { 'set-cookie': 'dockhand_session=abc; Path=/' },
+      }),
+    );
+
+    const [line, ...rest] = clientLines();
+    expect(rest).toEqual([]);
+    expect(line).toMatchObject({
+      component: 'client',
+      method: 'POST',
+      route: '/api/auth',
+      status: 200,
+      msg: 'dockhand request',
+    });
+    expect(typeof line.ms).toBe('number');
+  });
+
+  it('logs an unreachable Dockhand, which is the case that produced nothing at all', async () => {
+    await expect(
+      login(() => Promise.reject(new TypeError('fetch failed'))),
+    ).rejects.toThrow();
+
+    const [line] = clientLines();
+    expect(line).toMatchObject({
+      component: 'client',
+      method: 'POST',
+      route: '/api/auth',
+      // Same shape as the client's own failure line: the exception NAME, which is
+      // bounded, never its free-text message.
+      err: { type: 'TypeError' },
+      msg: 'dockhand request failed',
+    });
+  });
+
+  it('never puts the url, the body or the credentials on the line', async () => {
+    await login(async () =>
+      new Response('{}', {
+        status: 200,
+        headers: { 'set-cookie': 'dockhand_session=abc; Path=/' },
+      }),
+    );
+
+    // Non-empty first: "contains no secret" is trivially true of a line that was never
+    // written, which would make this test green against the very version it exists to
+    // rule out.
+    expect(clientLines()).toHaveLength(1);
+
+    const line = JSON.stringify(clientLines());
+    expect(line).not.toContain('p@ssw0rd-do-not-log-me');
+    expect(line).not.toContain('svc');
+    expect(line).not.toContain('dockhand.example');
+    // The full path would be /api/auth/login; the logged route stops one segment short,
+    // the same truncation the client applies.
+    expect(line).not.toContain('/api/auth/login');
+  });
+});

--- a/tests/session-login.test.ts
+++ b/tests/session-login.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SessionManager } from '../src/auth/session.js';
 import type { DockhandConfig } from '../src/types/dockhand.js';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
 
 interface MockResponseInit {
   ok: boolean;
@@ -97,15 +102,25 @@ describe('SessionManager login', () => {
       }),
     );
     vi.stubGlobal('fetch', fetchMock);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const written: string[] = [];
+    const writeSyncSpy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+      if (fd === 2) {
+        const text = String(buffer);
+        written.push(text);
+        return Buffer.byteLength(text);
+      }
+      return 0;
+    });
 
     const manager = new SessionManager(config());
 
     await expect(manager.getCookie()).rejects.toThrow(/HTTP 307/);
     await expect(manager.getCookie()).rejects.toThrow(/trailing slash/);
 
-    const logged = errorSpy.mock.calls.map((call) => call.join(' ')).join('\n');
+    const logged = written.join('\n');
     expect(logged).toContain('/login?redirect=%2Fapi%2Fauth%2Flogin');
+
+    writeSyncSpy.mockRestore();
   });
 
   it('throws with the response body on a rejected login (HTTP 401)', async () => {

--- a/tests/spec-loader-missing-spec.test.ts
+++ b/tests/spec-loader-missing-spec.test.ts
@@ -11,11 +11,29 @@
  * spec-present assertions (or vice versa).
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return { ...actual, existsSync: () => false };
 });
+
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
 
 describe('spec-loader — spec file missing', () => {
   afterEach(() => {
@@ -23,17 +41,19 @@ describe('spec-loader — spec file missing', () => {
   });
 
   it('specInfoVersion() returns undefined gracefully instead of throwing', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const { specInfoVersion } = await import('../src/openapi/spec-loader.js');
 
     expect(specInfoVersion()).toBeUndefined();
-    expect(errorSpy).toHaveBeenCalled();
+    expect(written.length).toBeGreaterThan(0);
+    restore();
   });
 
   it('specOperation() also degrades to undefined for the same missing-spec case (consistency check)', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { restore } = captureLoggerOutput();
     const { specOperation } = await import('../src/openapi/spec-loader.js');
 
     expect(specOperation({ method: 'GET', path: '/api/environments' })).toBeUndefined();
+    restore();
   });
 });

--- a/tests/tool-correlation.test.ts
+++ b/tests/tool-correlation.test.ts
@@ -1,0 +1,106 @@
+/**
+ * registerTool is the single choke point every tool passes through, which makes it
+ * the only place the call identifier has to be created.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import { z } from 'zod';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe('tool call correlation', () => {
+  let written: string[];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env['LOG_LEVEL'] = 'debug';
+    written = [];
+    // NOT process.stderr.write: pino.destination({ fd: 2, sync: true }) is a SonicBoom
+    // stream that calls fs.writeSync(fd, ...) directly and never touches
+    // process.stderr.write, so a spy there captures nothing and the test reads as
+    // "the logger wrote nothing" no matter what it wrote. Verified against Task 1's
+    // logger while implementing Task 3. Spy on the DEFAULT import — a namespace
+    // import is a frozen ESM object and vi.spyOn cannot replace a property on it.
+    //
+    // The mock MUST report how many bytes it "wrote" via its return value: SonicBoom
+    // (node_modules/sonic-boom/index.js, releaseWritingBuf) treats fs.writeSync's return
+    // as the number of released bytes and keeps retrying whatever it thinks is still
+    // unwritten. A hardcoded `return 0` (as an earlier draft of this test had) tells
+    // SonicBoom that nothing was ever written, so it retries the same buffer forever —
+    // a busy loop that ran the suite out of heap during this task's RED check. Sibling
+    // tests (tests/tool-error-logging.test.ts, tests/login-failure-visibility.test.ts)
+    // already return Buffer.byteLength(text) for exactly this reason.
+    vi.spyOn(fs, 'writeSync').mockImplementation((_fd: unknown, chunk: unknown) => {
+      const text = String(chunk);
+      written.push(text);
+      return Buffer.byteLength(text);
+    });
+  });
+
+  afterEach(() => {
+    delete process.env['LOG_LEVEL'];
+    vi.restoreAllMocks();
+  });
+
+  async function invoke(name: string, callback: () => Promise<unknown>) {
+    const { registerTool } = await import('../src/utils/tool-helper.js');
+    let handler!: (args: unknown) => Promise<unknown>;
+    const server = { tool: (_n: string, _d: string, _s: unknown, cb: never) => { handler = cb; } };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTool(server as any, name, { id: z.number().optional() }, callback as never);
+    return handler({});
+  }
+
+  function lines() {
+    return written.join('').trim().split('\n').map((l) => JSON.parse(l));
+  }
+
+  it('emits a start and a success line carrying the same call id', async () => {
+    await invoke('list_stacks', async () => ({ content: [] }) as never);
+
+    const [start, done] = lines();
+    expect(start.tool).toBe('list_stacks');
+    expect(start.call).toMatch(UUID);
+    expect(done.call).toBe(start.call);
+    expect(done.msg).toBe('ok');
+    expect(typeof done.ms).toBe('number');
+  });
+
+  it('puts the endpoint template in the context, never a concrete path', async () => {
+    await invoke('get_stack_env_raw', async () => ({ content: [] }) as never);
+
+    const [start] = lines();
+    expect(start.route).toBe('/api/stacks/{name}/env/raw');
+  });
+
+  it('logs a failure at error level with the same call id', async () => {
+    await invoke('list_stacks', async () => {
+      throw new Error('Dockhand API error: GET https://d.example/api/stacks returned 500');
+    });
+
+    const [, failure] = lines();
+    expect(failure.level).toBe('error');
+    expect(failure.call).toMatch(UUID);
+    expect(failure.tool).toBe('list_stacks');
+  });
+
+  it('gives two concurrent invocations different call ids', async () => {
+    const { registerTool } = await import('../src/utils/tool-helper.js');
+    const handlers = new Map<string, (args: unknown) => Promise<unknown>>();
+    const server = { tool: (n: string, _d: string, _s: unknown, cb: never) => handlers.set(n, cb) };
+
+    const slow = async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      return { content: [] } as never;
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTool(server as any, 'list_stacks', {}, slow as never);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTool(server as any, 'list_containers', {}, slow as never);
+
+    await Promise.all([handlers.get('list_stacks')!({}), handlers.get('list_containers')!({})]);
+
+    const calls = new Set(lines().map((l) => l.call));
+    expect(calls.size).toBe(2);
+  });
+});

--- a/tests/tool-error-logging.test.ts
+++ b/tests/tool-error-logging.test.ts
@@ -68,10 +68,13 @@ describe('registerTool error logging', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Dockhand login failed');
 
-    expect(written).toHaveLength(1);
-    const logged = written[0];
-    expect(logged).toContain('health_check');
-    expect(logged).toContain('Dockhand login failed');
+    // Since Task 7 (call correlation, tests/tool-correlation.test.ts) registerTool also
+    // logs a "start" line before the callback runs, so a failure now produces two lines,
+    // not one. The error line is the one that carries the diagnosis.
+    expect(written).toHaveLength(2);
+    const [, errorLine] = written;
+    expect(errorLine).toContain('health_check');
+    expect(errorLine).toContain('Dockhand login failed');
     restore();
   });
 
@@ -88,13 +91,13 @@ describe('registerTool error logging', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Unknown error');
-    const logged = written[0];
-    expect(logged).toContain('get_system_info');
-    expect(logged).toContain('Unknown error');
+    const [, errorLine] = written;
+    expect(errorLine).toContain('get_system_info');
+    expect(errorLine).toContain('Unknown error');
     restore();
   });
 
-  it('does not log anything when the callback succeeds (happy path)', async () => {
+  it('logs only a start and an ok line when the callback succeeds (happy path)', async () => {
     const { written, restore } = captureLoggerOutput();
     const server = fakeServer();
 
@@ -105,7 +108,11 @@ describe('registerTool error logging', () => {
     const result = await server.tools.get('get_host_info')!.handler({ id: 42 });
 
     expect(result.isError).toBeUndefined();
-    expect(written).toHaveLength(0);
+    // Task 7 added an unconditional "start"/"ok" pair around every call (see
+    // tests/tool-correlation.test.ts) — a success no longer logs nothing, but it must
+    // never log at error level.
+    expect(written).toHaveLength(2);
+    expect(written.some((line) => line.includes('"level":"error"'))).toBe(false);
     restore();
   });
 
@@ -121,7 +128,8 @@ describe('registerTool error logging', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('ECONNREFUSED');
-    expect(written[0]).toContain('ECONNREFUSED');
+    const [, errorLine] = written;
+    expect(errorLine).toContain('ECONNREFUSED');
     restore();
   });
 });

--- a/tests/tool-error-logging.test.ts
+++ b/tests/tool-error-logging.test.ts
@@ -78,6 +78,32 @@ describe('registerTool error logging', () => {
     restore();
   });
 
+  // Asserting on the parsed line rather than on the object handed to the logger: the
+  // two were not the same. `err: { type: 'ToolError', message }` reached the log as
+  // "err":{"type":"Object","message":...,"stack":""} — pino's default serializer for
+  // the `err` key treats anything with a `message` as error-like and overwrites `type`
+  // with the constructor name. Every tool-failure line in production said "Object",
+  // and no test noticed, because none of them read a whole emitted line.
+  it('emits the error fields it was given, unmangled by the error serializer', async () => {
+    const { written, restore } = captureLoggerOutput();
+    const server = fakeServer();
+
+    registerTool(server as never, 'list_stacks', {}, async () => {
+      throw new Error('Dockhand login failed (HTTP 401)');
+    });
+
+    await server.tools.get('list_stacks')!.handler({});
+    restore();
+
+    const line = JSON.parse(written.find((l) => l.includes('tool failed'))!) as Record<string, unknown>;
+
+    expect(line.errType).toBe('ToolError');
+    expect(line.errMessage).toBe('Dockhand login failed (HTTP 401)');
+    // The shape that was actually being emitted, named explicitly so a return to it
+    // cannot pass by satisfying the two assertions above through some other route.
+    expect(line.err).toBeUndefined();
+  });
+
   it('logs "Unknown error" for a thrown non-Error value without crashing', async () => {
     const { written, restore } = captureLoggerOutput();
     const server = fakeServer();

--- a/tests/tool-error-logging.test.ts
+++ b/tests/tool-error-logging.test.ts
@@ -13,6 +13,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { registerTool } from '../src/utils/tool-helper.js';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
+
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
 
 interface CapturedTool {
   name: string;
@@ -38,7 +56,7 @@ describe('registerTool error logging', () => {
   });
 
   it('logs the tool name and error message when the callback throws (fail loud)', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const server = fakeServer();
 
     registerTool(server as never, 'health_check', {}, async () => {
@@ -50,14 +68,15 @@ describe('registerTool error logging', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Dockhand login failed');
 
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const logged = errorSpy.mock.calls[0].join(' ');
+    expect(written).toHaveLength(1);
+    const logged = written[0];
     expect(logged).toContain('health_check');
     expect(logged).toContain('Dockhand login failed');
+    restore();
   });
 
   it('logs "Unknown error" for a thrown non-Error value without crashing', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const server = fakeServer();
 
     registerTool(server as never, 'get_system_info', {}, async () => {
@@ -69,13 +88,14 @@ describe('registerTool error logging', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('Unknown error');
-    const logged = errorSpy.mock.calls[0].join(' ');
+    const logged = written[0];
     expect(logged).toContain('get_system_info');
     expect(logged).toContain('Unknown error');
+    restore();
   });
 
   it('does not log anything when the callback succeeds (happy path)', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const server = fakeServer();
 
     registerTool(server as never, 'get_host_info', { id: z.number() }, async ({ id }) => {
@@ -85,11 +105,12 @@ describe('registerTool error logging', () => {
     const result = await server.tools.get('get_host_info')!.handler({ id: 42 });
 
     expect(result.isError).toBeUndefined();
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(written).toHaveLength(0);
+    restore();
   });
 
   it('propagates a network-error message from a rejected client call and still logs it', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     const server = fakeServer();
 
     registerTool(server as never, 'list_containers', {}, async () => {
@@ -100,6 +121,7 @@ describe('registerTool error logging', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('ECONNREFUSED');
-    expect(errorSpy.mock.calls[0].join(' ')).toContain('ECONNREFUSED');
+    expect(written[0]).toContain('ECONNREFUSED');
+    restore();
   });
 });

--- a/tests/tools/meta.probe-debug-logging.test.ts
+++ b/tests/tools/meta.probe-debug-logging.test.ts
@@ -1,0 +1,100 @@
+/**
+ * self_check and validate_config make direct Dockhand requests (probeRawHealth,
+ * attemptRawLogin) that bypass DockhandClient, so before this they produced no debug
+ * line — LOG_LEVEL=debug missed the health and credential probes, the exact exchanges
+ * that matter when a diagnostic reports a failure. loggedProbe() now emits the same
+ * one-line-per-request shape every other Dockhand call does. Codex #209.
+ *
+ * The load-bearing assertion is the credential-safety one: the login probe carries the
+ * DOCKHAND_USERNAME and DOCKHAND_PASSWORD in its request body, and none of that, nor the
+ * URL, may reach the line.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+
+function captureStderr(): string[] {
+  const lines: string[] = [];
+  vi.spyOn(fs, 'writeSync').mockImplementation((_fd: unknown, chunk: unknown) => {
+    const text = String(chunk);
+    lines.push(text);
+    return Buffer.byteLength(text);
+  });
+  return lines;
+}
+
+function clientLines(written: string[]) {
+  return written
+    .join('')
+    .trim()
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>)
+    .filter((e) => e.component === 'client');
+}
+
+describe('diagnostic probes emit a debug line', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env['LOG_LEVEL'] = 'debug';
+  });
+  afterEach(() => {
+    delete process.env['LOG_LEVEL'];
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('probeRawHealth logs method, route /api/health, status and duration', async () => {
+    const written = captureStderr();
+    const { probeRawHealth } = await import('../../src/tools/meta.js');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+
+    await probeRawHealth('https://dockhand.example');
+
+    const [line] = clientLines(written);
+    expect(line).toMatchObject({ component: 'client', method: 'GET', route: '/api/health', status: 200 });
+    expect(typeof line.ms).toBe('number');
+    // Never the concrete URL.
+    expect(JSON.stringify(line)).not.toContain('dockhand.example');
+  });
+
+  it('attemptRawLogin logs route /api/auth and never the credentials or URL', async () => {
+    process.env['DOCKHAND_USERNAME'] = 'svc';
+    process.env['DOCKHAND_PASSWORD'] = 'p@ssw0rd-do-not-log-me';
+    const written = captureStderr();
+    const { attemptRawLogin } = await import('../../src/tools/meta.js');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        status: 200,
+        text: vi.fn().mockResolvedValue('{}'),
+        headers: { getSetCookie: () => ['dockhand_session=x; Path=/'], get: () => null },
+      }),
+    );
+
+    await attemptRawLogin('https://dockhand.example');
+
+    const [line] = clientLines(written);
+    expect(line).toMatchObject({ component: 'client', method: 'POST', route: '/api/auth', status: 200 });
+    const serialised = JSON.stringify(line);
+    expect(serialised).not.toContain('svc');
+    expect(serialised).not.toContain('p@ssw0rd-do-not-log-me');
+    expect(serialised).not.toContain('dockhand.example');
+    expect(serialised).not.toContain('/api/auth/login');
+    delete process.env['DOCKHAND_USERNAME'];
+    delete process.env['DOCKHAND_PASSWORD'];
+  });
+
+  it('logs a warn with only the error name when the probe throws', async () => {
+    const written = captureStderr();
+    const { probeRawHealth } = await import('../../src/tools/meta.js');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed: ECONNREFUSED 10.0.0.9')));
+
+    await expect(probeRawHealth('https://dockhand.example')).rejects.toThrow();
+
+    const [line] = clientLines(written);
+    expect(line).toMatchObject({ component: 'client', method: 'GET', route: '/api/health' });
+    expect(line.err).toEqual({ type: 'TypeError' });
+    // The exception message carries an address; only the name may be logged.
+    expect(JSON.stringify(line)).not.toContain('10.0.0.9');
+  });
+});

--- a/tests/tools/meta.probe-debug-logging.test.ts
+++ b/tests/tools/meta.probe-debug-logging.test.ts
@@ -84,6 +84,41 @@ describe('diagnostic probes emit a debug line', () => {
     delete process.env['DOCKHAND_PASSWORD'];
   });
 
+  it('logs the health-probe TIMEOUT as a failure, and never a late success line', async () => {
+    // withTimeout must reject inside loggedProbe, not around it. Codex #209: wrapping it
+    // outside let a timeout escape unlogged, and a fetch resolving after the timeout
+    // emitted a success line once self_check had already reported Dockhand down.
+    vi.useFakeTimers();
+    try {
+      const written = captureStderr();
+      const { probeRawHealth } = await import('../../src/tools/meta.js');
+      // A fetch that resolves only long after the 5s health timeout.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(
+          () => new Promise((resolve) => setTimeout(() => resolve({ ok: true, status: 200 }), 60_000)),
+        ),
+      );
+
+      const probe = probeRawHealth('https://dockhand.example');
+      const settled = probe.then(() => 'resolved', () => 'rejected');
+      await vi.advanceTimersByTimeAsync(5_001); // past the health timeout
+      expect(await settled).toBe('rejected');
+
+      const lines = clientLines(written);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toMatchObject({ component: 'client', method: 'GET', route: '/api/health' });
+      expect((lines[0] as { err?: unknown }).err).toBeDefined(); // logged as a failure, not a success
+      expect(lines[0].msg).toBe('dockhand request failed');
+
+      // Advance past when the fetch would resolve: still no late success line.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(clientLines(written).filter((l) => l.msg === 'dockhand request')).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('logs a warn with only the error name when the probe throws', async () => {
     const written = captureStderr();
     const { probeRawHealth } = await import('../../src/tools/meta.js');

--- a/tests/transport-security-e2e.test.ts
+++ b/tests/transport-security-e2e.test.ts
@@ -3,6 +3,24 @@ import http from 'node:http';
 import type { Server as HttpServer } from 'node:http';
 import { createServer } from '../src/server.js';
 import type { ServerConfig } from '../src/server.js';
+// The logger writes via pino.destination({ fd: 2, sync: true }) (SonicBoom), which
+// calls fs.writeSync(fd, ...) directly rather than console.error/process.stderr.write.
+// Default import, not `import * as fs`: the namespace form is a frozen ES module
+// object and vi.spyOn cannot redefine a property on it.
+import fs from 'node:fs';
+
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
 
 // End-to-end regression tests for the HIGH finding: the /mcp Streamable-HTTP
 // endpoint had no authentication and no DNS-rebinding/Origin protection, and
@@ -236,22 +254,23 @@ describe('/mcp opt-in bearer authentication', () => {
   });
 
   it('with neither MCP_ALLOWED_HOSTS nor MCP_AUTH_TOKEN configured: emits a startup warning that /mcp is unauthenticated and host-unchecked', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     await startServer();
 
-    const allOutput = errorSpy.mock.calls.map((call) => String(call.join(' '))).join('\n');
-    expect(allOutput).toContain('WARNING');
+    const allOutput = written.join('\n');
+    expect(allOutput).toContain('"level":"warn"');
     expect(allOutput).toContain('MCP_ALLOWED_HOSTS');
     expect(allOutput).toContain('MCP_AUTH_TOKEN');
+    restore();
   });
 
   it('with MCP_ALLOWED_HOSTS configured (but no token): does NOT emit the "no protection at all" warning', async () => {
     vi.stubEnv('MCP_ALLOWED_HOSTS', `127.0.0.1:${TEST_PORT}`);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { written, restore } = captureLoggerOutput();
     await startServer();
 
-    const messages = errorSpy.mock.calls.map((call) => String(call.join(' ')));
-    expect(messages.some((msg) => msg.includes('WARNING'))).toBe(false);
+    expect(written.some((msg) => msg.includes('"level":"warn"'))).toBe(false);
+    restore();
   });
 
   it('(c) with MCP_AUTH_TOKEN configured: a request with no Authorization header is rejected (401)', async () => {


### PR DESCRIPTION
Closes #116.

`LOG_LEVEL` has been in the README since the beginning and no code ever read it. All ~30 output sites were `console.error`, so the server effectively had one level: an operator debugging a failure got either everything or the same everything.

## What this adds

- **Four working levels** (`error`/`warn`/`info`/`debug`). No `silent` — the #116 login-failure line must stay unconditional, and a level that suppresses everything would hand that guarantee back to whoever sets an env var. An unrecognised value warns and falls back to `info` rather than refusing to start.
- **Structured JSON on stderr**, `sync: true`, level as a word rather than pino's numeric default.
- **Correlation** across three levels: `sid` (session) ⊇ `req` (HTTP request) ⊇ `call` (tool invocation), all UUIDs, carried by `AsyncLocalStorage`. `grep <req>` gives the whole chain from the access line to the last Dockhand call.
- **An nginx-format access line on stdout** for every request, including the ones the auth and Host/Origin guards reject — those are the two an operator most wants.
- **Real client address** behind a reverse proxy, gated by `TRUSTED_PROXIES`.
- **One `debug` line per Dockhand request**: method, endpoint template, status, duration, query parameter *names*.

## Secret-freeness is structural, not a filter

The debug line receives the endpoint **template** from `TOOL_ENDPOINT_MAP` (`/api/stacks/{name}/env/raw`), never the concrete URL. That URL carries stack names, container ids and `trigger_git_webhook`'s query-string secret — `src/utils/redact.ts` exists because that secret already reaches error messages. There is no field on that path a value could occupy, rather than a redaction list that has to keep up with every future parameter.

The accurate claim is **no secret reaches the log**, not "no value": the pre-existing thrown `Dockhand API error: ${redactQueryStrings(url)}` reaches `log().error` and still carries the concrete path. That boundary is deliberate and documented.

## Verified against the running CrowdSec instance, not just against its test

```
├ s00-raw   └ 🟢 crowdsecurity/docker-logs (+4 ~9)
├ s01-parse └ 🟢 crowdsecurity/nginx-logs (+23 ~2)
├ s02-enrich  🟢 dateparse-enrich  🟢 geoip-enrich  🟢 http-logs
├ Scenarios   🟢 LePresidente/http-generic-401-bf
              🟢 crowdsecurity/http-dos-swithcing-ua
```

A `401` on `/mcp` lands in the 401-bruteforce scenario with GeoIP enrichment — no custom parser, no file, no rotation. The appended `req=`/`sid=` fields were checked separately and do not break the grok.

The README's new "Securing the server with CrowdSec" section leads with the `TRUSTED_PROXIES` warning rather than burying it: without it, behind a proxy, the first ban CrowdSec issues takes out the proxy and everyone behind it.

## Review

Nine tasks, each implemented by a fresh agent and reviewed independently, then a whole-branch review with repository-wide scope. The final review found three merge blockers that no diff-scoped review could see, all demonstrated rather than hypothesised:

- `express.json()` sat ahead of the access-log middleware, so a body-parser rejection called `next(err)` and produced **no access line at all** — and the suite was equally green in both orders.
- `sid` came straight from a request header into the access line with no sanitisation, letting an outsider write plausible `req=`/`sid=` text into the stream CrowdSec reads.
- A `.debug()` added in any of ~40 tool files would have leaked every tool argument with 1052/1052 tests green.

All three are fixed and pinned by regression tests, each counter-checked against the unfixed version.

Also fixed: `err.type: 'ToolError'` never actually reached a log line — pino's `err` serializer overwrites `type` on any object carrying a `message` key, so every tool-failure line said `"type":"Object"`.

**Deferred, tracked:** `sync: true` on fd 2 blocks the event loop if the log consumer stalls. The obvious remedy does not work — `flushSync` is on the destination rather than pino's `Logger`, and sonic-boom's `flushSync` skips an in-flight buffer entirely, so the ten test files spying on `fs.writeSync` see nothing under an async destination. Rebuilding that capture layer is its own change. The trade-off is recorded in `src/utils/logger.ts`.

## Verification

1067 tests (from 1052), typecheck clean, build clean, `api:validate` OK.