### PR TITLE
fix(client): unify logger error field on flat errType, documented + pinned

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,9 @@ Start with `LOG_LEVEL=debug`. Every Dockhand request then appears with its endpo
 status code and duration, and every line of a single call shares one `call`
 identifier — `grep` for it to get the whole sequence. The `req` identifier ties those
 lines back to the access line that started them, and `sid` covers everything one
-client did across its whole session.
+client did across its whole session. A failed Dockhand request additionally logs a
+`warn` line carrying `errType` — the exception name (e.g. `TimeoutError`, `TypeError`),
+a bounded vocabulary rather than free text — so you can filter failures by error type.
 
 ## Development
 

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -139,16 +139,20 @@ export class SessionManager {
         redirect: 'manual',
       });
     } catch (error) {
-      // `err: { type }` and no message, mirroring the client: an exception name is
-      // bounded to the DOM/Node vocabulary (TypeError, TimeoutError, ...), the message
-      // is free text from an exception this code did not construct.
+      // Flat `errType`, mirroring the client: pino's default error serializer
+      // treats ANY object carrying a `message` key as error-like and overwrites
+      // `type` with the constructor name — a nested `err: { type }` here would be
+      // one added `message` field away from silently logging "type":"Object"
+      // instead of the exception name. `error.name` is bounded to the DOM/Node
+      // exception vocabulary (TypeError, TimeoutError, ...); the message is free
+      // text from an exception this code did not construct.
       log().warn(
         {
           component: 'client',
           method: 'POST',
           route,
           ms: Date.now() - started,
-          err: { type: error instanceof Error ? error.name : 'UnknownError' },
+          errType: error instanceof Error ? error.name : 'UnknownError',
         },
         'dockhand request failed',
       );

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -225,12 +225,14 @@ export class DockhandClient {
       );
       return response;
     } catch (error) {
-      // No `message` field: it is free text from an exception this code did not
-      // construct, and the one field in this file that would not be structurally
-      // value-free. `error.name` is bounded to the DOM/Node exception vocabulary
-      // (TypeError, TimeoutError, AbortError, ...) and — unlike the previous
-      // hardcoded 'NetworkError' — actually reflects what AbortSignal.timeout()
-      // throws when the SSE timeout fires.
+      // Flat `errType`, not nested under `err`: pino's default error serializer
+      // treats ANY object carrying a `message` key as error-like and overwrites
+      // `type` with the constructor name — a nested `err: { type }` here would be
+      // one added `message` field away from silently logging "type":"Object"
+      // instead of the exception name. `error.name` is bounded to the DOM/Node
+      // exception vocabulary (TypeError, TimeoutError, AbortError, ...) and —
+      // unlike the previous hardcoded 'NetworkError' — actually reflects what
+      // AbortSignal.timeout() throws when the SSE timeout fires.
       log().warn(
         {
           component: 'client',
@@ -238,7 +240,7 @@ export class DockhandClient {
           route,
           ...(query.length ? { query } : {}),
           ms: Date.now() - started,
-          err: { type: error instanceof Error ? error.name : 'UnknownError' },
+          errType: error instanceof Error ? error.name : 'UnknownError',
         },
         'dockhand request failed',
       );

--- a/src/tools/meta.ts
+++ b/src/tools/meta.ts
@@ -742,8 +742,13 @@ async function loggedProbe(
     log().debug({ component: 'client', method, route, status: response.status, ms: Date.now() - started }, 'dockhand request');
     return response;
   } catch (error) {
+    // Flat `errType`, not nested under `err`: pino's default error serializer treats
+    // ANY object carrying a `message` key as error-like and overwrites `type` with the
+    // constructor name — a nested `err: { type }` here would be one added `message`
+    // field away from silently logging "type":"Object" instead of the exception name
+    // (see Issue #212, and the identical fix in DockhandClient/SessionManager).
     log().warn(
-      { component: 'client', method, route, ms: Date.now() - started, err: { type: error instanceof Error ? error.name : 'UnknownError' } },
+      { component: 'client', method, route, ms: Date.now() - started, errType: error instanceof Error ? error.name : 'UnknownError' },
       'dockhand request failed',
     );
     throw error;

--- a/tests/client-debug-logging.test.ts
+++ b/tests/client-debug-logging.test.ts
@@ -129,7 +129,7 @@ describe('client debug logging', () => {
     const [line] = debugLines();
     expect(line.level).toBe('warn');
     expect(line.route).toBe('/api/stacks');
-    expect(line.err.type).toBe('TypeError');
+    expect(line.errType).toBe('TypeError');
     expect(JSON.stringify(line)).not.toContain('paperless');
   });
 

--- a/tests/error-field-serializer.test.ts
+++ b/tests/error-field-serializer.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #212: this file pins the pino default-serializer trap that let three call
+ * sites (DockhandClient, SessionManager, meta.ts's loggedProbe) silently log
+ * `"err":{"type":"Object", ...}` instead of the exception name.
+ *
+ * pino applies its `err` serializer (pino.stdSerializers.err) to the `err` key by
+ * default, with no opt-in required (see src/utils/logger.ts — no `serializers` option
+ * is configured, yet the mangling still happens). That serializer treats ANY object
+ * carrying a `message` key as error-like and overwrites `type` with the object's
+ * *constructor* name, not the value that was put there. A plain object's constructor
+ * is `Object`, so `err: { type: 'ToolError', message: 'x' }` reaches the log as
+ * `"err":{"type":"Object","message":"x","stack":""}` — the label never arrives.
+ *
+ * The flat shape (`errType` as a sibling field, never nested under `err`) sidesteps
+ * the serializer entirely: pino only special-cases the `err` key.
+ *
+ * These two tests run through the REAL logger singleton (src/utils/logger.ts), not a
+ * hand-rolled pino instance, so a future change to the logger's options (e.g. adding
+ * a custom `err` serializer) is covered by the same assertions.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import { logger } from '../src/utils/logger.js';
+
+// Same capture pattern as tests/tool-error-logging.test.ts: the logger writes via
+// pino.destination({ fd: 2, sync: true }) (SonicBoom), which calls
+// fs.writeSync(fd, ...) directly — never console.error/process.stderr.write. Default
+// import, not `import * as fs`: the namespace form is a frozen ES module object and
+// vi.spyOn cannot redefine a property on it.
+function captureLoggerOutput(): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const spy = vi.spyOn(fs, 'writeSync').mockImplementation((fd: unknown, buffer: unknown) => {
+    if (fd === 2) {
+      const text = String(buffer);
+      written.push(text);
+      return Buffer.byteLength(text);
+    }
+    return 0;
+  });
+  return { written, restore: () => spy.mockRestore() };
+}
+
+describe('error field shape (Issue #212)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a flat errType survives verbatim in the emitted line', () => {
+    const { written, restore } = captureLoggerOutput();
+    logger.warn({ component: 'test', errType: 'ToolError' }, 'flat case');
+    restore();
+
+    const line = JSON.parse(written[0]!) as Record<string, unknown>;
+    expect(line['errType']).toBe('ToolError');
+    // Confirms this is really the flat-field escape hatch, not a coincidence: no
+    // `err` key was created at all.
+    expect(line['err']).toBeUndefined();
+  });
+
+  it('a nested err: { type, message } is mangled by pino default serializer — this is the trap the flat shape avoids', () => {
+    const { written, restore } = captureLoggerOutput();
+    // The exact shape the three fixed call sites used to emit. `message` is what
+    // triggers pino's default `err` serializer; a nested `err: { type }` alone
+    // (no `message`) does NOT trigger it, which is why this bug went unnoticed until
+    // a call site gained a message field.
+    logger.warn({ component: 'test', err: { type: 'ToolError', message: 'x' } }, 'nested case');
+    restore();
+
+    const line = JSON.parse(written[0]!) as Record<string, unknown>;
+    const err = line['err'] as Record<string, unknown>;
+    // Empirically verified against the installed pino (9.14.0): the serializer
+    // overwrites `type` with the value's constructor name. A plain object literal's
+    // constructor is `Object`, not `ToolError` — the label is gone, not merely
+    // renamed. If this ever fails because pino changed what it emits here, that is
+    // real news: update the assertion to the new value and keep the `!== 'ToolError'`
+    // guarantee below either way.
+    expect(err['type']).toBe('Object');
+    expect(err['type']).not.toBe('ToolError');
+  });
+});

