### PR TITLE
docs(tools): preview_backup_restore needs backups:view, not manage

### DIFF
--- a/src/tools/backup-restore.ts
+++ b/src/tools/backup-restore.ts
@@ -8,13 +8,13 @@
  * src/routes/api/backup/restore/+server.ts           POST (run)
  * src/routes/api/backup/restore/stop/+server.ts       POST (stop/cancel)
  *
- * PERMISSION NOTE (Finsys/dockhand#1534, filed upstream): the preview handler's own
- * `@openapi` annotation says its 403 is "needs backups:view", but the handler itself
- * calls `requireBackups(auth, 'manage')` — it actually requires `backups:manage`, same
- * as run and stop. This tool follows the HANDLER, not the (wrong) annotation; the field
- * descriptions below say so explicitly since neither the derived MCP description nor
- * docs/dockhand-openapi.json's response-description text is corrected for this (the
- * bug lives entirely in the upstream repo, not in anything this project generates).
+ * PERMISSION NOTE (Finsys/dockhand#1534, resolved upstream): preview is read-only
+ * (restic ls/dump + read-only host probes, it writes nothing) and gates on
+ * `backups:view`, like every other read-only backup endpoint (snapshots, browse, dump).
+ * It briefly required `manage` and was the odd one out; upstream relaxed the handler to
+ * `view` rather than documenting `manage`, so the handler and its `@openapi` annotation
+ * now agree on `view`. The actual restore (`run`) and `stop` still require
+ * `backups:manage`.
  *
  * Job-polling: all three POST handlers are backed by createJobResponse()
  * (src/lib/server/sse.ts upstream) — preview via the thin `jobResult()` wrapper, run


### PR DESCRIPTION
Follow-up to the #202 backup tools. Finsys/dockhand#1534 (which our `preview_backup_restore` PERMISSION NOTE referenced as an open upstream bug) was **resolved upstream the other way**: preview is read-only, so the maintainer relaxed the handler to `backups:view` (matching `snapshots`/`browse`/`dump`) instead of documenting `manage`. Handler and `@openapi` annotation now agree on `view` (verified at upstream `restore/preview/+server.ts:24` → `requireBackups(auth, 'view')`).

This updates our now-stale code comment accordingly: preview → `view`; `run`/`stop` still require `manage`. Our doc PR Finsys/dockhand#1537 was closed in favour of the handler change; Finsys/dockhand#1538 (backupFlags/restoreFlags) was merged.

Comment-only — no behaviour, schema, or tool-description change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QZfJ5mmFxX8KEQcvSBU1F