### PR TITLE
Guard malformed env response + auto-track MISSING_TOOL coverage

### DIFF
--- a/.github/workflows/api-schema-sync.yml
+++ b/.github/workflows/api-schema-sync.yml
@@ -109,6 +109,144 @@ jobs:
             echo "docs/coverage.md unverändert — kein Commit"
           fi
 
+      - name: Coverage tracker summary
+        # #227 Part 2 -- reuses the SAME computeValidation() numbers docs/coverage.md
+        # was just (re)generated from above, so the tracker issue below can never
+        # disagree with the committed report. See scripts/coverage-tracker-summary.mjs
+        # for why this can't be a github-script step directly (needs the schema/tool
+        # loading machinery, not just GitHub API access).
+        id: coverage-tracker
+        if: always()
+        run: node scripts/coverage-tracker-summary.mjs
+
+      - name: Create/update/close/reopen coverage tracker issue
+        # #227 Part 2 ("Make future MISSING_TOOL coverage gaps self-tracking").
+        #
+        # Fixes the exact failure mode that got the PREVIOUS mechanism (issue #60,
+        # label `coverage-tracker`) removed in #165 ("drop dead coverage-tracker"):
+        # that step could only ever UPDATE an already-OPEN issue with the label --
+        # once a human closed #60, every subsequent run silently no-op'd
+        # (core.warning() only, never failed the workflow) and coverage drift went
+        # unnoticed for ~3 months. This step instead:
+        #   - creates the ONE tracker issue if none exists at all (open or closed),
+        #   - reopens a previously-closed tracker if new gaps appear later,
+        #   - updates the body of an already-open tracker (no duplicate created),
+        #   - closes the tracker (state_reason: completed) once MISSING_TOOL hits 0.
+        # docs/coverage.md (committed above) remains the single source of truth for
+        # the numbers -- this issue is only the actionable, self-healing companion.
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          MISSING_COUNT: ${{ steps.coverage-tracker.outputs.missing_count }}
+          TRACKER_BODY: ${{ steps.coverage-tracker.outputs.body }}
+        with:
+          script: |
+            const TRACKER_LABEL = 'coverage-tracker';
+            const TRACKER_TITLE = 'MCP API coverage tracker (auto-maintained)';
+            const missingCount = parseInt(process.env.MISSING_COUNT, 10);
+            const body = process.env.TRACKER_BODY;
+
+            if (Number.isNaN(missingCount)) {
+              core.warning('coverage-tracker-summary.mjs did not report a numeric missing_count -- skipping tracker update.');
+              return;
+            }
+
+            // state: 'all' -- a previously CLOSED tracker must be found too, so it
+            // can be reopened instead of a duplicate being created (the #60/#165 bug
+            // was specifically about a closed issue never getting revisited).
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: TRACKER_LABEL,
+              state: 'all',
+              per_page: 10,
+            });
+
+            const openIssues = existing.data.filter((i) => i.state === 'open');
+            if (openIssues.length > 1) {
+              const nums = openIssues.map((i) => `#${i.number}`).join(', ');
+              core.warning(`Multiple OPEN issues carry label "${TRACKER_LABEL}" (${nums}) -- skipping update to avoid clobbering.`);
+              return;
+            }
+
+            const openIssue = openIssues[0];
+            // Most recently updated (closed or open) issue with the label, if any --
+            // the one candidate to reopen when a fresh tracker is needed.
+            const anyIssue = existing.data.length > 0
+              ? existing.data.slice().sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0]
+              : undefined;
+
+            if (missingCount === 0) {
+              if (!openIssue) {
+                core.info('MISSING_TOOL is 0 and no open tracker issue exists -- nothing to close.');
+                return;
+              }
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                body: 'MISSING_TOOL reached 0 -- closing this tracker automatically. It will reopen if a future Dockhand release introduces an endpoint without an MCP tool.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+              core.info(`Closed coverage tracker issue #${openIssue.number} (MISSING_TOOL: 0).`);
+              return;
+            }
+
+            // missingCount > 0 from here on.
+            if (openIssue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: openIssue.number,
+                body,
+              });
+              core.info(`Updated open coverage tracker issue #${openIssue.number} (MISSING_TOOL: ${missingCount}).`);
+              return;
+            }
+
+            if (anyIssue) {
+              // A tracker exists but is CLOSED (either it was resolved before, or a
+              // human closed it manually) -- reopen it instead of creating a
+              // duplicate. This is the exact step the #60 mechanism never took.
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: anyIssue.number,
+                body,
+                state: 'open',
+                state_reason: 'reopened',
+              });
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: anyIssue.number,
+                body: `Reopened automatically: MISSING_TOOL is ${missingCount} again.`,
+              });
+              core.info(`Reopened coverage tracker issue #${anyIssue.number} (MISSING_TOOL: ${missingCount}).`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: TRACKER_TITLE,
+              labels: [TRACKER_LABEL],
+              body,
+            });
+            core.info(`Created coverage tracker issue #${created.data.number} (MISSING_TOOL: ${missingCount}).`);
+
       - name: Generate body-contract report
         # Task P1.4/P1.6, rein advisory: siehe generate-body-contract-doc.mjs Kopf-
         # kommentar. Läuft wie der Coverage-Schritt unabhängig vom Validate-Ergebnis --

--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -10,7 +10,7 @@
 > hartes Gate in `scripts/validate-mcp-tools.mjs` (Exit 1 + Auto-Issue) — hier weiterhin nur
 > zur Übersicht gelistet. Die übrigen drei Typen bleiben vollständig advisory.
 
-**Erzeugt:** 2026-09-05T21:47:21.936Z
+**Erzeugt:** 2026-09-05T21:59:23.338Z
 
 ## Zusammenfassung
 
