### PR TITLE
fix(environments): stop leaking hawserToken and tlsKey in environment responses

### DIFF
--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -10,7 +10,7 @@
 > hartes Gate in `scripts/validate-mcp-tools.mjs` (Exit 1 + Auto-Issue) — hier weiterhin nur
 > zur Übersicht gelistet. Die übrigen drei Typen bleiben vollständig advisory.
 
-**Erzeugt:** 2026-08-17T20:01:17.811Z
+**Erzeugt:** 2026-08-26T08:56:14.633Z
 
 ## Zusammenfassung
 
@@ -31,12 +31,12 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:494 |
 | `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:494 |
 | `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:494 |
-| `create_environment` | POST | `/api/environments` | `url` | environments.ts:93 |
+| `create_environment` | POST | `/api/environments` | `url` | environments.ts:157 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:419 |
 | `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:427 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
-| `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:161 |
+| `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:225 |
 
 ## UNTYPED_PASSTHROUGH (46)
 
@@ -46,7 +46,7 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 |------|------|------|------|-------|
 | `create_config_set` | POST | `/api/config-sets` | `name` | users.ts:281 |
 | `create_container` | POST | `/api/containers` | `name`, `image` | containers.ts:284 |
-| `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | `notificationId` | environments.ts:253 |
+| `create_environment_notification` | POST | `/api/environments/{environmentId}/notifications` | `notificationId` | environments.ts:317 |
 | `create_git_credential` | POST | `/api/git/credentials` | `name` | git-stacks.ts:98 |
 | `create_git_stack` | POST | `/api/git/stacks` | `stackName` | git-stacks.ts:234 |
 | `create_ldap_provider` | POST | `/api/auth/ldap` | `name`, `serverUrl`, `baseDn` | auth.ts:65 |
@@ -60,8 +60,8 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `create_template_source` | POST | `/api/templates/sources` | `name`, `url` | templates.ts:41 |
 | `create_volume` | POST | `/api/volumes` | `name` | volumes.ts:116 |
 | `set_dashboard_preferences` | POST | `/api/dashboard/preferences` | - | dashboard.ts:29 |
-| `set_environment_image_prune` | POST | `/api/environments/{environmentId}/image-prune` | - | environments.ts:236 |
-| `set_environment_update_check` | POST | `/api/environments/{environmentId}/update-check` | - | environments.ts:219 |
+| `set_environment_image_prune` | POST | `/api/environments/{environmentId}/image-prune` | - | environments.ts:300 |
+| `set_environment_update_check` | POST | `/api/environments/{environmentId}/update-check` | - | environments.ts:283 |
 | `set_grid_preferences` | POST | `/api/preferences/grid` | `gridId` | users.ts:263 |
 | `set_sidebar_preferences` | POST | `/api/preferences/sidebar` | `order`, `hidden` | preferences.ts:24 |
 | `test_notification_config` | POST | `/api/notifications/test` | `type` | notifications.ts:65 |
@@ -72,8 +72,8 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `update_config_set` | PUT | `/api/config-sets/{configSetId}` | - | users.ts:298 |
 | `update_container` | POST | `/api/containers/{containerId}/update` | - | containers.ts:255 |
 | `update_container_runtime` | POST | `/api/containers/{containerId}/update-runtime` | - | containers.ts:522 |
-| `update_environment` | PUT | `/api/environments/{environmentId}` | - | environments.ts:133 |
-| `update_environment_notification` | PUT | `/api/environments/{environmentId}/notifications/{notificationId}` | - | environments.ts:284 |
+| `update_environment` | PUT | `/api/environments/{environmentId}` | - | environments.ts:197 |
+| `update_environment_notification` | PUT | `/api/environments/{environmentId}/notifications/{notificationId}` | - | environments.ts:348 |
 | `update_general_settings` | POST | `/api/settings/general` | - | system.ts:97 |
 | `update_git_credential` | PUT | `/api/git/credentials/{credentialId}` | - | git-stacks.ts:129 |
 | `update_git_repository` | PUT | `/api/git/repositories/{repositoryId}` | - | git-stacks.ts:280 |
@@ -121,7 +121,7 @@ Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehl
 | `stop_stack` | POST | `/api/stacks/{name}/stop` | - | stacks.ts:68 |
 | `sync_git_repository` | POST | `/api/git/repositories/{repositoryId}/sync` | - | git-stacks.ts:181 |
 | `sync_git_stack` | POST | `/api/git/stacks/{stackId}/sync` | - | git-stacks.ts:37 |
