### PR TITLE
fix(system): make log-context isolation a module invariant

### DIFF
--- a/src/utils/access-log-middleware.ts
+++ b/src/utils/access-log-middleware.ts
@@ -23,13 +23,18 @@ export function createAccessLogMiddleware(
   write: (line: string) => void = (line) => process.stdout.write(`${line}\n`),
 ): RequestHandler {
   return (req: Request, res: Response, next) => {
-    // This object is the log context for the whole request (see runWithLogContext:
-    // it is stored, not copied). The founding request of a session arrives without
-    // an mcp-session-id header — the id does not exist yet — and server.ts backfills
-    // it here via extendLogContext once the handshake produces one. Reading `context`
-    // at emit time rather than a captured local is what puts that id on the access
-    // line of the request that created the session.
+    // This is the seed for the log context of the whole request. runWithLogContext
+    // copies it into a private store and hands that copy to the callback below as
+    // `store` — `held` captures THAT object, not this literal, because the founding
+    // request of a session arrives without an mcp-session-id header (the id does not
+    // exist yet) and server.ts backfills it via extendLogContext() once the handshake
+    // produces one. Reading `held` at emit time is what puts that id on the access
+    // line of the request that created the session; reading `context` would only ever
+    // show the value it had before the run started.
     const context: LogContext = { req: randomUUID(), sid: header(req, 'mcp-session-id') };
+    // Fallback only: replaced synchronously by the runWithLogContext callback below,
+    // before `next()` runs. res.on('finish')/'close' can only fire after that.
+    let held: LogContext = context;
 
     const ip = resolveClientIp({
       peer: req.socket?.remoteAddress,
@@ -64,8 +69,8 @@ export function createAccessLogMiddleware(
           bytes: Number(res.getHeader('content-length') ?? 0),
           referer: header(req, 'referer'),
           userAgent: header(req, 'user-agent'),
-          req: context.req,
-          sid: context.sid,
+          req: held.req,
+          sid: held.sid,
         }),
       );
     };
@@ -75,6 +80,9 @@ export function createAccessLogMiddleware(
     res.on('finish', emit);
     res.on('close', emit);
 
-    runWithLogContext(context, () => next());
+    runWithLogContext(context, (store) => {
+      held = store;
+      next();
+    });
   };
 }