@@ -27,14 +27,14 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `activate_license` | POST | `/api/license` | `licenseKey` | system.ts:179 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:726 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:726 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:726 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:726 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:747 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:747 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:747 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:747 |
 | `create_environment` | POST | `/api/environments` | `url` | environments.ts:157 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:651 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:659 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:672 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:680 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
 | `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:225 |
 
@@ -90,7 +90,7 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `update_secret_provider` | PUT | `/api/secret-providers/{id}` | - | secret-providers.ts:83 |
 | `update_template_source` | PUT | `/api/templates/sources` | `id` | templates.ts:52 |
 | `update_user` | PUT | `/api/users/{userId}` | - | users.ts:50 |
-| `validate_stack_compose` | POST | `/api/stacks/{name}/validate` | `compose` | stacks.ts:858 |
+| `validate_stack_compose` | POST | `/api/stacks/{name}/validate` | `compose` | stacks.ts:879 |
 
 ## BODY_CONTRACT_UNRESOLVED (35)
 

--- a/docs/body-contract-report.md
+++ b/docs/body-contract-report.md
@@ -10,7 +10,7 @@
 > hartes Gate in `scripts/validate-mcp-tools.mjs` (Exit 1 + Auto-Issue) — hier weiterhin nur
 > zur Übersicht gelistet. Die übrigen drei Typen bleiben vollständig advisory.
 
-**Erzeugt:** 2026-09-05T20:54:24.531Z
+**Erzeugt:** 2026-09-05T21:47:21.936Z
 
 ## Zusammenfassung
 
@@ -27,14 +27,14 @@ Das Tool sendet ein Body-Feld, das der OpenAPI-Contract nicht kennt (nach Aussch
 | Tool | HTTP | Pfad | Feld | Datei |
 |------|------|------|------|-------|
 | `activate_license` | POST | `/api/license` | `licenseKey` | system.ts:179 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:711 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:711 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:711 |
-| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:711 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `name` | stacks.ts:726 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `composePath` | stacks.ts:726 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `envPath` | stacks.ts:726 |
+| `adopt_stack` | POST | `/api/stacks/adopt` | `sourceDir` | stacks.ts:726 |
 | `create_environment` | POST | `/api/environments` | `url` | environments.ts:157 |
 | `create_user` | POST | `/api/users` | `roles` | users.ts:33 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:636 |
-| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:644 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env` | `keys` | stacks.ts:651 |
+| `remove_stack_env_vars` | PUT | `/api/stacks/{name}/env/raw` | `keys` | stacks.ts:659 |
 | `set_container_auto_update` | POST | `/api/auto-update/{containerName}` | `policy` | auto-update.ts:37 |
 | `test_environment_connection` | POST | `/api/environments/test` | `url` | environments.ts:225 |
 
@@ -90,7 +90,7 @@ Das Tool hat ein untypisiertes `z.record(...)`-Feld (z.B. `settings`), obwohl de
 | `update_secret_provider` | PUT | `/api/secret-providers/{id}` | - | secret-providers.ts:83 |
 | `update_template_source` | PUT | `/api/templates/sources` | `id` | templates.ts:52 |
 | `update_user` | PUT | `/api/users/{userId}` | - | users.ts:50 |
-| `validate_stack_compose` | POST | `/api/stacks/{name}/validate` | `compose` | stacks.ts:843 |
+| `validate_stack_compose` | POST | `/api/stacks/{name}/validate` | `compose` | stacks.ts:858 |
 
 ## BODY_CONTRACT_UNRESOLVED (35)
 

