### PR TITLE
test: harden noUnusedLocals guard + field-scoped negative assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,40 @@ script runs as a hard gate in CI. Unused imports/locals are additionally caught 
 TS 7 by `tsc` (`noUnusedLocals`/`noUnusedParameters` in `tsconfig.tests.json`, via
 `npm run typecheck:tests`).
 
+### Testing conventions
+
+These grew out of the test-hardening review of PRs #210–#215 (Issue #224) — several
+tests there passed while proving nothing. Two mechanical rules and one habit came out
+of it, and are enforced or expected repo-wide:
+
+**`noUnusedLocals` / `noUnusedParameters` stay on for tests.** They are set in
+`tsconfig.tests.json` and checked by `npm run typecheck:tests` (part of CI). The
+reason to keep them, spelled out: a value parsed from output into a local that is
+then never asserted on is a *dead assertion* — a test that looks like it checks
+something but doesn't. With these flags on, that is a compile error instead of a
+silently green test. Do not relax them for test files, and do not add a per-file
+tsconfig under `tests/` to opt a file back out.
+
+**A negative assertion must name the field it denies.** `expect(raw).not.toContain('42')`
+over a whole serialized blob is a coincidence waiting to happen — it can also match a
+timestamp, an id, or an unrelated field, so it can fail for the wrong reason (or, for
+a keyword sweep, fail because an unrelated *legitimate* field's name happens to contain
+the word). Real case in #215: `not.toContain('42')` collided with a timestamp. Parse the
+output and assert on the specific field (`obj.route`, `obj.err.type`) instead of the raw
+string. When the whole point of the check is "no *unexpected* field anywhere in the
+tree carries this", walk the object (see `walkEntries()` in
+`tests/tools/meta.self-check.test.ts`, or `quotedFields()` /
+`statusBytesSegment()` in `tests/access-log.test.ts`) and name the offending path in
+the assertion message — do not fall back to `JSON.stringify(value)` plus a blind regex.
+
+**Counter-check every new regression test against the un-fixed code, once.** If a test
+stays green against the version of the code it exists to catch, it proves nothing — a
+fallback path, a duplicate-key dedupe, or an env-driven later failure can all keep a
+test green for the wrong reason (all three happened across #214/#215). Before
+considering a new regression test done: revert the fix (or otherwise reintroduce the
+bug) locally, run the test, confirm it fails **for the reason the test claims to check**,
+then restore the fix.
+
 ## License
 
 [MIT](LICENSE)

--- a/tests/access-log.test.ts
+++ b/tests/access-log.test.ts
@@ -32,6 +32,15 @@ function quotedFields(line: string): { request: string; referer: string; userAge
   return { request: pieces[1], referer: pieces[3], userAgent: pieces[5] };
 }
 
+// The unquoted " status bytes " segment between the request and referer fields — the
+// only place status/bytes can appear, so a check against it names those two fields
+// instead of sweeping the whole line (Issue #224).
+function statusBytesSegment(line: string): string {
+  const pieces = line.split('"');
+  expect(pieces).toHaveLength(7);
+  return pieces[2];
+}
+
 function lineWith(overrides: Partial<Parameters<typeof formatAccessLine>[0]>): string {
   return formatAccessLine({
     ip: '203.0.113.9', time: AT, method: 'GET', path: '/health', httpVersion: '1.1',
@@ -136,9 +145,13 @@ describe('formatAccessLine', () => {
       httpVersion: '1.1', status: 200, bytes: 1,
     });
 
-    expect(line).not.toContain('hunter2');
-    expect(line).not.toContain('secret');
-    expect(line).toContain('"POST /mcp HTTP/1.1"');
+    // Field-scoped (Issue #224): the query only ever could have survived in the
+    // "request" field (method + path + version) — that is the field this check names,
+    // not the whole line, which also carries ip/time/status/bytes and could in
+    // principle contain either substring by coincidence.
+    expect(quotedFields(line).request).not.toContain('hunter2');
+    expect(quotedFields(line).request).not.toContain('secret');
+    expect(quotedFields(line).request).toBe('POST /mcp HTTP/1.1');
   });
 
   it('cannot be used to forge a second log line', () => {
@@ -244,6 +257,9 @@ describe('formatAccessLine', () => {
   it('never prints NaN for status or bytes', () => {
     const line = lineWith({ status: Number.NaN, bytes: Number.NaN });
 
-    expect(line).not.toContain('NaN');
+    // Field-scoped (Issue #224): status/bytes only ever render into this segment —
+    // naming it instead of the whole line rules out a coincidental "NaN" elsewhere
+    // (a timestamp or identifier) masquerading as a real finding either way.
+    expect(statusBytesSegment(line)).not.toContain('NaN');
   });
 });

--- a/tests/tools/meta.self-check.test.ts
+++ b/tests/tools/meta.self-check.test.ts
@@ -2,6 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { runSelfCheck } from '../../src/tools/meta.js';
 import type { SelfCheckEnvironment } from '../../src/tools/meta.js';
 
+/**
+ * Walks an arbitrary JSON-like value and yields a dotted path for every key/leaf it
+ * contains (Issue #224). Lets a check name the exact field it denies instead of
+ * regex-sweeping a `JSON.stringify()` of the whole thing — where a match against an
+ * unrelated field's name or value would fail the test for the wrong reason.
+ */
+function walkEntries(value: unknown, path = 'result'): Array<[string, unknown]> {
+  const entries: Array<[string, unknown]> = [[path, value]];
+  if (value !== null && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      entries.push(...walkEntries(child, `${path}.${key}`));
+    }
+  }
+  return entries;
+}
+
 describe('runSelfCheck', () => {
   it('reports ok when Dockhand is reachable, auth is valid, and all environments are reachable', async () => {
     const result = await runSelfCheck({
@@ -96,10 +112,17 @@ describe('runSelfCheck', () => {
       listEnvironments: async () => [{ id: 1, name: 'production', reachable: true, hawserConnected: true }],
     });
 
-    const serialized = JSON.stringify(result);
-    expect(serialized).not.toMatch(/token/i);
-    expect(serialized).not.toMatch(/secret/i);
-    expect(serialized).not.toMatch(/password/i);
+    // Field-scoped (Issue #224): walk the actual result shape and name the offending
+    // field/value on failure. A blind `JSON.stringify(result)` sweep would fail for
+    // the wrong reason the day a legitimate, non-secret field name happens to contain
+    // one of these words (e.g. "authTokenPresent: boolean") — this still catches an
+    // unexpected new field anywhere in the tree, but says exactly which one.
+    for (const [path, value] of walkEntries(result)) {
+      expect(path, `field name "${path}"`).not.toMatch(/token|secret|password/i);
+      if (typeof value === 'string') {
+        expect(value, `value of "${path}"`).not.toMatch(/token|secret|password/i);
+      }
+    }
   });
 
   it('degrades gracefully (does not throw) if the environments probe itself fails', async () => {

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -5,6 +5,11 @@
     "rootDir": ".",
     "types": ["node"],
     "allowJs": true,
+    // Do not relax these two for test files (Issue #224): a value parsed from output
+    // into a local that is then never asserted on is a dead assertion — a test that
+    // looks like it checks something but doesn't. With these on, that's a compile
+    // error here instead of a silently green test. There is no per-file tsconfig
+    // under tests/, so nothing can opt a single test file back out of this.
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },


### PR DESCRIPTION
Closes #224.

## Summary

Two mechanical rules from the #210–#215 test-hardening review, now made explicit and enforced repo-wide:

- **`noUnusedLocals` / `noUnusedParameters` stay on for tests.** They were already set in `tsconfig.tests.json`; added a one-line comment explaining why (catches a *dead assertion* — a value parsed from output into a local that's never asserted on — as a compile error instead of a silently green test), so it doesn't get "cleaned up" later. Confirmed there's no per-file tsconfig under `tests/` and no `@ts-nocheck`/`@ts-ignore` anywhere in the test suite that could opt a file back out.
- **Field-scoped negative assertions.** Swept the suite for `not.toContain(`/`not.toMatch(` over raw serialized output (108 call sites). The large majority already use distinctive, low-collision sentinel values and needed no change. Rescoped the two genuinely collision-prone cases:
  - `tests/access-log.test.ts`: the `'hunter2'`/`'secret'` query-leak check and the `'NaN'` status/bytes check now scope to the `request` field (via the existing `quotedFields()` helper) and a new `statusBytesSegment()` helper, instead of the whole multi-field access-log line.
  - `tests/tools/meta.self-check.test.ts`: the `/token|secret|password/i` sweep now walks the actual result shape (new `walkEntries()` helper) and names the offending field/value on assertion failure, instead of a blind `JSON.stringify()` + regex — which would fail for the wrong reason the day an unrelated, legitimate field name happens to match one of those words.
  - Both rewrites were counter-checked: reverted the underlying source fix, confirmed the rewritten test fails **for the stated reason**, then restored the fix.
- **README.md**: added a "Testing conventions" section documenting both rules above plus the counter-check-against-the-un-fixed-code habit (issue item 3), so new tests follow them without re-deriving the reasoning.

## Test plan

- [x] `npx vitest run` — 106 files / 1430 tests, all green
- [x] `npm run typecheck` / `npm run typecheck:tests` — clean
- [x] `npm run build` — clean
- [x] `npm run api:validate` — OK (unchanged pre-existing gaps, unrelated to this PR)
- [x] `npm run lint` (Docker-based) — 0 errors (1 pre-existing warning in an untouched file)
- [x] Counter-check on both rewritten assertions (reverted the fix under test, confirmed red for the right reason, restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QZfJ5mmFxX8KEQcvSBU1F