--- a/tests/session-login-debug-logging.test.ts
+++ b/tests/session-login-debug-logging.test.ts
@@ -86,9 +86,11 @@ describe('login request logging', () => {
       component: 'client',
       method: 'POST',
       route: '/api/auth',
-      // Same shape as the client's own failure line: the exception NAME, which is
-      // bounded, never its free-text message.
-      err: { type: 'TypeError' },
+      // Same flat shape as the client's own failure line: the exception NAME, which
+      // is bounded, never its free-text message. Flat, not nested under `err` — pino's
+      // default error serializer treats any object with a `message` key as error-like
+      // and overwrites `type` with the constructor name (see Issue #212).
+      errType: 'TypeError',
       msg: 'dockhand request failed',
     });
   });

--- a/tests/tools/meta.probe-debug-logging.test.ts
+++ b/tests/tools/meta.probe-debug-logging.test.ts
@@ -108,7 +108,7 @@ describe('diagnostic probes emit a debug line', () => {
       const lines = clientLines(written);
       expect(lines).toHaveLength(1);
       expect(lines[0]).toMatchObject({ component: 'client', method: 'GET', route: '/api/health' });
-      expect((lines[0] as { err?: unknown }).err).toBeDefined(); // logged as a failure, not a success
+      expect((lines[0] as { errType?: unknown }).errType).toBeDefined(); // logged as a failure, not a success
       expect(lines[0].msg).toBe('dockhand request failed');
 
       // Advance past when the fetch would resolve: still no late success line.
@@ -128,7 +128,7 @@ describe('diagnostic probes emit a debug line', () => {
 
     const [line] = clientLines(written);
     expect(line).toMatchObject({ component: 'client', method: 'GET', route: '/api/health' });
-    expect(line.err).toEqual({ type: 'TypeError' });
+    expect(line.errType).toBe('TypeError');
     // The exception message carries an address; only the name may be logged.
     expect(JSON.stringify(line)).not.toContain('10.0.0.9');
   });


### PR DESCRIPTION
Closes #212. Follow-up from #209.

## Problem
Two error-field shapes coexisted: flat `errType` (tool-helper) and nested `err:{ type }` (dockhand-client, auth/session). pino's default `err` serializer relabels any object carrying a `message` key to its constructor name — so `err:{ type:'X', message }` silently logs `"type":"Object"`. The nested sites survived only because they carried `type` and **no** `message`: one added field from silently breaking. Neither shape was documented, so an operator had to read the source to filter by error type.

## Change
1. **Unify on flat `errType`** at every nested site: `src/client/dockhand-client.ts`, `src/auth/session.ts`, and a **third** site found during the work — `src/tools/meta.ts` `loggedProbe` (the same trap, used by `self_check`/`validate_config`). Comments at each site now explain the serializer trap. No nested `err:{...}` logging site remains (real-`Error` `err: error` uses are the correct, intended serializer path and stay).
2. **Document** `errType` in the README troubleshooting section (bounded exception-name vocabulary, never free text).
3. **Pin the trap** with `tests/error-field-serializer.test.ts`: through the real logger, a flat `errType` survives verbatim while a nested `err:{type,message}` is empirically mangled to `err.type === 'Object'` (pino 9.14). The next person who reintroduces the nested shape gets a red test instead of a production `Object`.

## Tests
Assertions in `client-debug-logging.test.ts` / `meta.probe-debug-logging.test.ts` updated to the flat field. Full suite 1083/1083, `tsc --noEmit` clean. Counter-check: reverting a call site to the nested shape makes the debug-logging test go red (`expected undefined to be 'TypeError'`).

_Repo has no `lint` script; CI gates typecheck/test/build, all green._