### PR TITLE
fix(client): derive each request's own route template in the debug log

### DIFF
--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -217,7 +217,7 @@ export class DockhandClient {
   private async loggedFetch(method: string, url: string, init: RequestInit): Promise<Response> {
     const started = Date.now();
     const parsed = new URL(url);
-    const route = matchRoute(parsed.pathname) ?? coarseRoute(parsed.pathname);
+    const route = matchRoute(parsed.pathname, method) ?? coarseRoute(parsed.pathname);
     const query = [...parsed.searchParams.keys()];
 
     try {

--- a/src/client/dockhand-client.ts
+++ b/src/client/dockhand-client.ts
@@ -7,7 +7,8 @@ import { SessionManager } from '../auth/session.js';
 import type { DockhandConfig, SSEResult } from '../types/dockhand.js';
 import { normalizeBaseUrl } from '../utils/url.js';
 import { redactQueryStrings } from '../utils/redact.js';
-import { log, currentLogContext } from '../utils/log-context.js';
+import { log } from '../utils/log-context.js';
+import { matchRoute } from '../openapi/match-route.js';
 
 /** Timeout for SSE streaming responses (5 minutes). */
 const SSE_TIMEOUT_MS = 300_000;
@@ -194,20 +195,29 @@ export class DockhandClient {
    * The single place this client talks to the network, so the single place a debug
    * line belongs.
    *
-   * It logs the endpoint TEMPLATE from the call context, never `url`. That is not
-   * politeness: `url` carries stack names, container ids and — for
-   * trigger_git_webhook — a secret in the query string. There is deliberately no code
-   * path here that can write a value, rather than a filter that has to keep up with
-   * every parameter a future tool introduces. That is exact for the context-supplied
-   * route; for the `coarseRoute()` fallback it is a truncation argument instead — two
-   * path segments are short enough that no identifier fits, even though the segments
-   * themselves come from the same caller-supplied `pathname` that `url` would expose
-   * in full.
+   * It logs the endpoint TEMPLATE, never `url`. That is not politeness: `url` carries
+   * stack names, container ids and — for trigger_git_webhook — a secret in the query
+   * string. There is deliberately no code path here that can write a value, rather than
+   * a filter that has to keep up with every parameter a future tool introduces.
+   *
+   * The template comes from `matchRoute()` (src/openapi/match-route.ts), which
+   * reverse-matches THIS request's own `parsed.pathname` against the pinned spec's known
+   * path templates — not from the tool-scope context. A tool that fans out to several
+   * endpoints (e.g. remove_stack_env_vars hitting both `/env` and `/env/raw`) previously
+   * logged the same context-supplied route for every one of its requests; matching each
+   * request's own pathname gives each of them its own, correct route. `matchRoute()`
+   * only ever returns one of the spec's known template strings, so this is exact, the
+   * same way the context-supplied route used to be. For the `coarseRoute()` fallback —
+   * used when the pathname matches no known template, e.g. a stale `TOOL_ENDPOINT_MAP`
+   * entry pointing at a path the pinned spec no longer has, or the spec being
+   * unavailable at runtime — it is a truncation argument instead: two path segments are
+   * short enough that no identifier fits, even though the segments themselves come from
+   * the same caller-supplied `pathname` that `url` would expose in full.
    */
   private async loggedFetch(method: string, url: string, init: RequestInit): Promise<Response> {
     const started = Date.now();
     const parsed = new URL(url);
-    const route = currentLogContext().route ?? coarseRoute(parsed.pathname);
+    const route = matchRoute(parsed.pathname) ?? coarseRoute(parsed.pathname);
     const query = [...parsed.searchParams.keys()];
 
     try {

--- a/src/openapi/match-route.ts
+++ b/src/openapi/match-route.ts
@@ -17,6 +17,8 @@ interface TemplateEntry {
   readonly template: string;
   readonly segments: readonly string[];
   readonly literalCount: number;
+  /** Lowercased HTTP methods the spec defines for this template. */
+  readonly methods: ReadonlySet<string>;
 }
 
 /** Bucketed by segment count so a match never compares templates of the wrong shape. */
@@ -32,10 +34,15 @@ function isPlaceholder(segment: string): boolean {
 
 function buildIndex(): Map<number, TemplateEntry[]> {
   const index = new Map<number, TemplateEntry[]>();
-  for (const template of specPathTemplates()) {
+  for (const { template, methods } of specPathTemplates()) {
     const segments = splitSegments(template);
     const literalCount = segments.filter((segment) => !isPlaceholder(segment)).length;
-    const entry: TemplateEntry = { template, segments, literalCount };
+    const entry: TemplateEntry = {
+      template,
+      segments,
+      literalCount,
+      methods: new Set(methods.map((method) => method.toLowerCase())),
+    };
     const bucket = index.get(segments.length);
     if (bucket) {
       bucket.push(entry);
@@ -57,34 +64,59 @@ function segmentsMatch(templateSegments: readonly string[], pathSegments: readon
 }
 
 /**
- * Resolves `pathname` to the most specific matching OpenAPI path template — "most
- * specific" meaning the most literal (non-`{...}`) segments, so a literal route like
- * `/api/stacks/adopt` wins over the parameterised `/api/stacks/{name}` it would
- * otherwise also match. Ties (equally-literal templates) break lexicographically; ties
- * only happen between equally-safe templates, so the tie-break is cosmetic, not a
- * safety decision.
+ * Resolves a concrete request (`method` + `pathname`) to the most specific matching OpenAPI
+ * path template.
  *
- * Returns `undefined` when no known template matches — including when the spec is
- * unavailable, since `specPathTemplates()` then yields an empty set and every pathname
- * fails to match by construction.
+ * The METHOD is decisive first, because a pathname alone can match two templates that differ
+ * only by which verb each defines. `DELETE /api/stacks/adopt` (the `delete_stack` tool acting
+ * on a stack literally named `adopt`) matches both the literal `/api/stacks/adopt` — which the
+ * spec defines only for POST — and `/api/stacks/{name}`, which is where DELETE actually lives.
+ * Picking purely by literal-count would log the nonexistent `DELETE /api/stacks/adopt`. So a
+ * candidate whose spec operations include the request's method always beats one whose do not.
+ * (Codex, PR #219.)
+ *
+ * Among candidates of equal method standing, "most specific" then means the most literal
+ * (non-`{...}`) segments — so `POST /api/stacks/adopt` still resolves to the literal template.
+ * Ties break lexicographically; ties only happen between equally-safe templates, so the
+ * tie-break is cosmetic, not a safety decision. If NO matching template defines the method
+ * (a spec gap), the method-agnostic most-literal template is still returned rather than
+ * dropping to `coarseRoute` — it is a valid known template, never a caller value.
+ *
+ * Returns `undefined` when no known template matches at all — including when the spec is
+ * unavailable, since `specPathTemplates()` then yields an empty set and every pathname fails
+ * to match by construction.
  */
-export function matchRoute(pathname: string): string | undefined {
+export function matchRoute(pathname: string, method: string): string | undefined {
   indexByLength ??= buildIndex();
 
   const pathSegments = splitSegments(pathname);
   const candidates = indexByLength.get(pathSegments.length);
   if (!candidates) return undefined;
 
+  const wantedMethod = method.toLowerCase();
   let best: TemplateEntry | undefined;
+  let bestMethodMatch = false;
   for (const candidate of candidates) {
     if (!segmentsMatch(candidate.segments, pathSegments)) continue;
-    if (
-      !best ||
-      candidate.literalCount > best.literalCount ||
-      (candidate.literalCount === best.literalCount && candidate.template < best.template)
-    ) {
+    const methodMatch = candidate.methods.has(wantedMethod);
+    if (!best || preferred(methodMatch, candidate, bestMethodMatch, best)) {
       best = candidate;
+      bestMethodMatch = methodMatch;
     }
   }
   return best?.template;
+}
+
+/** Whether (methodMatch, candidate) should replace the current (bestMethodMatch, best). */
+function preferred(
+  methodMatch: boolean,
+  candidate: TemplateEntry,
+  bestMethodMatch: boolean,
+  best: TemplateEntry,
+): boolean {
+  // A template that defines the request's method always wins over one that does not.
+  if (methodMatch !== bestMethodMatch) return methodMatch;
+  // Then most-literal wins, then lexicographic (cosmetic — both are safe templates).
+  if (candidate.literalCount !== best.literalCount) return candidate.literalCount > best.literalCount;
+  return candidate.template < best.template;
 }

--- a/src/openapi/match-route.ts
+++ b/src/openapi/match-route.ts
@@ -1,0 +1,90 @@
+/**
+ * Reverse-matches a concrete request pathname back to its OpenAPI path TEMPLATE, so that
+ * `loggedFetch` (src/client/dockhand-client.ts) can log the endpoint a request actually
+ * hit instead of the single, tool-wide route the caller happened to be invoked under.
+ *
+ * This is deliberately NOT a heuristic templatiser (guess which segments "look like" an
+ * identifier). It only ever matches against the KNOWN set of templates the pinned spec
+ * defines (`specPathTemplates()`) and only ever returns one of those exact strings —
+ * structurally, there is no code path here that can hand back a caller-supplied value,
+ * the same safety property `coarseRoute()` relies on for its fallback. A pathname that
+ * matches nothing returns `undefined` and the caller falls back to `coarseRoute()`.
+ */
+
+import { specPathTemplates } from './spec-loader.js';
+
+interface TemplateEntry {
+  readonly template: string;
+  readonly segments: readonly string[];
+  readonly literalCount: number;
+}
+
+/** Bucketed by segment count so a match never compares templates of the wrong shape. */
+let indexByLength: Map<number, TemplateEntry[]> | undefined;
+
+function splitSegments(path: string): string[] {
+  return path.split('/').filter((segment) => segment.length > 0);
+}
+
+function isPlaceholder(segment: string): boolean {
+  return segment.startsWith('{') && segment.endsWith('}');
+}
+
+function buildIndex(): Map<number, TemplateEntry[]> {
+  const index = new Map<number, TemplateEntry[]>();
+  for (const template of specPathTemplates()) {
+    const segments = splitSegments(template);
+    const literalCount = segments.filter((segment) => !isPlaceholder(segment)).length;
+    const entry: TemplateEntry = { template, segments, literalCount };
+    const bucket = index.get(segments.length);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      index.set(segments.length, [entry]);
+    }
+  }
+  return index;
+}
+
+/** Every segment must be an exact literal match, or the template's `{...}` placeholder. */
+function segmentsMatch(templateSegments: readonly string[], pathSegments: readonly string[]): boolean {
+  for (let i = 0; i < templateSegments.length; i++) {
+    const templateSegment = templateSegments[i];
+    if (templateSegment === undefined || isPlaceholder(templateSegment)) continue;
+    if (templateSegment !== pathSegments[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Resolves `pathname` to the most specific matching OpenAPI path template — "most
+ * specific" meaning the most literal (non-`{...}`) segments, so a literal route like
+ * `/api/stacks/adopt` wins over the parameterised `/api/stacks/{name}` it would
+ * otherwise also match. Ties (equally-literal templates) break lexicographically; ties
+ * only happen between equally-safe templates, so the tie-break is cosmetic, not a
+ * safety decision.
+ *
+ * Returns `undefined` when no known template matches — including when the spec is
+ * unavailable, since `specPathTemplates()` then yields an empty set and every pathname
+ * fails to match by construction.
+ */
+export function matchRoute(pathname: string): string | undefined {
+  indexByLength ??= buildIndex();
+
+  const pathSegments = splitSegments(pathname);
+  const candidates = indexByLength.get(pathSegments.length);
+  if (!candidates) return undefined;
+
+  let best: TemplateEntry | undefined;
+  for (const candidate of candidates) {
+    if (!segmentsMatch(candidate.segments, pathSegments)) continue;
+    if (
+      !best ||
+      candidate.literalCount > best.literalCount ||
+      (candidate.literalCount === best.literalCount && candidate.template < best.template)
+    ) {
+      best = candidate;
+    }
+  }
+  return best?.template;
+}

--- a/src/openapi/spec-loader.ts
+++ b/src/openapi/spec-loader.ts
@@ -89,15 +89,32 @@ export function specInfoVersion(): string | undefined {
   return spec?.info?.version;
 }
 
+/** A path template plus the HTTP methods (lowercased) the spec defines an operation for. */
+export interface SpecPathTemplate {
+  readonly template: string;
+  readonly methods: readonly string[];
+}
+
+// A Path Item Object may carry non-operation keys (parameters, summary, description,
+// servers, $ref) alongside the verbs. Only these are real operations.
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'patch', 'head', 'options', 'trace']);
+
 /**
- * Returns every path template key from the pinned OpenAPI spec (e.g.
- * `/api/stacks/{name}/env/raw`), or `[]` when the spec is unavailable (see `loadSpec()`).
- * Used by `matchRoute()` (src/openapi/match-route.ts) to reverse-match a concrete request
- * pathname back to its template — the set this function returns is the ONLY thing a debug
- * log line is ever allowed to contain instead of the caller's real path, so an empty
- * result must make every match fail closed, not throw.
+ * Returns every path template from the pinned OpenAPI spec (e.g. `/api/stacks/{name}/env/raw`)
+ * together with the HTTP methods it defines, or `[]` when the spec is unavailable (see
+ * `loadSpec()`). Used by `matchRoute()` (src/openapi/match-route.ts) to reverse-match a concrete
+ * request back to its template — the set this function returns is the ONLY thing a debug log line
+ * is ever allowed to contain instead of the caller's real path, so an empty result must make every
+ * match fail closed, not throw. The methods are carried because a concrete pathname can match two
+ * templates that differ only by which verb each defines (e.g. `POST /api/stacks/adopt` the literal
+ * vs. `DELETE /api/stacks/{name}` where `name` is `adopt`) — the matcher needs the method to pick
+ * the right one.
  */
-export function specPathTemplates(): string[] {
+export function specPathTemplates(): SpecPathTemplate[] {
   const spec = loadSpec();
-  return spec?.paths ? Object.keys(spec.paths) : [];
+  if (!spec?.paths) return [];
+  return Object.entries(spec.paths).map(([template, operations]) => ({
+    template,
+    methods: Object.keys(operations).filter((key) => HTTP_METHODS.has(key.toLowerCase())),
+  }));
 }

--- a/src/openapi/spec-loader.ts
+++ b/src/openapi/spec-loader.ts
@@ -88,3 +88,16 @@ export function specInfoVersion(): string | undefined {
   const spec = loadSpec();
   return spec?.info?.version;
 }
+
+/**
+ * Returns every path template key from the pinned OpenAPI spec (e.g.
+ * `/api/stacks/{name}/env/raw`), or `[]` when the spec is unavailable (see `loadSpec()`).
+ * Used by `matchRoute()` (src/openapi/match-route.ts) to reverse-match a concrete request
+ * pathname back to its template — the set this function returns is the ONLY thing a debug
+ * log line is ever allowed to contain instead of the caller's real path, so an empty
+ * result must make every match fail closed, not throw.
+ */
+export function specPathTemplates(): string[] {
+  const spec = loadSpec();
+  return spec?.paths ? Object.keys(spec.paths) : [];
+}

--- a/src/utils/log-context.ts
+++ b/src/utils/log-context.ts
@@ -24,8 +24,6 @@ export interface LogContext {
   call?: string;
   /** Name of the tool being invoked. */
   tool?: string;
-  /** OpenAPI path template of the Dockhand endpoint — never a concrete path. */
-  route?: string;
 }
 
 const storage = new AsyncLocalStorage<LogContext>();

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -85,6 +85,7 @@ export function registerTool<T extends ZodShape>(
           log().error(
             {
               component: 'tools',
+              route: toolRoute,
               ms: Date.now() - started,
               errType: 'ToolError',
               errMessage: message,

--- a/src/utils/tool-helper.ts
+++ b/src/utils/tool-helper.ts
@@ -46,20 +46,26 @@ export function registerTool<T extends ZodShape>(
     const outer = currentLogContext();
     const started = Date.now();
 
+    // The tool's own endpoint template (never a concrete path). This is logged on the
+    // tool's own start/ok/failed lines call-time — NOT bound into the log context.
+    // Binding it would bake it into every pino child (see log()), and the per-request
+    // client debug line (loggedFetch) now derives and logs its OWN route from the
+    // request pathname (matchRoute, #214): a child already carrying a bound `route`
+    // makes pino serialize BOTH keys, so a fan-out line would report the stale
+    // tool-wide route alongside the correct request one. (Codex, PR #219.)
+    const toolRoute = TOOL_ENDPOINT_MAP[name]?.path;
+
     return runWithLogContext(
       {
         ...outer,
         call: randomUUID(),
         tool: name,
-        // The template, never the concrete path: this is what keeps a stack name or a
-        // container id out of every debug line the client below will write.
-        route: TOOL_ENDPOINT_MAP[name]?.path,
       },
       async () => {
-        log().info({ component: 'tools' }, 'start');
+        log().info({ component: 'tools', route: toolRoute }, 'start');
         try {
           const result = await callback(args);
-          log().info({ component: 'tools', ms: Date.now() - started }, 'ok');
+          log().info({ component: 'tools', route: toolRoute, ms: Date.now() - started }, 'ok');
           return result;
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';

--- a/tests/client-debug-logging.test.ts
+++ b/tests/client-debug-logging.test.ts
@@ -97,14 +97,26 @@ describe('client debug logging', () => {
     expect(serialised).not.toContain('paperless');
   });
 
-  it('falls back to a coarse template outside a tool context', async () => {
-    // Login and self-check calls run without a tool context, so there is no entry in
-    // TOOL_ENDPOINT_MAP to consult. Two segments is enough to tell auth from stacks
-    // and cannot contain an identifier.
+  it('matches a request to its own template regardless of tool context', async () => {
+    // The route now comes from matchRoute() reverse-matching THIS request's own
+    // pathname against the spec (src/openapi/match-route.ts) — not from a tool-scope
+    // context — so a request outside a tool context (login, self-check; here simulated
+    // by calling the client directly, with no runWithLogContext() wrapping it) still
+    // gets its own exact template, the same as a request made through a tool.
     const instance = await client();
     await instance.get('/api/stacks/paperless/env/raw');
 
-    expect(debugLines()[0].route).toBe('/api/stacks');
+    expect(debugLines()[0].route).toBe('/api/stacks/{name}/env/raw');
+  });
+
+  it('falls back to a coarse template for a pathname matching no known template', async () => {
+    // Two segments is enough to tell one area of the API from another and cannot
+    // contain an identifier — the fallback for a path the spec has no template for
+    // (a stale TOOL_ENDPOINT_MAP entry, or the spec being unavailable at runtime).
+    const instance = await client();
+    await instance.get('/api/does-not-exist/foo/bar');
+
+    expect(debugLines()[0].route).toBe('/api/does-not-exist');
   });
 
   it('says nothing at all at info level', async () => {
@@ -128,7 +140,7 @@ describe('client debug logging', () => {
 
     const [line] = debugLines();
     expect(line.level).toBe('warn');
-    expect(line.route).toBe('/api/stacks');
+    expect(line.route).toBe('/api/stacks/{name}/env/raw');
     expect(line.errType).toBe('TypeError');
     expect(JSON.stringify(line)).not.toContain('paperless');
   });
@@ -150,5 +162,28 @@ describe('client debug logging', () => {
     expect(lines).toHaveLength(2);
     expect(lines.map((l) => l.status)).toEqual([401, 200]);
     expect(lines[0].route).toBe(lines[1].route);
+  });
+
+  it('gives two calls to different endpoints two distinct, correct routes (Issue #214)', async () => {
+    // The bug this fixes: a tool that fans out to several endpoints (e.g.
+    // remove_stack_env_vars hitting both /env and /env/raw) used to log the SAME
+    // route — the tool's single TOOL_ENDPOINT_MAP entry — for every request it made,
+    // regardless of which endpoint actually got hit. Each request now derives its own
+    // route from its own pathname, so two calls to two different endpoints on the same
+    // client produce two distinct, individually-correct route values.
+    const instance = await client();
+    // The shared `beforeEach` mock resolves to a single Response instance; a second
+    // read of its already-consumed body throws, so each call needs its own instance.
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    await instance.get('/api/stacks/paperless/env');
+    await instance.get('/api/stacks/paperless/env/raw');
+
+    const lines = debugLines();
+    expect(lines).toHaveLength(2);
+    expect(lines[0]?.route).toBe('/api/stacks/{name}/env');
+    expect(lines[1]?.route).toBe('/api/stacks/{name}/env/raw');
+    expect(lines[0]?.route).not.toBe(lines[1]?.route);
   });
 });

--- a/tests/client-debug-logging.test.ts
+++ b/tests/client-debug-logging.test.ts
@@ -97,6 +97,31 @@ describe('client debug logging', () => {
     expect(serialised).not.toContain('paperless');
   });
 
+  it('emits exactly one route key inside a tool context — no stale tool-wide route (Codex #219)', async () => {
+    // The production path: a request made from inside a tool invocation. registerTool used
+    // to BIND the tool's single route into the log context, log() baked it into the pino
+    // child, and loggedFetch's own matched route did not replace it — pino serialized BOTH
+    // keys, so a fan-out line carried the stale tool-wide route alongside the correct one.
+    // JSON.parse silently keeps the last duplicate, which is exactly why the other tests in
+    // this file (which parse) never saw it — this one asserts on the RAW line.
+    const { runWithLogContext } = await import('../src/utils/log-context.js');
+    const instance = await client();
+    await runWithLogContext({ sid: 's', req: 'r', call: 'c', tool: 'remove_stack_env_vars' }, async () => {
+      await instance.get('/api/stacks/paperless/env/raw');
+    });
+
+    const clientLine = written
+      .join('')
+      .trim()
+      .split('\n')
+      .find((l) => l.includes('"component":"client"'));
+    expect(clientLine).toBeDefined();
+    // Exactly one "route" in the raw JSON — a duplicate is the bug.
+    expect((clientLine!.match(/"route"/g) ?? []).length).toBe(1);
+    // And it is the request's own matched template, not any tool-wide value.
+    expect((JSON.parse(clientLine!) as { route: string }).route).toBe('/api/stacks/{name}/env/raw');
+  });
+
   it('matches a request to its own template regardless of tool context', async () => {
     // The route now comes from matchRoute() reverse-matching THIS request's own
     // pathname against the spec (src/openapi/match-route.ts) — not from a tool-scope

--- a/tests/openapi/match-route.test.ts
+++ b/tests/openapi/match-route.test.ts
@@ -2,26 +2,44 @@ import { describe, it, expect } from 'vitest';
 import { matchRoute } from '../../src/openapi/match-route.js';
 
 /**
- * `matchRoute()` reverse-matches a concrete pathname against the KNOWN set of templates
- * in the pinned spec (`docs/dockhand-openapi.json`) — these tests run against that real
- * spec, not a mock, so a match here is evidence the fix works against what actually ships.
+ * `matchRoute()` reverse-matches a concrete request (method + pathname) against the KNOWN
+ * set of templates in the pinned spec (`docs/dockhand-openapi.json`) — these tests run
+ * against that real spec, not a mock, so a match here is evidence the fix works against
+ * what actually ships.
  */
 describe('matchRoute', () => {
   it('distinguishes /env from /env/raw — the core bug this fixes', () => {
     // remove_stack_env_vars hits both endpoints; before this fix both debug lines said
     // "…/env/raw" because the route came from the tool's single TOOL_ENDPOINT_MAP entry.
-    expect(matchRoute('/api/stacks/paperless/env/raw')).toBe('/api/stacks/{name}/env/raw');
-    expect(matchRoute('/api/stacks/paperless/env')).toBe('/api/stacks/{name}/env');
+    expect(matchRoute('/api/stacks/paperless/env/raw', 'GET')).toBe('/api/stacks/{name}/env/raw');
+    expect(matchRoute('/api/stacks/paperless/env', 'GET')).toBe('/api/stacks/{name}/env');
   });
 
   it('prefers the literal template over the parameterised one it also matches', () => {
-    // /api/stacks/adopt matches BOTH the literal /api/stacks/adopt and the parameterised
-    // /api/stacks/{name} (with {name} = "adopt"). The literal one must win.
-    expect(matchRoute('/api/stacks/adopt')).toBe('/api/stacks/adopt');
+    // POST /api/stacks/adopt matches BOTH the literal /api/stacks/adopt (which the spec
+    // defines for POST) and the parameterised /api/stacks/{name} (with {name} = "adopt").
+    // For the method the literal defines, the literal one wins.
+    expect(matchRoute('/api/stacks/adopt', 'POST')).toBe('/api/stacks/adopt');
+  });
+
+  /**
+   * METHOD DECIDES FIRST (Codex, PR #219). The pinned spec defines POST on the literal
+   * /api/stacks/adopt but DELETE only on /api/stacks/{name}. `delete_stack` acting on a
+   * stack literally named "adopt" sends DELETE /api/stacks/adopt — which must resolve to
+   * /api/stacks/{name} (where DELETE lives), NOT the literal /api/stacks/adopt (a
+   * nonexistent DELETE combination). A method-blind most-literal rule gets this wrong.
+   */
+  it('picks the template that actually defines the request method, not just the most literal one', () => {
+    expect(matchRoute('/api/stacks/adopt', 'DELETE')).toBe('/api/stacks/{name}');
+    // The same collision on images: POST /api/images/pull is the literal; DELETE is on
+    // /api/images/{id}. An image literally identified as "pull" under DELETE must resolve
+    // to the {id} template.
+    expect(matchRoute('/api/images/pull', 'DELETE')).toBe('/api/images/{id}');
+    expect(matchRoute('/api/images/pull', 'POST')).toBe('/api/images/pull');
   });
 
   it('returns undefined for a pathname that matches no known template', () => {
-    expect(matchRoute('/api/totally-unknown-endpoint/xyz')).toBeUndefined();
+    expect(matchRoute('/api/totally-unknown-endpoint/xyz', 'GET')).toBeUndefined();
   });
 
   /**
@@ -41,7 +59,7 @@ describe('matchRoute', () => {
    * `{name}` and the result to equal the template exactly, nothing else.
    */
   it('never leaks a caller value that collides with a template keyword (stack named "env")', () => {
-    const result = matchRoute('/api/stacks/env/env/raw');
+    const result = matchRoute('/api/stacks/env/env/raw', 'GET');
     expect(result).toBe('/api/stacks/{name}/env/raw');
     // Anchor the safety property explicitly, not just via toBe: the RETURNED string must
     // be the template, not the caller's own path re-emitted unchanged.

--- a/tests/openapi/match-route.test.ts
+++ b/tests/openapi/match-route.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { matchRoute } from '../../src/openapi/match-route.js';
+
+/**
+ * `matchRoute()` reverse-matches a concrete pathname against the KNOWN set of templates
+ * in the pinned spec (`docs/dockhand-openapi.json`) — these tests run against that real
+ * spec, not a mock, so a match here is evidence the fix works against what actually ships.
+ */
+describe('matchRoute', () => {
+  it('distinguishes /env from /env/raw — the core bug this fixes', () => {
+    // remove_stack_env_vars hits both endpoints; before this fix both debug lines said
+    // "…/env/raw" because the route came from the tool's single TOOL_ENDPOINT_MAP entry.
+    expect(matchRoute('/api/stacks/paperless/env/raw')).toBe('/api/stacks/{name}/env/raw');
+    expect(matchRoute('/api/stacks/paperless/env')).toBe('/api/stacks/{name}/env');
+  });
+
+  it('prefers the literal template over the parameterised one it also matches', () => {
+    // /api/stacks/adopt matches BOTH the literal /api/stacks/adopt and the parameterised
+    // /api/stacks/{name} (with {name} = "adopt"). The literal one must win.
+    expect(matchRoute('/api/stacks/adopt')).toBe('/api/stacks/adopt');
+  });
+
+  it('returns undefined for a pathname that matches no known template', () => {
+    expect(matchRoute('/api/totally-unknown-endpoint/xyz')).toBeUndefined();
+  });
+
+  /**
+   * SAFETY COUNTER-CHECK (the property this whole approach exists to guarantee): a stack
+   * literally named "env" must not leak through as a literal path segment. The pathname
+   * has an "env" segment TWICE — once as the caller's stack name (position 3, where the
+   * template has `{name}`) and once as the literal "env" sub-resource (position 4, where
+   * the template has the literal "env"). Only a matcher that compares by POSITION against
+   * the template — not by "is this word one I recognise as a keyword" — gets this right.
+   *
+   * A heuristic ("approach B", rejected by design) that instead walks segments and treats
+   * any segment matching a known route keyword (env, raw, stacks, ...) as literal
+   * regardless of position would treat BOTH "env" segments as the literal keyword and
+   * return the caller's own path unchanged (`/api/stacks/env/env/raw`) instead of
+   * substituting the first one for `{name}` — silently leaking the caller's stack name.
+   * This assertion is what would catch that: it requires the FIRST "env" to have become
+   * `{name}` and the result to equal the template exactly, nothing else.
+   */
+  it('never leaks a caller value that collides with a template keyword (stack named "env")', () => {
+    const result = matchRoute('/api/stacks/env/env/raw');
+    expect(result).toBe('/api/stacks/{name}/env/raw');
+    // Anchor the safety property explicitly, not just via toBe: the RETURNED string must
+    // be the template, not the caller's own path re-emitted unchanged.
+    expect(result).not.toBe('/api/stacks/env/env/raw');
+  });
+});

--- a/tests/tool-error-logging.test.ts
+++ b/tests/tool-error-logging.test.ts
@@ -102,6 +102,10 @@ describe('registerTool error logging', () => {
     // The shape that was actually being emitted, named explicitly so a return to it
     // cannot pass by satisfying the two assertions above through some other route.
     expect(line.err).toBeUndefined();
+    // The failed line must still carry the tool's endpoint (Codex #219): route stopped
+    // being a bound context field and is now added call-time on start/ok/failed — the
+    // catch path must not be the one that gets forgotten.
+    expect(line.route).toBe('/api/stacks');
   });
 
   it('logs "Unknown error" for a thrown non-Error value without crashing', async () => {


### PR DESCRIPTION
Closes #214. Follow-up from #209 (Codex P2).

## Problem
`loggedFetch` read `currentLogContext().route` — the calling **tool's** single `TOOL_ENDPOINT_MAP` entry — for every outbound request. A tool that fans out to several endpoints (e.g. `remove_stack_env_vars` hits both `/api/stacks/{name}/env` and `…/env/raw`) logged the *same* route for all of them, so when one call failed the debug line couldn't say which.

## Fix (approach A — reverse-match known templates; heuristic B rejected)
- `specPathTemplates()` (new, in `spec-loader.ts`) exposes the pinned OpenAPI spec's path-template keys, reusing the existing `loadSpec()` cache.
- `src/openapi/match-route.ts` — `matchRoute(pathname)` reverse-matches the concrete pathname against those templates: bucket by segment count, a segment matches literal-or-`{placeholder}`, **most-literal-wins** (so `/api/stacks/adopt` → itself, not `/api/stacks/{name}`). It returns **only** a known template string — structurally it can never emit a caller value, the same safety property the old context route had.
- `loggedFetch` now derives `route = matchRoute(parsed.pathname) ?? coarseRoute(parsed.pathname)` per request and no longer reads the tool context. `coarseRoute` stays as the fallback (unmatched path / spec unavailable).

## Safety
Counter-checked: a stack literally named `env` (`/api/stacks/env/env/raw`) yields the **template** `/api/stacks/{name}/env/raw` — the caller's `env` rendered as `{name}`, never leaked. The existing "never writes the concrete path" assertion (`not.toContain('paperless')`) is unchanged and still runs.

## Tests
New `tests/openapi/match-route.test.ts` (distinct-endpoints, literal precedence against a real spec collision, env-collision safety, unmatched→undefined). Full suite 1108 green, `tsc` clean.

**Flagged judgment call:** two pre-existing `client-debug-logging.test.ts` tests were *rewritten* (not just adjusted) because the matcher now works outside tool context, making the old "with/without tool context differs" scenario unreachable by construction. Independent review confirmed no assertion was weakened and `coarseRoute` fallback coverage was re-added via a new, better-fitting test.

_Repo has no `lint` script; CI gates typecheck/test/build, all green._