--- a/src/utils/log-context.ts
+++ b/src/utils/log-context.ts
@@ -31,19 +31,27 @@ export interface LogContext {
 const storage = new AsyncLocalStorage<LogContext>();
 
 /**
- * The given object BECOMES the store — it is not copied. That is what makes a later
- * extendLogContext() visible to whoever opened the context, which the access-log
- * middleware depends on: it learns the session id only after the MCP handshake has
- * run, and writes its line later still, from a res.on('finish') listener that has no
- * reliable context of its own. Holding the object is deterministic; reaching back
- * into AsyncLocalStorage from an event listener would work by accident at best.
+ * Isolation is a module invariant, not a call-site convention: the given `context` is
+ * copied into a private store, and that copy — never the caller's own object — is what
+ * ends up in AsyncLocalStorage and gets handed to the callback. A caller can mutate its
+ * original object after the run has started, or reuse one object literal across two
+ * runs, without either reaching the store (tests/log-context.test.ts, describe block
+ * "isolation from the caller").
  *
- * The invariant that keeps runs isolated is therefore at the call sites: each one
- * passes a fresh object per run (a literal or a spread), never a shared or reused
- * one. Both callers in src/ do; tests/log-context.test.ts pins both halves.
+ * The callback receives the store as its argument for exactly one reason: a later
+ * extendLogContext() (e.g. backfilling a session id once the MCP handshake produces
+ * one) needs to be visible to whoever opened the context, and the store is a private
+ * copy that only this function and extendLogContext() ever see through
+ * AsyncLocalStorage — the caller has no other way to reach it. The access-log
+ * middleware relies on this: it learns the session id only after the handshake has
+ * run, and writes its line later still, from a res.on('finish') listener that has no
+ * reliable context of its own, so it holds the `store` argument across the callback and
+ * reads it back at emit time. Holding the object is deterministic; reaching back into
+ * AsyncLocalStorage from an event listener would work by accident at best.
  */
-export function runWithLogContext<T>(context: LogContext, fn: () => T): T {
-  return storage.run(context, fn);
+export function runWithLogContext<T>(context: LogContext, fn: (store: LogContext) => T): T {
+  const store = { ...context };
+  return storage.run(store, () => fn(store));
 }
 
 export function extendLogContext(patch: Partial<LogContext>): void {

--- a/tests/log-context.test.ts
+++ b/tests/log-context.test.ts
@@ -10,6 +10,7 @@ import {
   currentLogContext,
   log,
 } from '../src/utils/log-context.js';
+import type { LogContext } from '../src/utils/log-context.js';
 import { logger } from '../src/utils/logger.js';
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -53,20 +54,69 @@ describe('log context', () => {
     expect(seen.sort()).toEqual(['r1/c1', 'r2/c2']);
   });
 
-  // The access-log middleware holds the object it opened the context with and reads it
-  // back when the response finishes, because that is the only deterministic way for it
-  // to learn a session id that did not exist when the request arrived. That works only
-  // if the store IS the given object rather than a copy of it — with a copy the
-  // backfill lands somewhere the caller can never see, and the access line silently
-  // keeps saying sid=-.
-  it('makes a backfill visible to whoever opened the context', () => {
+  // The access-log middleware needs to see a backfill (extendLogContext, called once
+  // the MCP handshake produces a session id) after the run has started. It gets that
+  // by holding the STORE the callback receives — never the caller's own literal, which
+  // the module never mutates. This is the module's half of the contract; the
+  // middleware's half (holding `store`, not the literal it passed in) is exercised
+  // end-to-end by tests/founding-session-correlation.test.ts.
+  it('hands the callback the live store, and a backfill through it is visible there', () => {
     const context = { req: 'r1' };
+    let capturedStore: LogContext | undefined;
 
-    runWithLogContext(context, () => {
+    runWithLogContext(context, (store) => {
+      capturedStore = store;
       extendLogContext({ sid: 's-created-later' });
     });
 
-    expect(context).toEqual({ req: 'r1', sid: 's-created-later' });
+    expect(capturedStore).toEqual({ req: 'r1', sid: 's-created-later' });
+    // The caller's own literal is never touched — only the copy the module made from it.
+    expect(context).toEqual({ req: 'r1' });
+  });
+
+  // Isolation is a module invariant, not a call-site convention: a caller mutating the
+  // object it passed in, or reusing one object literal across two runs, must never
+  // reach the store. Both of the following were possible with `storage.run(context, fn)`
+  // (the store WAS the caller's object) and are the reason this function now makes its
+  // own copy and hands that copy to the callback instead.
+  describe('isolation from the caller (module invariant)', () => {
+    it('does not let a mutation of the original object after the run has started reach the store', async () => {
+      const original: LogContext = { req: 'r1' };
+      const seenReq: (string | undefined)[] = [];
+
+      const running = runWithLogContext(original, async () => {
+        // Yield once so the mutation below runs while this call is in flight —
+        // i.e. genuinely "after the run has started", not before it.
+        await tick();
+        seenReq.push(currentLogContext().req);
+      });
+
+      // External mutation of the ORIGINAL object, after runWithLogContext has already
+      // captured its copy.
+      original.req = 'mutated-from-outside';
+
+      await running;
+
+      expect(seenReq).toEqual(['r1']);
+    });
+
+    it('does not let one object literal reused across two runs cross-contaminate', () => {
+      const shared: LogContext = { req: 'r1' };
+      let seenInB: LogContext | undefined;
+
+      // Run A extends the store it was handed.
+      runWithLogContext(shared, () => {
+        extendLogContext({ call: 'from-A' });
+      });
+
+      // Run B reuses the SAME object literal. It must start clean, not inherit A's
+      // extension merely because both runs began from the same reference.
+      runWithLogContext(shared, () => {
+        seenInB = currentLogContext();
+      });
+
+      expect(seenInB).toEqual({ req: 'r1' });
+    });
   });
 
   it('does not leak a nested extension back into the outer context', () => {


### PR DESCRIPTION
Closes #211. Follow-up from #209.

## Problem
`runWithLogContext` was `storage.run(context, fn)` — no copy. #209 removed the copy so `extendLogContext({ sid })` in `onsessioninitialized` could reach the object the access-log middleware holds. Correct, but isolation (no external mutation of the store, no aliasing one object across two runs) became a call-site convention the JSDoc documented rather than an invariant the module enforced — no guard, no test.

## Fix
Hand a private copy to the callback:
```ts
export function runWithLogContext<T>(context: LogContext, fn: (store: LogContext) => T): T {
  const store = { ...context };
  return storage.run(store, () => fn(store));
}
```
The access-log middleware now **holds that store** (not the caller's literal) and reads `held.sid`/`held.req` at emit — so the sid `extendLogContext` backfills is the one the access line reads. `tool-helper.ts` ignores the new `store` param and still typechecks.

## Tests
Adds the aliasing test `tests/log-context.test.ts` never had:
- external mutation of the passed object after the run starts does not reach the store;
- the same object handed to two runs does not cross-contaminate.

Both verified **red against the unfixed `storage.run(context, fn)`** for the right reason (store was the caller's object), green after. `tests/founding-session-correlation.test.ts` (the sid-backfill regression net) stays green. Full suite 1083/1083, `tsc --noEmit` clean.

_Note: repo has no `lint` script; CI gates typecheck/test/build, all green._