--- a/scripts/coverage-tracker-summary.mjs
+++ b/scripts/coverage-tracker-summary.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Emits what `.github/workflows/api-schema-sync.yml` needs to create / update /
+ * close / reopen the single, self-healing `coverage-tracker` issue (#227 Part 2).
+ *
+ * Reuses the SAME `computeValidation()` numbers `scripts/generate-coverage-doc.mjs`
+ * builds `docs/coverage.md` from (via the exports of `validate-mcp-tools.mjs`), so
+ * the tracker issue and `docs/coverage.md` can never disagree on the count — this
+ * script does not recompute or re-derive anything, only reads the same inputs a
+ * second time and hands the result to `buildTrackerBody()`
+ * (scripts/lib/coverage-tracker.mjs, unit-tested in tests/coverage-tracker.test.ts).
+ *
+ * Run this AFTER `node scripts/extract-dockhand-api.mjs` in the workflow (same
+ * precondition `generate-coverage-doc.mjs` has: a fresh `docs/dockhand-api-schema.json`
+ * on disk) — see api-schema-sync.yml step ordering.
+ *
+ * Writes two GitHub Actions step outputs to `$GITHUB_OUTPUT` (a later `github-script`
+ * step reads `steps.coverage-tracker.outputs.missing_count` /
+ * `.outputs.body` to talk to the GitHub REST API — that part is intentionally NOT in
+ * this script: creating/closing/reopening issues needs the workflow's `github-token`
+ * auth context, which a plain node script run via `actions/setup-node` does not have):
+ *
+ *   missing_count  -- integer, MISSING_TOOL count
+ *   body           -- the full issue body (multi-line, GITHUB_OUTPUT heredoc form)
+ *
+ * When $GITHUB_OUTPUT is unset (local/manual run), prints both to stdout instead —
+ * lets a maintainer preview the exact body a workflow run would produce/post,
+ * without needing CI (this is the "kein Live-Test möglich" case called out in the
+ * task: the workflow YAML integration itself can only be exercised in CI, but this
+ * script's OWN output is inspectable locally).
+ *
+ * Usage:
+ *   node scripts/coverage-tracker-summary.mjs
+ */
+
+import { appendFileSync } from 'node:fs';
+import {
+  loadSchema,
+  extractToolCalls,
+  computeValidation,
+  loadOmissionRegistry,
+} from './validate-mcp-tools.mjs';
+import { buildTrackerBody } from './lib/coverage-tracker.mjs';
+
+function main() {
+  const schema = loadSchema();
+  const toolCalls = extractToolCalls();
+  const registry = loadOmissionRegistry();
+  // toolBodyShapes=null: same as generate-coverage-doc.mjs — the tracker only needs
+  // the MISSING_TOOL bucket, not the body-contract findings.
+  const { missingTool } = computeValidation(schema, toolCalls, null, registry);
+
+  const workflowRunUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+    ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : undefined;
+
+  const body = buildTrackerBody({
+    missingCount: missingTool.length,
+    missingTool,
+    sourceCommit: schema.sourceCommit,
+    workflowRunUrl,
+  });
+
+  const outPath = process.env.GITHUB_OUTPUT;
+  if (outPath) {
+    // Heredoc form (GitHub Actions "multiline string" convention) — a delimiter
+    // that cannot plausibly appear inside the body itself, since the body is
+    // markdown built entirely from schema data (paths/methods/commit hash).
+    const delimiter = `COVERAGE_TRACKER_BODY_EOF_${Date.now()}`;
+    appendFileSync(outPath, `missing_count=${missingTool.length}\n`);
+    appendFileSync(outPath, `body<<${delimiter}\n${body}\n${delimiter}\n`);
+    console.error(`[coverage-tracker-summary] missing_count=${missingTool.length} — outputs written to $GITHUB_OUTPUT`);
+  } else {
+    console.log(`missing_count=${missingTool.length}`);
+    console.log('--- body ---');
+    console.log(body);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { main };

--- a/scripts/coverage-tracker-workflow-step.mjs
+++ b/scripts/coverage-tracker-workflow-step.mjs
@@ -1,0 +1,128 @@
+/**
+ * The `github-script` body of the "Create/update/close/reopen coverage tracker
+ * issue" step in `.github/workflows/api-schema-sync.yml` (#227 Part 2), factored
+ * out into its own function so it can be exercised by
+ * `tests/coverage-tracker-workflow-step.test.ts` with a MOCKED `github`/`context`/
+ * `core` — this workflow step talks to the live GitHub REST API and therefore
+ * cannot be tested any other way (no CI run available here, see the task's
+ * "kein Live-Test möglich" note).
+ *
+ * IMPORTANT: this file is NOT what actually runs in CI. `actions/github-script`
+ * only accepts an inline `script:` block, not an importable module — the
+ * workflow's `script:` is meant to be a byte-for-byte copy of this function's
+ * body (minus the wrapping `async function ... { }` / export). If you change the
+ * logic here, copy the SAME change into the workflow YAML, and vice versa —
+ * `tests/coverage-tracker-workflow-step.test.ts` ("drift guard" describe block)
+ * extracts both texts and fails the build if they diverge, so a missed copy
+ * cannot silently ship.
+ */
+
+async function runCoverageTrackerStep(github, context, core, process) {
+  const TRACKER_LABEL = 'coverage-tracker';
+  const TRACKER_TITLE = 'MCP API coverage tracker (auto-maintained)';
+  const missingCount = parseInt(process.env.MISSING_COUNT, 10);
+  const body = process.env.TRACKER_BODY;
+
+  if (Number.isNaN(missingCount)) {
+    core.warning('coverage-tracker-summary.mjs did not report a numeric missing_count -- skipping tracker update.');
+    return;
+  }
+
+  // state: 'all' -- a previously CLOSED tracker must be found too, so it
+  // can be reopened instead of a duplicate being created (the #60/#165 bug
+  // was specifically about a closed issue never getting revisited).
+  const existing = await github.rest.issues.listForRepo({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    labels: TRACKER_LABEL,
+    state: 'all',
+    per_page: 10,
+  });
+
+  const openIssues = existing.data.filter((i) => i.state === 'open');
+  if (openIssues.length > 1) {
+    const nums = openIssues.map((i) => `#${i.number}`).join(', ');
+    core.warning(`Multiple OPEN issues carry label "${TRACKER_LABEL}" (${nums}) -- skipping update to avoid clobbering.`);
+    return;
+  }
+
+  const openIssue = openIssues[0];
+  // Most recently updated (closed or open) issue with the label, if any --
+  // the one candidate to reopen when a fresh tracker is needed.
+  const anyIssue = existing.data.length > 0
+    ? existing.data.slice().sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at))[0]
+    : undefined;
+
+  if (missingCount === 0) {
+    if (!openIssue) {
+      core.info('MISSING_TOOL is 0 and no open tracker issue exists -- nothing to close.');
+      return;
+    }
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: openIssue.number,
+      body,
+    });
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: openIssue.number,
+      body: 'MISSING_TOOL reached 0 -- closing this tracker automatically. It will reopen if a future Dockhand release introduces an endpoint without an MCP tool.',
+    });
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: openIssue.number,
+      state: 'closed',
+      state_reason: 'completed',
+    });
+    core.info(`Closed coverage tracker issue #${openIssue.number} (MISSING_TOOL: 0).`);
+    return;
+  }
+
+  // missingCount > 0 from here on.
+  if (openIssue) {
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: openIssue.number,
+      body,
+    });
+    core.info(`Updated open coverage tracker issue #${openIssue.number} (MISSING_TOOL: ${missingCount}).`);
+    return;
+  }
+
+  if (anyIssue) {
+    // A tracker exists but is CLOSED (either it was resolved before, or a
+    // human closed it manually) -- reopen it instead of creating a
+    // duplicate. This is the exact step the #60 mechanism never took.
+    await github.rest.issues.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: anyIssue.number,
+      body,
+      state: 'open',
+      state_reason: 'reopened',
+    });
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: anyIssue.number,
+      body: `Reopened automatically: MISSING_TOOL is ${missingCount} again.`,
+    });
+    core.info(`Reopened coverage tracker issue #${anyIssue.number} (MISSING_TOOL: ${missingCount}).`);
+    return;
+  }
+
+  const created = await github.rest.issues.create({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    title: TRACKER_TITLE,
+    labels: [TRACKER_LABEL],
+    body,
+  });
+  core.info(`Created coverage tracker issue #${created.data.number} (MISSING_TOOL: ${missingCount}).`);
+}
+
+export { runCoverageTrackerStep };