-| `test_environment` | POST | `/api/environments/{environmentId}/test` | - | environments.ts:147 |
+| `test_environment` | POST | `/api/environments/{environmentId}/test` | - | environments.ts:211 |
 | `test_git_repository` | POST | `/api/git/repositories/{repositoryId}/test` | - | git-stacks.ts:188 |
 | `test_git_stack` | POST | `/api/git/stacks/{stackId}/test` | - | git-stacks.ts:44 |
 | `test_ldap_provider` | POST | `/api/auth/ldap/{providerId}/test` | - | auth.ts:79 |
@@ -129,7 +129,7 @@ Für diesen body-tragenden Endpunkt liegt (noch) kein OpenAPI-Contract vor (fehl
 | `test_oidc_provider` | POST | `/api/auth/oidc/{providerId}/test` | - | auth.ts:51 |
 | `toggle_schedule` | POST | `/api/schedules/{type}/{scheduleId}/toggle` | - | schedules.ts:66 |
 | `toggle_system_schedule` | POST | `/api/schedules/system/{scheduleId}/toggle` | - | schedules.ts:73 |
-| `trigger_environment_image_prune` | PUT | `/api/environments/{environmentId}/image-prune` | - | environments.ts:293 |
+| `trigger_environment_image_prune` | PUT | `/api/environments/{environmentId}/image-prune` | - | environments.ts:357 |
 | `unpause_container` | POST | `/api/containers/{containerId}/unpause` | - | containers.ts:194 |
 | `upload_container_file` | POST | `/api/containers/{containerId}/files/upload` | - | containers.ts:412 |
 

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -9,6 +9,70 @@ import { registerTool, jsonResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
 
 /**
+ * Field names on a Dockhand environment payload that a routine lookup must never hand
+ * back (Issue #232):
+ *   - `hawserToken` — the agent token a node uses to register itself over the Dockhand
+ *     WebSocket. Dedicated tools already own issuing/inspecting it (list_hawser_tokens /
+ *     create_hawser_token / revoke_hawser_token, src/tools/auth.ts).
+ *   - `tlsKey` — the decrypted private TLS client key, for `direct`/`hawser-standard`
+ *     environments configured with mutual TLS. The heavier of the two: a private key,
+ *     not a revocable node token.
+ *
+ * Both are decrypted at the data-access layer and land in the row returned to every
+ * caller — verified against the real upstream code (Finsys/dockhand v1.0.44,
+ * src/lib/server/db.ts): getEnvironments()/getEnvironment()/createEnvironment() all
+ * `decrypt(e.tlsKey)` and `decrypt(e.hawserToken)` before returning, and
+ * updateEnvironment() ends by calling getEnvironment() (same decryption). This is NOT a
+ * deliberate response shape: every sibling credential-bearing endpoint (registries,
+ * LDAP, OIDC) explicitly strips its secret before responding in its own route handler
+ * (`const { password, ...safeRegistry } = registry`, a `sanitized` object for LDAP/OIDC
+ * configs) — only the environments routes spread the row as-is. Whoever reads this in a
+ * year: this list is a fix for an oversight, not curation of an endpoint that answers
+ * this way on purpose.
+ *
+ * Deliberately an explicit list, not a heuristic over field names: a pattern like
+ * /token|secret|key/i would also catch a field like `tokenCount`, and a false positive
+ * here silently drops data a caller needs. The trade-off is that this list is NOT
+ * notified when Dockhand adds a new credential field upstream — extend it here if
+ * one more shows up (checked at the time of writing: tlsCa/tlsCert are the public CA
+ * and client certificate, never encrypted/decrypted in db.ts, so they are not secrets
+ * and are intentionally left out).
+ *
+ * Also applied to create_environment/update_environment: verified against the real
+ * upstream handlers (Finsys/dockhand v1.0.44, src/routes/api/environments/+server.ts
+ * and src/routes/api/environments/[id]/+server.ts) that POST and PUT both respond with
+ * `json(env)` / `{ ...env, ... }` — the same full DB row as GET, both fields included.
+ * test_environment and test_environment_connection do NOT need this: both build a
+ * curated `{ success, info, isEdgeMode, hawser: {...} }` object by hand and never
+ * spread the environment row (verified against the same handlers).
+ */
+const ENVIRONMENT_CREDENTIAL_FIELDS = ['hawserToken', 'tlsKey'] as const;
+
+/**
+ * Returns a shallow copy of a single environment object with every field in
+ * ENVIRONMENT_CREDENTIAL_FIELDS removed. Every other field passes through unchanged.
+ * Non-object input (defensive — the Dockhand API is expected to always answer with an
+ * object here) is returned as-is rather than thrown on.
+ */
+function stripEnvironmentCredentials(env: unknown): unknown {
+  if (typeof env !== 'object' || env === null) return env;
+  const copy = { ...(env as Record<string, unknown>) };
+  for (const field of ENVIRONMENT_CREDENTIAL_FIELDS) {
+    delete copy[field];
+  }
+  return copy;
+}
+
+/**
+ * Applies stripEnvironmentCredentials across a list_environments payload (an array of
+ * environment objects). Non-array input is returned as-is, defensively.
+ */
+function stripEnvironmentListCredentials(payload: unknown): unknown {
+  if (!Array.isArray(payload)) return payload;
+  return payload.map(stripEnvironmentCredentials);
+}
+
+/**
  * Resolve host/port from explicit args or a URL string into the request body.
  * Only applies to hawser-standard connections — other types ignore host/port.
  *
@@ -68,14 +132,14 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
   registerTool(server, 'list_environments',
     {},
     async () => {
-      return jsonResponse(await client.get('/api/environments'));
+      return jsonResponse(stripEnvironmentListCredentials(await client.get('/api/environments')));
     }
   );
 
   registerTool(server, 'get_environment',
     { environmentId: z.number().describe('Environment ID') },
     async ({ environmentId }) => {
-      return jsonResponse(await client.get(`/api/environments/${encodePath(environmentId)}`));
+      return jsonResponse(stripEnvironmentCredentials(await client.get(`/api/environments/${encodePath(environmentId)}`)));
     }
   );
 
@@ -90,7 +154,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
     async ({ name, connectionType, host, port, url }) => {
       const body: Record<string, unknown> = { name, connectionType };
       resolveHostPort(body, { host, port, url }, connectionType, true);
-      return jsonResponse(await client.post('/api/environments', body));
+      return jsonResponse(stripEnvironmentCredentials(await client.post('/api/environments', body)));
     }
   );
 
@@ -130,7 +194,7 @@ export function registerEnvironmentTools(server: McpServer, client: DockhandClie
       if (highlightChanges !== undefined) body.highlightChanges = highlightChanges;
       if (socketPath !== undefined) body.socketPath = socketPath;
       resolveHostPort(body, { host, port, url }, resolvedConnectionType, false);
-      return jsonResponse(await client.put(`/api/environments/${encodePath(environmentId)}`, body));
+      return jsonResponse(stripEnvironmentCredentials(await client.put(`/api/environments/${encodePath(environmentId)}`, body)));
     }
   );
 

--- a/tests/environment-credential-leak.test.ts
+++ b/tests/environment-credential-leak.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression cover for Issue #232.
+ *
+ * list_environments and get_environment used to hand back the Dockhand API response
+ * verbatim. That response carries two credential fields per environment:
+ *   - `hawserToken` — the agent token a node uses to register itself over the Dockhand
+ *     WebSocket. Neither tool exists to hand it out: list_hawser_tokens /
+ *     create_hawser_token / revoke_hawser_token already own that job (src/tools/auth.ts).
+ *   - `tlsKey` — the decrypted private TLS client key for direct/hawser-standard
+ *     environments configured with mutual TLS. Heavier than a node token: a private key.
+ * Dropping both fields is curation of what a routine lookup tool returns, not
+ * concealment — see the full rationale in the issue.
+ *
+ * create_environment and update_environment are covered here too, beyond the issue's
+ * named scope: reading the real upstream handlers (Finsys/dockhand v1.0.44) while
+ * fixing this showed both POST and PUT respond with the identical `{ ...env, ... }`
+ * spread as GET — same leak, same fix. test_environment/test_environment_connection
+ * were checked the same way and do NOT need it: both build a curated response object
+ * by hand and never spread the environment row.
+ *
+ * Two fixtures are used deliberately:
+ *   - one WITH hawserToken present, to prove the field is actually removed rather than
+ *     "never was in this fixture" (a fixture missing the field would pass trivially and
+ *     prove nothing — see the mutation-testing guidance in
+ *     .claude/rules/test-coverage-pflicht.md in homelab-management),
+ *   - fields named similarly (`tokenCount`) to guard against a future regex-based
+ *     implementation (`/token|secret/i`) that the issue explicitly warns against: an
+ *     explicit field list must leave lookalike fields untouched.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { registerEnvironmentTools } from '../src/tools/environments.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { type: 'text'; text: string }[] }>;
+
+interface MockClient {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Registers the environment tools against a fake MCP server that captures each tool's
+ * (already error-wrapped) handler by name, plus a mocked client — same pattern as
+ * tests/stack-env-merge-behavior.test.ts.
+ */
+function setup(): { handlers: Map<string, ToolHandler>; client: MockClient } {
+  const handlers = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, cb: ToolHandler) => {
+      handlers.set(name, cb);
+    },
+  };
+  const client: MockClient = { get: vi.fn(), post: vi.fn(), put: vi.fn() };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerEnvironmentTools(server as any, client as any);
+  return { handlers, client };
+}
+
+function jsonOut(res: { content: { text: string }[] }): unknown {
+  return JSON.parse(res.content[0]!.text);
+}
+
+/**
+ * One environment as Dockhand's API actually returns it — both credential fields
+ * included. `tlsKey` is a plain placeholder string, deliberately NOT a real or
+ * PEM-shaped value: a fixture that looks like a real private key would read as a
+ * genuine finding in a future secret scan and cost someone an hour chasing it down.
+ */
+function envFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    name: 'hhdocker01',
+    connectionType: 'hawser-standard',
+    host: '100.100.50.40',
+    port: 2376,
+    icon: 'server',
+    tokenCount: 3, // lookalike field name — must survive an explicit-field-list fix
+    hawserToken: 'hawser-secret-value-should-never-leave-this-tool',
+    tlsKey: 'not-a-real-key',
+    ...overrides,
+  };
+}
+
+describe('list_environments strips hawserToken (Issue #232)', () => {
+  it('removes hawserToken from every entry, keeps every other field intact', async () => {
+    const { handlers, client } = setup();
+    const handler = handlers.get('list_environments');
+    if (!handler) throw new Error('list_environments handler was not registered');
+
+    const fixture = [
+      envFixture({ id: 1, name: 'hhdocker01' }),
+      envFixture({ id: 2, name: 'hhdocker02', hawserToken: 'a-different-secret-value' }),
+    ];
+    client.get.mockResolvedValue(fixture);
+
+    const out = jsonOut(await handler({})) as Record<string, unknown>[];
+
+    expect(client.get).toHaveBeenCalledWith('/api/environments');
+    expect(out).toHaveLength(2);
+    for (const env of out) {
+      expect(env).not.toHaveProperty('hawserToken');
+      expect(env).not.toHaveProperty('tlsKey');
+    }
+    // Every other field survives untouched, including the lookalike `tokenCount`.
+    expect(out[0]).toEqual({
+      id: 1,
+      name: 'hhdocker01',
+      connectionType: 'hawser-standard',
+      host: '100.100.50.40',
+      port: 2376,
+      icon: 'server',
+      tokenCount: 3,
+    });
+    expect(out[1]).toMatchObject({ id: 2, name: 'hhdocker02', tokenCount: 3 });
+  });
+
+  it('passes through a non-array payload unchanged in shape (defensive, no crash)', async () => {
+    const { handlers, client } = setup();
+    const handler = handlers.get('list_environments');
+    if (!handler) throw new Error('list_environments handler was not registered');
+
+    client.get.mockResolvedValue(null);
+
+    const out = jsonOut(await handler({}));
+    expect(out).toBeNull();
+  });
+});
+
+describe('get_environment strips hawserToken (Issue #232)', () => {
+  it('removes hawserToken from the single environment object, keeps every other field', async () => {
+    const { handlers, client } = setup();
+    const handler = handlers.get('get_environment');
+    if (!handler) throw new Error('get_environment handler was not registered');
+
+    client.get.mockResolvedValue(envFixture());
+
+    const out = jsonOut(await handler({ environmentId: 1 })) as Record<string, unknown>;
+
+    expect(client.get).toHaveBeenCalledWith('/api/environments/1');
+    expect(out).not.toHaveProperty('hawserToken');
+    expect(out).not.toHaveProperty('tlsKey');
+    expect(out).toEqual({
+      id: 1,
+      name: 'hhdocker01',
+      connectionType: 'hawser-standard',
+      host: '100.100.50.40',
+      port: 2376,
+      icon: 'server',
+      tokenCount: 3,
+    });
+  });
+});
+
+describe('create_environment strips hawserToken (Issue #232 follow-on)', () => {
+  it('removes hawserToken from the created environment, keeps every other field', async () => {
+    const { handlers, client } = setup();
+    const handler = handlers.get('create_environment');
+    if (!handler) throw new Error('create_environment handler was not registered');
+    client.post.mockResolvedValue(envFixture({ id: 3, name: 'hhdocker03' }));
+
+    const out = jsonOut(
+      await handler({ name: 'hhdocker03', connectionType: 'hawser-standard' }),
+    ) as Record<string, unknown>;
+
+    expect(out).not.toHaveProperty('hawserToken');
+    expect(out).not.toHaveProperty('tlsKey');
+    expect(out).toEqual({
+      id: 3,
+      name: 'hhdocker03',
+      connectionType: 'hawser-standard',
+      host: '100.100.50.40',
+      port: 2376,
+      icon: 'server',
+      tokenCount: 3,
+    });
+  });
+});
+
+describe('update_environment strips hawserToken (Issue #232 follow-on)', () => {
+  it('removes hawserToken from the updated environment, keeps every other field', async () => {
+    const { handlers, client } = setup();
+    const handler = handlers.get('update_environment');
+    if (!handler) throw new Error('update_environment handler was not registered');
+    client.put.mockResolvedValue(envFixture({ name: 'renamed' }));
+
+    // connectionType passed explicitly so the internal GET (used to resolve it when
+    // omitted) is skipped — irrelevant to this leak, kept out of the test.
+    const out = jsonOut(
+      await handler({ environmentId: 1, name: 'renamed', connectionType: 'hawser-standard' }),
+    ) as Record<string, unknown>;
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(out).not.toHaveProperty('hawserToken');
+    expect(out).not.toHaveProperty('tlsKey');
+    expect(out).toEqual({
+      id: 1,
+      name: 'renamed',
+      connectionType: 'hawser-standard',
+      host: '100.100.50.40',
+      port: 2376,
+      icon: 'server',
+      tokenCount: 3,
+    });
+  });
+});


