### PR TITLE
chore(api): bump pinned Dockhand OpenAPI to v1.0.43

### DIFF
--- a/docs/dockhand-openapi.json
+++ b/docs/dockhand-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Dockhand API",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "description": "Auto-generated from src/routes/**/+server.ts by scripts/generate-openapi.ts. Path, HTTP method, tag, and auth requirement are derived automatically from the route tree and hooks.server.ts PUBLIC_PATHS. Parameters, response status codes, and request body fields are additionally auto-detected from each handler’s own source (query params via url.searchParams, status codes via status:/error(), body fields via destructuring) — adding a new endpoint therefore requires ZERO manual spec edits to show up with real params/responses. An optional, additive `@openapi` JSDoc annotation on a handler replaces the generic auto-descriptions with hand-written summaries, exact types, and examples."
   },
   "servers": [
@@ -7329,7 +7329,30 @@
             "bearerAuth": []
           }
         ],
-        "description": "Send `multipart/form-data` with one or more `files` parts; each file is tar-wrapped and written into the target directory. Partial success is reported per file in `uploaded`/`errors`."
+        "description": "Send `multipart/form-data` with one or more `files` parts; each file is tar-wrapped and written into the target directory. Partial success is reported per file in `uploaded`/`errors`.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    },
+                    "description": "One or more files to write into the target directory"
+                  }
+                },
+                "required": [
+                  "files"
+                ]
+              }
+            }
+          }
+        }
       }
     },
     "/api/containers/{id}/inspect": {
@@ -8627,6 +8650,9 @@
                     },
                     "source": {
                       "type": "string"
+                    },
+                    "rateLimited": {
+                      "type": "boolean"
                     },
                     "notes": {
                       "type": "array",
@@ -11923,18 +11949,6 @@
                   },
                   "vulnerabilityCriteria": {
                     "type": "string"
-                  },
-                  "checkPinnedVersions": {
-                    "type": "boolean"
-                  },
-                  "semverMaxBump": {
-                    "type": "string"
-                  },
-                  "semverMatchFlavor": {
-                    "type": "boolean"
-                  },
-                  "semverIncludePrerelease": {
-                    "type": "boolean"
                   }
                 }
               },
@@ -11942,11 +11956,7 @@
                 "enabled": true,
                 "cron": "0 4 * * *",
                 "autoUpdate": false,
-                "vulnerabilityCriteria": "never",
-                "checkPinnedVersions": true,
-                "semverMaxBump": "minor",
-                "semverMatchFlavor": true,
-                "semverIncludePrerelease": false
+                "vulnerabilityCriteria": "never"
               }
             }
           }
@@ -15491,7 +15501,19 @@
             "bearerAuth": []
           }
         ],
-        "description": "The request body is the raw image tar (Content-Type application/x-tar), streamed straight to the daemon without buffering. Local/socket or direct TCP only; Hawser is rejected."
+        "description": "The request body is the raw image tar (Content-Type application/x-tar), streamed straight to the daemon without buffering. Local/socket or direct TCP only; Hawser is rejected.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-tar": {
+              "schema": {
+                "type": "string",
+                "format": "binary",
+                "description": "The raw image tar, streamed to the daemon (docker load)"
+              }
+            }
+          }
+        }
       }
     },
     "/api/images/pull": {
@@ -23447,6 +23469,134 @@
         ]
       }
     },