--- a/scripts/lib/coverage-tracker.mjs
+++ b/scripts/lib/coverage-tracker.mjs
@@ -1,0 +1,96 @@
+/**
+ * Pure builder for the single, self-healing `coverage-tracker` issue body (#227
+ * Part 2 — "Make future MISSING_TOOL coverage gaps self-tracking").
+ *
+ * Context: a PREVIOUS sticky-issue mechanism existed (issue #60, labeled
+ * `coverage-tracker`) but was removed in #165 ("drop dead coverage-tracker") because
+ * its update step could only ever UPDATE an already-OPEN issue with that label — once
+ * a human closed #60, the step silently no-op'd (`core.warning()` only, never failed
+ * the workflow) and coverage drift went unnoticed for roughly three months. #165
+ * replaced it with the committed, always-current `docs/coverage.md` report, which
+ * remains the single source of truth for the numbers below.
+ *
+ * #227 asks to bring the ACTIONABLE side back, but fixed: the workflow step (see
+ * scripts/coverage-tracker-summary.mjs + api-schema-sync.yml) now CREATES the issue
+ * if none is open, and REOPENS a previously-closed one if new gaps appear — the exact
+ * failure mode above becomes structurally impossible instead of merely documented.
+ *
+ * This module only builds the markdown body from numbers `computeValidation()`
+ * already produced elsewhere (validate-mcp-tools.mjs / generate-coverage-doc.mjs) —
+ * it does no I/O and re-derives nothing, so the tracker issue and docs/coverage.md
+ * can never disagree on the count.
+ */
+
+import { groupMissingByArea } from './coverage-report.mjs';
+
+/** GitHub label used to find/create the single tracker issue (matches #60's label). */
+const TRACKER_LABEL = 'coverage-tracker';
+
+/**
+ * @param {object} input
+ * @param {number} input.missingCount MISSING_TOOL count (`missingTool.length`)
+ * @param {Array<{path: string, method: string, pathParams?: string[]}>} input.missingTool
+ * @param {string} input.sourceCommit Dockhand upstream commit the schema was extracted from
+ * @param {string} [input.workflowRunUrl] Link to the run that produced this body (omitted if not given — e.g. local/manual invocation)
+ * @returns {string} Full issue body markdown (title is set by the caller, not part of this).
+ */
+function buildTrackerBody({ missingCount, missingTool, sourceCommit, workflowRunUrl }) {
+  const lines = [];
+
+  lines.push(
+    'This issue tracks Dockhand REST API endpoints that do not yet have a corresponding ' +
+      'MCP tool, as detected by `scripts/validate-mcp-tools.mjs`.'
+  );
+  lines.push('');
+  lines.push(
+    '**Auto-maintained** by the ' +
+      '[`api-schema-sync`](../actions/workflows/api-schema-sync.yml) workflow ' +
+      '(daily 05:00 UTC + manual dispatch). Do not edit this body by hand — it is fully ' +
+      'replaced on every run that changes the count. See `docs/coverage.md` for the full, ' +
+      'always-current report (COVERED / ORPHANED_TOOL / deliberately-omitted endpoints, ' +
+      'per-endpoint tables).'
+  );
+  lines.push('');
+  lines.push(`**Dockhand upstream commit:** \`${sourceCommit}\``);
+  lines.push(`**MISSING_TOOL:** ${missingCount}`);
+  if (workflowRunUrl) {
+    lines.push(`**Last sync:** [run log](${workflowRunUrl})`);
+  }
+  lines.push('');
+
+  if (missingCount === 0) {
+    lines.push(
+      'No open gaps — every in-scope endpoint currently has an MCP tool. This issue is ' +
+        'closed automatically and will be **reopened** if a future Dockhand release ' +
+        'introduces an endpoint without a tool, rather than silently going stale (see #165 ' +
+        'for why the previous mechanism died, and why this one reopens instead of only ' +
+        'updating-while-open).'
+    );
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  lines.push('## MISSING_TOOL — by area');
+  lines.push('');
+  lines.push(
+    'Endpoints that exist per the schema but have no MCP tool yet, grouped by the first ' +
+      'path segment after `/api/`:'
+  );
+  lines.push('');
+
+  const grouped = groupMissingByArea(missingTool);
+  for (const { area, entries } of grouped) {
+    lines.push(`### ${area} (${entries.length})`);
+    lines.push('');
+    lines.push('| HTTP | Path |');
+    lines.push('|------|------|');
+    for (const e of entries) {
+      lines.push(`| ${e.method} | \`${e.path}\` |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export { TRACKER_LABEL, buildTrackerBody };

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -420,8 +420,23 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
           // sources lookup (i.e. only when replaceNonSecrets is non-empty).
           const existingForReplace = await client.get<StackEnv>(envPath, { env: environmentId });
           const existingVarsRaw = existingForReplace?.variables;
+          // #244 (Codex finding on the merged #243/#231 code): a malformed
+          // response here (missing/non-array `variables`) must NOT silently
+          // fall back to an empty existing-state map — Issue-#196 lesson
+          // applies here too. An empty map means every key the caller omits
+          // isSecret on resolves via `?? false`, so a resent EXISTING secret
+          // (e.g. after a get_stack_env round-trip returning it masked as
+          // '***', then forwarded back unchanged) would be silently demoted
+          // to plaintext the instant the DB PUT below fires (DELETE-all +
+          // INSERT). Throw and abort the whole replace instead of risking
+          // that — mirrors resolveIsGitStack()'s "throw, don't default" shape
+          // guard above.
+          if (!Array.isArray(existingVarsRaw)) {
+            throw new Error(
+              `update_stack_env: GET ${envPath} returned an unexpected response shape (missing/invalid "variables" array) — refusing to replace variable(s) for stack "${name}" without a reliably resolved existing isSecret state (a malformed response could silently demote an existing secret to plaintext).`);
+          }
           const existingIsSecretByKey = new Map(
-            (Array.isArray(existingVarsRaw) ? existingVarsRaw : [])
+            existingVarsRaw
               .filter((v): v is EnvVariable => !!v && typeof v.key === 'string')
               .map((v) => [v.key, v.isSecret === true]),
           );

--- a/src/tools/stacks.ts
+++ b/src/tools/stacks.ts
@@ -284,9 +284,30 @@ export function registerStackTools(server: McpServer, client: DockhandClient): v
         const existing = await client.get<StackEnv>(envPath, { env: environmentId });
         const existingVarsRaw = existing?.variables;
         // Guard against a malformed API response (variables null / not an array).
-        const existingVars: EnvVariable[] = Array.isArray(existingVarsRaw)
-          ? existingVarsRaw.filter((v): v is EnvVariable => !!v && typeof v.key === 'string')
-          : [];
+        //
+        // Same guard as #244's replace-mode fix, and for the same reason
+        // (Issue-#196 lesson: unexpected shape on a write path must throw,
+        // never silently default). A silent [] fallback here is WORSE than
+        // in replace mode: this existingVars feeds the merge below that
+        // preserves an existing key's isSecret flag when the payload omits
+        // it ("Preserve the existing isSecret flag when the caller omits
+        // it"). An empty map means that lookup always misses, so
+        // `existingVar?.isSecret` is `undefined` for every key -- a caller
+        // rotating an EXISTING secret's value without resending isSecret
+        // (the normal shape after a get_stack_env round-trip) then sends
+        // isSecret:undefined, which JSON.stringify drops from the request
+        // body entirely. Ground Truth (Finsys/dockhand src/lib/server/db.ts,
+        // setStackEnvVars): `isSecret: v.isSecret ?? false` defaults the
+        // missing flag to false server-side, and the DB PUT there is
+        // DELETE-all-for-this-stack + INSERT of exactly the sent list -- so
+        // the old encrypted row is gone the instant the plaintext-defaulted
+        // one replaces it, reported as `success: true`.
+        if (!Array.isArray(existingVarsRaw)) {
+          throw new Error(
+            `update_stack_env: GET ${envPath} returned an unexpected response shape (missing/invalid "variables" array) — refusing to merge variable(s) for stack "${name}" without a reliably resolved existing isSecret state (a malformed response could silently demote an existing secret to plaintext).`);
+        }
+        const existingVars: EnvVariable[] = existingVarsRaw
+          .filter((v): v is EnvVariable => !!v && typeof v.key === 'string');
 
         existingVarsForBaseline = existingVars;
         existingSecrets = existingVars.filter((v) => v.isSecret === true);

--- a/tests/coverage-tracker-workflow-step.test.ts
+++ b/tests/coverage-tracker-workflow-step.test.ts
@@ -204,6 +204,17 @@ describe('runCoverageTrackerStep', () => {
 
     await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '2', TRACKER_BODY: 'new gaps' } });
 
+    // Our mockGithub() ignores whatever `state` filter it was called with and
+    // always returns the full fixture array -- so without this assertion, a
+    // regression from state:'all' back to state:'open' (the exact #165/#60
+    // bug: the real GitHub API would then never return a CLOSED issue at
+    // all, so a closed tracker could never be found and reopened) would
+    // still pass every other assertion below, because the mock's returned
+    // data doesn't change. This is the one assertion that actually pins the
+    // real-world-relevant call argument.
+    expect(github.rest.issues.listForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'all' }),
+    );
     expect(github.rest.issues.create).not.toHaveBeenCalled();
     expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
     expect(github.rest.issues.update).toHaveBeenCalledWith(

--- a/tests/coverage-tracker-workflow-step.test.ts
+++ b/tests/coverage-tracker-workflow-step.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runCoverageTrackerStep } from '../scripts/coverage-tracker-workflow-step.mjs';
+
+/**
+ * #227 Part 2 -- the "Create/update/close/reopen coverage tracker issue" step in
+ * `.github/workflows/api-schema-sync.yml` talks to the live GitHub REST API via
+ * `actions/github-script`'s injected `github`/`context`/`core` -- there is no way
+ * to exercise the ACTUAL workflow step outside CI (the task's "kein Live-Test
+ * möglich" note). Two things are tested here instead:
+ *
+ * 1. A drift guard: `scripts/coverage-tracker-workflow-step.mjs` claims to be a
+ *    byte-for-byte copy of the YAML `script:` block (see its header comment) --
+ *    this test proves that claim instead of leaving it as an unverified comment,
+ *    by extracting both texts and comparing them structurally.
+ * 2. The actual control-flow logic (create vs. update vs. close vs. reopen vs.
+ *    the defensive multi-open-issue bail-out), run against a MOCKED
+ *    github.rest.issues.* client -- this is the part that would silently regress
+ *    without a live CI run to catch it.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const WORKFLOW_PATH = resolve(__dirname, '..', '.github', 'workflows', 'api-schema-sync.yml');
+const STEP_MODULE_PATH = resolve(__dirname, '..', 'scripts', 'coverage-tracker-workflow-step.mjs');
+
+/**
+ * Extracts the `script: |` block scalar body of the named step from the workflow
+ * YAML, without needing a full YAML parser (avoids depending on the transitive,
+ * undeclared `js-yaml` package a future dependency bump could remove or change --
+ * a drift guard breaking because of an unrelated dependency change is exactly the
+ * "test fails for the wrong reason" anti-pattern this repo's own
+ * test-coverage-pflicht avoids elsewhere). Plain-text, indentation-based
+ * extraction is sufficient for this one well-known, stable step.
+ */
+function extractWorkflowScript(stepName: string): string {
+  const text = readFileSync(WORKFLOW_PATH, 'utf8');
+  const lines = text.split('\n');
+  const stepLineIdx = lines.findIndex((l) => l.trim() === `- name: ${stepName}`);
+  if (stepLineIdx === -1) {
+    throw new Error(`Step "${stepName}" not found in ${WORKFLOW_PATH}`);
+  }
+
+  const scriptLineIdx = lines.findIndex(
+    (l, i) => i > stepLineIdx && l.trim() === 'script: |',
+  );
+  if (scriptLineIdx === -1) {
+    throw new Error(`No "script: |" block found after step "${stepName}"`);
+  }
+  const bodyIndent = lines[scriptLineIdx].match(/^\s*/)![0].length + 2;
+
+  const bodyLines: string[] = [];
+  for (let i = scriptLineIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // A blank line is part of the block scalar (JS allows blank lines); anything
+    // indented LESS than bodyIndent ends the block.
+    if (line.trim() !== '' && line.match(/^\s*/)![0].length < bodyIndent) break;
+    bodyLines.push(line.length >= bodyIndent ? line.slice(bodyIndent) : '');
+  }
+  // Drop trailing blank lines (YAML block scalars normally end with exactly one
+  // trailing newline; our line-based capture may pick up extra blanks before the
+  // next step's `- name:`).
+  while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') bodyLines.pop();
+  return bodyLines.join('\n');
+}
+
+/**
+ * Extracts the body of `async function runCoverageTrackerStep(...) { ... }` from
+ * the .mjs file, dedented by one level (2 spaces) to match the YAML block's
+ * indentation (which has no wrapping function).
+ */
+function extractModuleFunctionBody(): string {
+  const text = readFileSync(STEP_MODULE_PATH, 'utf8');
+  const startMarker = 'async function runCoverageTrackerStep(github, context, core, process) {';
+  // lastIndexOf, not indexOf: the header comment above ALSO mentions this exact
+  // string as literal code-quoted text (documenting what to strip when copying
+  // into the YAML) -- indexOf would match that comment occurrence instead of the
+  // real function definition and silently compare against the wrong (empty/
+  // comment) text. Caught by this very test failing for the wrong reason on the
+  // first run.
+  const startIdx = text.lastIndexOf(startMarker);
+  if (startIdx === -1) throw new Error('runCoverageTrackerStep() not found');
+  const bodyStart = startIdx + startMarker.length;
+  const endMarker = '\n}\n\nexport { runCoverageTrackerStep };';
+  const endIdx = text.indexOf(endMarker, bodyStart);
+  if (endIdx === -1) throw new Error('End of runCoverageTrackerStep() not found');
+  const rawBody = text.slice(bodyStart, endIdx);
+  const lines = rawBody.split('\n');
+  // Drop the leading blank line right after the opening brace.
+  if (lines[0] === '') lines.shift();
+  const dedented = lines.map((l) => (l.startsWith('  ') ? l.slice(2) : l));
+  while (dedented.length > 0 && dedented[dedented.length - 1] === '') dedented.pop();
+  return dedented.join('\n');
+}
+
+describe('coverage tracker workflow step — drift guard', () => {
+  it('the YAML script: block is identical to runCoverageTrackerStep()\'s body (see the header comment claiming this)', () => {
+    const workflowScript = extractWorkflowScript('Create/update/close/reopen coverage tracker issue');
+    const moduleBody = extractModuleFunctionBody();
+
+    expect(workflowScript).toBe(moduleBody);
+  });
+});
+
+/**
+ * Minimal mock of the octokit surface this step uses. Each mocked method records
+ * its calls so tests can assert exactly what happened -- and, crucially, what did
+ * NOT happen (e.g. "no issue was created" when one should have been updated
+ * instead).
+ */
+function mockGithub(issues: Array<{ number: number; state: 'open' | 'closed'; updated_at: string }>) {
+  return {
+    rest: {
+      issues: {
+        listForRepo: vi.fn().mockResolvedValue({ data: issues }),
+        update: vi.fn().mockResolvedValue({}),
+        createComment: vi.fn().mockResolvedValue({}),
+        create: vi.fn().mockResolvedValue({ data: { number: 999 } }),
+      },
+    },
+  };
+}
+
+function mockCore() {
+  return { info: vi.fn(), warning: vi.fn() };
+}
+
+const context = { repo: { owner: 'strausmann', repo: 'mcp-dockhand' } };
+
+describe('runCoverageTrackerStep', () => {
+  it('missing_count not numeric: warns and does nothing (defensive -- a broken upstream script must not crash the workflow)', async () => {
+    const github = mockGithub([]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: 'not-a-number', TRACKER_BODY: 'x' } });
+
+    expect(github.rest.issues.listForRepo).not.toHaveBeenCalled();
+    expect(core.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it('no existing tracker issue at all, missingCount > 0: CREATES exactly one issue with the coverage-tracker label', async () => {
+    const github = mockGithub([]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '5', TRACKER_BODY: 'body-x' } });
+
+    expect(github.rest.issues.create).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.create).toHaveBeenCalledWith(
+      expect.objectContaining({ labels: ['coverage-tracker'], body: 'body-x' }),
+    );
+    expect(github.rest.issues.update).not.toHaveBeenCalled();
+  });
+
+  it('an OPEN tracker exists, missingCount > 0: UPDATES it (no create, no close/reopen)', async () => {
+    const github = mockGithub([{ number: 42, state: 'open', updated_at: '2026-09-01T00:00:00Z' }]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '3', TRACKER_BODY: 'body-y' } });
+
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, body: 'body-y' }),
+    );
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('an OPEN tracker exists, missingCount === 0: CLOSES it (state_reason completed) with an explanatory comment', async () => {
+    const github = mockGithub([{ number: 42, state: 'open', updated_at: '2026-09-01T00:00:00Z' }]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '0', TRACKER_BODY: 'all clear' } });
+
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    // Body update + the close-with-state-reason update: two update() calls.
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(2);
+    expect(github.rest.issues.update).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ issue_number: 42, body: 'all clear' }),
+    );
+    expect(github.rest.issues.update).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ issue_number: 42, state: 'closed', state_reason: 'completed' }),
+    );
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('no OPEN tracker, missingCount === 0: does nothing (already resolved, nothing to close) -- this is the exact case the #60 mechanism could not distinguish from "should reopen"', async () => {
+    const github = mockGithub([{ number: 42, state: 'closed', updated_at: '2026-08-01T00:00:00Z' }]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '0', TRACKER_BODY: 'irrelevant' } });
+
+    expect(github.rest.issues.update).not.toHaveBeenCalled();
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    expect(github.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+
+  it('a CLOSED tracker exists, missingCount > 0: REOPENS it instead of creating a duplicate -- this is the #165 fix (the old step only ever updated an OPEN issue and silently gave up once it was closed)', async () => {
+    const github = mockGithub([{ number: 60, state: 'closed', updated_at: '2026-05-16T11:50:01Z' }]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '2', TRACKER_BODY: 'new gaps' } });
+
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 60, state: 'open', state_reason: 'reopened', body: 'new gaps' }),
+    );
+    expect(github.rest.issues.createComment).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple OPEN tracker issues (defensive, should never happen): warns and touches NOTHING, to avoid clobbering one arbitrarily', async () => {
+    const github = mockGithub([
+      { number: 10, state: 'open', updated_at: '2026-09-01T00:00:00Z' },
+      { number: 11, state: 'open', updated_at: '2026-09-02T00:00:00Z' },
+    ]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '4', TRACKER_BODY: 'x' } });
+
+    expect(core.warning).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update).not.toHaveBeenCalled();
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+  });
+
+  it('multiple issues with the label but only ONE open (the rest closed): reopening logic ignores the closed ones and updates the open one', async () => {
+    const github = mockGithub([
+      { number: 60, state: 'closed', updated_at: '2026-05-16T11:50:01Z' },
+      { number: 200, state: 'open', updated_at: '2026-09-01T00:00:00Z' },
+    ]);
+    const core = mockCore();
+
+    await runCoverageTrackerStep(github, context, core, { env: { MISSING_COUNT: '1', TRACKER_BODY: 'x' } });
+
+    expect(github.rest.issues.update).toHaveBeenCalledTimes(1);
+    expect(github.rest.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 200 }),
+    );
+    expect(github.rest.issues.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/coverage-tracker.test.ts
+++ b/tests/coverage-tracker.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { TRACKER_LABEL, buildTrackerBody } from '../scripts/lib/coverage-tracker.mjs';
+
+/**
+ * #227 Part 2 — pure body-builder for the self-healing `coverage-tracker` issue.
+ * The workflow-side I/O (finding/creating/updating/closing/reopening the actual
+ * GitHub issue) lives in `.github/workflows/api-schema-sync.yml` and cannot be unit
+ * tested without a live GitHub API — see `scripts/coverage-tracker-summary.mjs`
+ * header comment. This file covers everything that CAN be tested: the markdown the
+ * workflow feeds into that API call.
+ */
+
+describe('TRACKER_LABEL', () => {
+  it('matches the label the previous mechanism (#60) used, so an existing tracker issue is found, not duplicated', () => {
+    expect(TRACKER_LABEL).toBe('coverage-tracker');
+  });
+});
+
+describe('buildTrackerBody', () => {
+  it('missingCount 0: reports "no gaps" and does NOT render a MISSING_TOOL section', () => {
+    const body = buildTrackerBody({
+      missingCount: 0,
+      missingTool: [],
+      sourceCommit: 'abc123',
+    });
+
+    expect(body).toContain('No open gaps');
+    expect(body).toContain('**MISSING_TOOL:** 0');
+    expect(body).not.toContain('## MISSING_TOOL — by area');
+  });
+
+  it('missingCount > 0: renders a MISSING_TOOL section grouped by area, one table per area', () => {
+    const body = buildTrackerBody({
+      missingCount: 3,
+      missingTool: [
+        { path: '/api/backup/schedule', method: 'GET', pathParams: [] },
+        { path: '/api/backup/jobs', method: 'POST', pathParams: [] },
+        { path: '/api/registry/image', method: 'DELETE', pathParams: [] },
+      ],
+      sourceCommit: 'abc123',
+    });
+
+    expect(body).toContain('**MISSING_TOOL:** 3');
+    expect(body).toContain('## MISSING_TOOL — by area');
+    expect(body).toContain('### backup (2)');
+    expect(body).toContain('### registry (1)');
+    expect(body).toContain('| GET | `/api/backup/schedule` |');
+    expect(body).toContain('| POST | `/api/backup/jobs` |');
+    expect(body).toContain('| DELETE | `/api/registry/image` |');
+    expect(body).not.toContain('No open gaps');
+  });
+
+  it('always includes the source commit and the count, so the tracker can never silently disagree with docs/coverage.md', () => {
+    const body = buildTrackerBody({
+      missingCount: 1,
+      missingTool: [{ path: '/api/x/y', method: 'GET', pathParams: [] }],
+      sourceCommit: 'deadbeef',
+    });
+
+    expect(body).toContain('`deadbeef`');
+    expect(body).toContain('**MISSING_TOOL:** 1');
+  });
+
+  it('includes a run-log link only when workflowRunUrl is given (manual/local invocation omits it)', () => {
+    const withUrl = buildTrackerBody({
+      missingCount: 0,
+      missingTool: [],
+      sourceCommit: 'abc123',
+      workflowRunUrl: 'https://github.com/strausmann/mcp-dockhand/actions/runs/1',
+    });
+    const withoutUrl = buildTrackerBody({
+      missingCount: 0,
+      missingTool: [],
+      sourceCommit: 'abc123',
+    });
+
+    expect(withUrl).toContain('[run log](https://github.com/strausmann/mcp-dockhand/actions/runs/1)');
+    expect(withoutUrl).not.toContain('run log');
+  });
+
+  it('never instructs a human to edit the body by hand (the workflow fully replaces it every run)', () => {
+    const body = buildTrackerBody({ missingCount: 0, missingTool: [], sourceCommit: 'abc123' });
+    expect(body).toContain('Do not edit this body by hand');
+  });
+});

--- a/tests/stack-env-git-routing.test.ts
+++ b/tests/stack-env-git-routing.test.ts
@@ -373,6 +373,37 @@ describe('update_stack_env — replace mode routes non-secrets by resolved stack
 
     expect(client.get).not.toHaveBeenCalled();
   });
+
+  it('git stack, mode=replace: a malformed GET /env response (missing/non-array "variables") THROWS — never silently falls back to an empty existing-secrets map (which would demote a resent secret to plaintext, #244)', async () => {
+    const { handler, client } = setup();
+    wireGet(client, {
+      // Malformed: no usable `variables` array at all — e.g. an unexpected
+      // API shape (not the documented {variables:[...]} form).
+      structured: { error: 'unexpected shape' } as unknown as { variables: EnvVariable[] },
+      sources: { 'my-git-stack': { sourceType: 'git' } },
+    });
+
+    const res = await handler({
+      environmentId: 4,
+      name: 'my-git-stack',
+      mode: 'replace',
+      variables: [
+        { key: 'EXISTING_SECRET', value: 'old-secret-value' }, // isSecret omitted!
+        { key: 'PLAIN', value: 'p', isSecret: false },
+      ],
+    });
+
+    // Nothing may be written: a malformed existing-state lookup must not
+    // silently default to "no existing secrets" and demote EXISTING_SECRET
+    // to a plaintext non-secret via the DB PUT (DELETE-all+INSERT).
+    expect(envPut(client)).toBeUndefined();
+    expect(rawPut(client)).toBeUndefined();
+
+    const out = jsonOut(res);
+    expect(typeof out.error).toBe('string');
+    expect(String(out.error)).toContain('my-git-stack');
+    expect(String(out.error)).toMatch(/variables/i);
+  });
 });
 
 describe('update_stack_env — GET /api/stacks/sources permission (#231, Fix-Runde 3, Codex P2)', () => {

--- a/tests/stack-env-merge-behavior.test.ts
+++ b/tests/stack-env-merge-behavior.test.ts
@@ -261,13 +261,67 @@ describe('update_stack_env — merge auto-routing (mocked client)', () => {
     expect(rawPut(client)).toBeUndefined();
   });
 
-  it('merge tolerates a malformed structured GET response (variables not an array) without crashing', async () => {
+  it('merge now ABORTS instead of silently tolerating a malformed structured GET response (variables not an array) — same guard as #244\'s replace-mode fix, no write happens at all', async () => {
     const { handler, client } = setup();
     wireGet(client, { variables: null }, '');
 
-    await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y', isSecret: true }] });
+    const res = await handler({ environmentId: 1, name: 's', variables: [{ key: 'X', value: 'y', isSecret: true }] });
 
-    expect(envPut(client)?.[1]).toEqual({ variables: [{ key: 'X', value: 'y', isSecret: true }] });
+    // Before this fix: the malformed response silently fell back to an empty
+    // existing-state map, and the payload's own isSecret:true happened to
+    // make this particular case harmless (a brand-new key, no existing state
+    // needed). That was luck, not safety -- see the credential-loss test
+    // below for the case where the same silent fallback is NOT harmless.
+    expect(envPut(client)).toBeUndefined();
+    expect(rawPut(client)).toBeUndefined();
+    const out = jsonOut(res);
+    expect(typeof out.error).toBe('string');
+    expect(String(out.error)).toMatch(/variables/i);
+  });
+
+  it('merge-mode credential-loss guard: a GIT STACK\'s EXISTING secret resent as a value-only update (isSecret omitted) against a malformed structured GET response THROWS instead of silently demoting it to plaintext in the DB PUT', async () => {
+    const { handler, client } = setup();
+    // Malformed: no usable `variables` array at all -- the exact shape that,
+    // before this fix, silently emptied `existingVars` and discarded the
+    // knowledge that TOKEN already exists as an encrypted secret. Ground
+    // Truth (Finsys/dockhand src/lib/server/db.ts, setStackEnvVars):
+    // `isSecret: v.isSecret ?? false` -- an omitted isSecret defaults to
+    // false server-side, and the DB PUT there is DELETE-all-for-this-stack
+    // + INSERT of exactly the sent list, so the old encrypted row is gone
+    // the instant a plaintext-defaulted one replaces it.
+    //
+    // On a git stack the merged set (finalVariables) goes to the DB PUT
+    // verbatim -- so BEFORE this fix, TOKEN would reach client.put(envPath,
+    // {variables:[{key:'TOKEN',value:'rotated'}]}) with isSecret simply
+    // absent (JSON.stringify drops `isSecret: undefined`), which
+    // setStackEnvVars stores unencrypted. This test pins the git-stack path
+    // specifically; the guard itself fires earlier and unconditionally
+    // (before any git/internal routing decision), so it protects internal
+    // stacks identically -- see the "merge now ABORTS ..." test above.
+    client.get.mockImplementation((path: string) => {
+      if (path.endsWith('/env/raw')) return Promise.resolve({ content: '' });
+      if (path.endsWith('/api/stacks/sources')) return Promise.resolve({ s: { sourceType: 'git' } });
+      return Promise.resolve({ error: 'unexpected shape' });
+    });
+
+    const res = await handler({
+      environmentId: 1,
+      name: 's',
+      // Caller rotates the value but omits isSecret -- exactly like the
+      // safe "merge preserves an existing secret flag" test above; the ONLY
+      // difference here is the malformed GET response standing in for the
+      // existing-state lookup that test relies on.
+      variables: [{ key: 'TOKEN', value: 'rotated' }],
+    });
+
+    // Nothing may be written: TOKEN must never go out with isSecret
+    // undefined (which JSON.stringify drops from the request body entirely).
+    expect(envPut(client)).toBeUndefined();
+    expect(rawPut(client)).toBeUndefined();
+
+    const out = jsonOut(res);
+    expect(typeof out.error).toBe('string');
+    expect(String(out.error)).toMatch(/variables/i);
   });
 
   it('partial failure: DB PUT succeeds, .env/raw PUT fails -> error reported, db.secretsWritten stays set', async () => {


### PR DESCRIPTION
## Summary

Two small, independent items in one branch:

### #244 — guard malformed `GET /env` response in replace-mode git routing

`update_stack_env`'s `mode=replace` path for git stacks fetches the existing
variables to preserve `isSecret` flags the caller omits. If that GET returns
a malformed shape (missing/non-array `variables`), the code silently fell
back to an empty map — meaning a resent EXISTING secret (`isSecret` omitted,
e.g. after a `get_stack_env` round-trip returning it masked as `***`, then
forwarded back unchanged) would be silently demoted to plaintext the instant
the DB PUT (DELETE-all+INSERT) fires, with `success: true`.

Fixed by throwing instead of defaulting, mirroring `resolveIsGitStack()`'s
existing "throw, don't default" shape guard a few lines above (Issue-#196
lesson: unexpected shape at a write path → throw). Verified against the
Ground Truth handler (`Finsys/dockhand` v1.0.46,
`src/routes/api/stacks/[name]/env/+server.ts` `GET`): the endpoint always
returns `{variables: [...]}` on success (200) and throws on non-2xx (handled
separately by the client), so "malformed but 200" is exactly the narrow gap
this closes.

New regression test first proves the vulnerability (malformed response →
`EXISTING_SECRET` silently written as `isSecret:false`) before the fix, then
confirms the guard aborts safely with no write at all.

Closes #244

### #227 Part 2 — self-healing `coverage-tracker` issue for `MISSING_TOOL`

Part 1 (`validate_stack_compose`) already merged via #243. This finishes
Part 2: `api-schema-sync.yml` previously only opened/updated an issue when
`validate-mcp-tools.mjs`'s **hard** checks failed (label `api-change`). A
newly detected `MISSING_TOOL` is a soft coverage finding, not a hard
failure, so a new Dockhand endpoint could appear in `docs/coverage.md`
without ever producing an actionable tracking issue.

This reintroduces the *actionable* side of the coverage-tracker concept
(issue #60, removed in #165 as "dead") — but fixed. #60's mechanism could
only **update** an already-open issue; once #60 itself got closed by a
human, the workflow step silently no-op'd (`core.warning()` only) for ~3
months before anyone noticed. The new mechanism:

- creates the **one** `coverage-tracker`-labeled issue if none exists,
- updates it in place on repeat runs (no duplicates),
- closes it (`state_reason: completed`) once `MISSING_TOOL` hits 0,
- **reopens** a previously-closed tracker if new gaps appear later, instead
  of silently doing nothing (the exact step #60's mechanism never took).

`docs/coverage.md` remains the single source of truth for the numbers —
`scripts/coverage-tracker-summary.mjs` reuses `computeValidation()` from
`validate-mcp-tools.mjs` (same call `generate-coverage-doc.mjs` makes) so
the two outputs can never disagree. The actual `github-script` step logic
lives in `scripts/coverage-tracker-workflow-step.mjs` (importable,
unit-testable with a mocked `github.rest.issues.*`), with a **drift-guard
test** proving the YAML `script:` block stays byte-identical to it — so a
future edit to one without the other fails the build instead of silently
diverging. Hard validation-failure issue behavior (`api-change` label) is
untouched.

No live CI run was possible to exercise the workflow itself (no GitHub
Actions runner available here); the mocked `github.rest.issues.*` scenarios
in the test suite (create / update-open / close / reopen-closed / defensive
multi-open bail-out) are the closest available substitute. Each assertion
was confirmed to fail for the right reason via targeted mutation before
finalizing (including catching a real bug in the drift-guard extraction
helper itself — see commit history).

Closes #227

## Test plan

- [x] `npx vitest run` — 1185/1185 green (1170 pre-existing + 15 new)
- [x] Gegenversuch: the #244 regression test fails (proves the vuln) with
      the fix reverted, passes with it in place
- [x] Gegenversuch: mutating a single character in the YAML `script:` block
      makes the drift-guard test fail for the right reason; reverting makes
      it pass again
- [x] Gegenversuch: mutation-testing `buildTrackerBody`'s `missingCount === 0`
      branch condition breaks 2/6 tests for the right reason
- [x] `npm run build` (`tsc`) — clean
- [x] `npm run lint` (ESLint in container) — 0 errors (1 pre-existing,
      unrelated warning)
- [x] `node scripts/validate-mcp-tools.mjs` — unchanged output (298
      COVERED / 45 MISSING_TOOL / 0 critical), exit 0
- [x] `node scripts/coverage-tracker-summary.mjs` — smoke-tested locally
      against the real schema (missing_count=45, matches `docs/coverage.md`
      exactly); also verified the `$GITHUB_OUTPUT` heredoc form it writes
- [x] `node scripts/generate-coverage-doc.mjs` — unchanged, no-op ("kein
      Schreibvorgang")

🤖 Generated with [Claude Code](https://claude.com/claude-code)