### PR DESCRIPTION
Closes #232

## What

`list_environments`, `get_environment`, `create_environment` and `update_environment` no longer
return `hawserToken` (node agent token) or `tlsKey` (decrypted private TLS client key). Every other
field passes through unchanged.

## Why this is a fix, not curation

Every comparable Dockhand endpoint already strips its secrets in the route handler — registries
(`const { password, ...safeRegistry }`), git credentials (`hasPassword`/`hasSshKey`), LDAP and OIDC
(`'********'`), secret providers (`redactProviderConfig`), auth and hawser tokens (value never read
from the DB), profile and users (`passwordHash` never picked).

Eleven endpoints checked against the upstream source. **Only the environments routes spread the row
as-is.** This is an oversight, not an endpoint that answers this way on purpose — the code comment
says so, for whoever reads it in a year.

## Scope grew beyond the issue

The issue named two tools. Two more turned out to hit the same upstream handlers: `POST` and `PUT`
on `/api/environments` respond with the same full row as `GET`. Verified against
`Finsys/dockhand` v1.0.44, not against our own schema.

`test_environment` and `test_environment_connection` do **not** need this — both assemble a curated
result object by hand and never spread the row. Also verified in the handlers, so the exclusion is
a finding rather than an omission.

## Design

An explicit field list, not a pattern over field names. A heuristic like `/token|secret|key/i`
would also catch `tokenCount`, and a false positive here silently drops data a caller needs — a
test asserts that a `tokenCount` lookalike survives.

The trade-off is that an explicit list is not notified when a new credential field appears
upstream. That limitation is written at the list rather than left to be assumed.

`tlsCa` and `tlsCert` are deliberately **not** in the list: they are the public CA and client
certificate, never encrypted or decrypted in `db.ts`.

## Verified

- Mutation check run twice. First against the two original call sites: 2 of 3 tests went red for
  `hawserToken` reappearing, and the defensive non-array case correctly stayed green because it
  does not test stripping. Then with the field list emptied entirely: 4 of 5 red, each naming the
  reappearing field. Restored after both.
- `npm run typecheck`, `typecheck:tests`, `build`, `vitest run` (95 files, 1125 tests), `lint` —
  all green. The one lint warning is pre-existing and unrelated.
- Test fixtures use an obviously invented placeholder for the key (`not-a-real-key`), never
  anything PEM-shaped — a realistic-looking private key in a repository costs someone an hour in
  the next secret scan.

## Upstream

The real defect is in Dockhand, where the pattern is already established everywhere else. Worth
reporting there so the fix protects every client rather than just this wrapper. This PR is the
stopgap.