+    "/api/settings/semver": {
+      "get": {
+        "operationId": "get_api_settings_semver",
+        "tags": [
+          "settings"
+        ],
+        "summary": "Get the global newer-version-tag (semver) detection config",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "maxBump": {
+                      "type": "string"
+                    },
+                    "matchFlavor": {
+                      "type": "boolean"
+                    },
+                    "includePrerelease": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "enabled",
+                    "maxBump",
+                    "matchFlavor",
+                    "includePrerelease"
+                  ]
+                },
+                "example": {
+                  "enabled": true,
+                  "maxBump": "minor",
+                  "matchFlavor": true,
+                  "includePrerelease": false
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "post": {
+        "operationId": "post_api_settings_semver",
+        "tags": [
+          "settings"
+        ],
+        "summary": "Set the global newer-version-tag (semver) detection config",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                },
+                "example": {
+                  "success": true
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Permission denied (needs settings:edit)"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "maxBump": {
+                    "type": "string"
+                  },
+                  "matchFlavor": {
+                    "type": "boolean"
+                  },
+                  "includePrerelease": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "example": {
+                "enabled": true,
+                "maxBump": "minor",
+                "matchFlavor": true,
+                "includePrerelease": false
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/settings/theme": {
       "get": {
         "operationId": "get_api_settings_theme",
@@ -24992,6 +25142,178 @@
             "bearerAuth": []
           }
         ]
+      }
+    },
+    "/api/stacks/{name}/validate": {
+      "post": {
+        "operationId": "post_api_stacks_name_validate",
+        "tags": [
+          "stacks"
+        ],
+        "summary": "Run the Compose Validate preflight linter on a compose file and return findings with severities and line numbers (requires the 'view' permission)",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Stack name (used to exclude the stack's own containers from cross-stack collision checks)"
+          },
+          {
+            "name": "env",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Environment ID for the context-aware checks (from GET /api/environments)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "findings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "ruleId": {
+                            "type": "string"
+                          },
+                          "severity": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "hint": {
+                            "type": "string"
+                          },
+                          "service": {
+                            "type": "string"
+                          },
+                          "line": {
+                            "type": "integer"
+                          },
+                          "fix": {
+                            "type": "string"
+                          },
+                          "fixDescription": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "ruleId",
+                          "severity",
+                          "message"
+                        ]
+                      }
+                    },
+                    "counts": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "integer"
+                        },
+                        "warn": {
+                          "type": "integer"
+                        },
+                        "info": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "warn",
+                        "info"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "findings",
+                    "counts"
+                  ]
+                },
+                "example": {
+                  "findings": [
+                    {
+                      "ruleId": "LATEST_TAG",
+                      "severity": "warn",
+                      "message": "\"web\" uses `:latest` (nginx:latest)",
+                      "hint": "Pin a version tag for reproducible deploys and to enable newer-version detection.",
+                      "service": "web",
+                      "line": 3
+                    }
+                  ],
+                  "counts": {
+                    "error": 0,
+                    "warn": 1,
+                    "info": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "compose content is required"
+          },
+          "403": {
+            "description": "Permission denied"
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          },
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "compose": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "properties": {
+                      "disabled": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "severity": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "envVars": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "compose"
+                ]
+              },
+              "example": {
+                "compose": "services:\n  web:\n    image: nginx:latest\n    ports: [\"8080:80\"]\n"
+              }
+            }
+          }
+        }
       }
     },
     "/api/stacks/adopt": {

--- a/scripts/fetch-openapi.mjs
+++ b/scripts/fetch-openapi.mjs
@@ -52,7 +52,7 @@ const PROJECT_ROOT = resolve(__dirname, '..');
 // Schritt, nicht "immer der aktuelle Branch-Head".
 const SOURCE_REPO = 'https://github.com/Finsys/dockhand.git';
 const SOURCE_BRANCH = 'main';
-const SOURCE_COMMIT = 'da26f7f764563a35dacc970cc0196e6aa7828384';
+const SOURCE_COMMIT = 'a485c8580b083614a5e11f78b76d0e1a7173d12e';
 
 // Die vom Maintainer MITGELIEFERTE Spec -- nicht mehr selbst generiert.
 //

--- a/src/openapi/pinned.ts
+++ b/src/openapi/pinned.ts
@@ -9,4 +9,4 @@
  * `SOURCE_COMMIT` — update both together whenever the pinned commit changes.
  */
 
-export const PINNED_DOCKHAND_OPENAPI_COMMIT = 'da26f7f764563a35dacc970cc0196e6aa7828384';
+export const PINNED_DOCKHAND_OPENAPI_COMMIT = 'a485c8580b083614a5e11f78b76d0e1a7173d12e';

--- a/tests/spec-loader.test.ts
+++ b/tests/spec-loader.test.ts
@@ -42,9 +42,9 @@ describe('specOperation', () => {
 describe('specInfoVersion', () => {
   it("returns the real spec's info.version (used by get_tool_manifest, src/tools/meta.ts)", () => {
     // Same committed spec every other test in this file resolves operations against
-    // (docs/dockhand-openapi.json) — its info.version is currently "1.0.42". Re-pin this
+    // (docs/dockhand-openapi.json) — its info.version is currently "1.0.43". Re-pin this
     // literal whenever scripts/fetch-openapi.mjs (SOURCE_COMMIT) is bumped, same as
     // PINNED_DOCKHAND_OPENAPI_COMMIT in src/openapi/pinned.ts.
-    expect(specInfoVersion()).toBe('1.0.42');
+    expect(specInfoVersion()).toBe('1.0.43');
   });
 });


### PR DESCRIPTION
## Summary

Data-only refresh: bumps the pinned Dockhand OpenAPI source commit from
v1.0.42 to **v1.0.43** (`da26f7f` -> `a485c858`, verified against the
upstream `v1.0.43` tag) and regenerates `docs/dockhand-openapi.json`
(`info.version`: 1.0.42 -> 1.0.43). No tool logic changed.

## Spec delta (v1.0.42 -> v1.0.43, 247 -> 249 paths)

**New endpoints (not wrapped by any tool yet — candidates for future tools):**
- `POST /api/stacks/{name}/validate` — runs the Compose Validate preflight
  linter on a compose file, returns findings with severity/line numbers.
- `GET`/`POST /api/settings/semver` — global newer-version-tag (semver)
  detection config.

**4 existing paths gained/lost schema detail (none gate-relevant):**
- `POST /api/containers/{id}/files/upload`, `POST /api/images/load` — now
  formally declare the request bodies they already expect (multipart
  files / raw tar); no behavior change for the tools that already send them.
- `GET /api/containers/{id}/version-notes` — response gained an additive
  `rateLimited: boolean` field.
- `GET`/`PUT /api/environments/{id}/update-check` — lost
  `checkPinnedVersions`/`semverIncludePrerelease`/`semverMatchFlavor`/
  `semverMaxBump` (relocated to the new `/api/settings/semver` endpoint).
  Grepped the codebase — no tool ever referenced these fields, so no fallout.

## Gate / test status

- `npm run api:validate`: **GREEN**, unaffected by the bump. COVERED 295,
  MISSING_TOOL 36, ORPHANED_TOOL/PARAM_MISMATCH/MISSING_ENCODE/
  QUERY_PARAM_MISSING_REQUIRED/QUERY_PARAM_UNKNOWN/BODY_PARAM_MISSING_REQUIRED
  all 0, BODY_FINDINGS 92 (informative), CROSSREF_UNRESOLVED 22 (informative)
  — every count and the full `validation-report.md` body are byte-identical
  to the pre-bump run (only the generation timestamp differs). The two new
  paths don't move `MISSING_TOOL` because that count is driven by the
  separately unpinned `docs/dockhand-api-schema.json`, refreshed on its own
  schedule by `.github/workflows/api-schema-sync.yml` — not by this pin.
- `npm test`: 94 files, **1120 tests, all green**. Retargeted
  `tests/spec-loader.test.ts`'s hardcoded `info.version` literal from
  `1.0.42` to `1.0.43`, per that test's own inline comment instructing this
  on every bump (same pattern as the prior 1.0.42 bump, commit `d170dbf`).
- `npm run typecheck` and `typecheck:tests`: clean.

## Scope note

`docs/dockhand-api-schema.json` was deliberately **not** regenerated here.
It tracks unpinned upstream `main` HEAD via `scripts/extract-dockhand-api.mjs`
and is refreshed independently by a scheduled CI workflow
(`api-schema-sync.yml`) — regenerating it in this PR would have pulled in
unrelated upstream drift beyond the v1.0.43 tag and conflated two
independently-versioned artifacts.

## Test plan

- [x] `PINNED_DOCKHAND_OPENAPI_COMMIT` (`src/openapi/pinned.ts`) and
      `SOURCE_COMMIT` (`scripts/fetch-openapi.mjs`) both point at
      `a485c8580b083614a5e11f78b76d0e1a7173d12e` (verified == upstream
      `v1.0.43` tag via `git ls-remote`)
- [x] `docs/dockhand-openapi.json` `info.version` == `1.0.43`
- [x] `npm run api:validate` exits 0, no new hard-gate findings
- [x] `npm test` green (1120/1120)
- [x] `npm run typecheck` / `typecheck:tests` clean
