### PR TITLE
feat(tools): add download_backup_snapshot_file (binary download=1 variant of dump)

### DIFF
--- a/src/openapi/description-suffixes.ts
+++ b/src/openapi/description-suffixes.ts
@@ -175,13 +175,30 @@ const RESTORE_IN_PLACE_DESTRUCTIVE =
  */
 const BACKUP_SNAPSHOT_DUMP_MAY_EXPOSE_VOLUME_SECRETS =
   'This tool returns only the inline/redacted preview — it never sets the endpoint\'s raw ' +
-  '`download=1` tar/byte-stream flag (a separate, not-yet-wrapped follow-up). SECURITY: ' +
-  'dumping a path under /volumes/* returns that backed-up file\'s content completely ' +
-  'unredacted — backed-up application data can contain real secrets (passwords, API keys, ' +
-  'private keys, credentialed config files) that will appear verbatim in the response. Do ' +
-  'not log or print the dumped content. The one path this endpoint DOES redact is ' +
+  '`download=1` tar/byte-stream flag. For the raw binary tar/byte-stream variant of this ' +
+  'same endpoint, use download_backup_snapshot_file instead. SECURITY: dumping a path under ' +
+  '/volumes/* returns that backed-up file\'s content completely unredacted — backed-up ' +
+  'application data can contain real secrets (passwords, API keys, private keys, ' +
+  'credentialed config files) that will appear verbatim in the response. Do not log or ' +
+  'print the dumped content. The one path this endpoint DOES redact is ' +
   '/metadata/metadata.json (returned as a parsed, redacted layout, never the raw file) — for ' +
   'a snapshot\'s full metadata layout, prefer get_backup_snapshot_metadata instead.';
+
+/**
+ * `download_backup_snapshot_file` (same endpoint as dump_backup_snapshot_file above, but
+ * with `download=1` set — src/tools/backup-snapshots.ts, #247) returns the RAW binary
+ * tar/byte stream (base64-framed), not a redacted or inline preview. Everything the
+ * suffix above warns about for /volumes/* applies here too, plus the content is now the
+ * actual unredacted bytes rather than a text preview.
+ */
+const BACKUP_SNAPSHOT_DOWNLOAD_RETURNS_RAW_BYTES =
+  'Returns the raw file/directory content as base64-encoded bytes (prefixed "base64:"), ' +
+  'not a preview. SECURITY: a path under /volumes/* is the backed-up application\'s own ' +
+  'data, byte-for-byte and completely unredacted — it can contain real secrets (passwords, ' +
+  'API keys, private keys, credentialed config files). Do not log or print the returned ' +
+  'content. A raw /metadata/metadata.json download is refused by the server with 403 (it ' +
+  'would bypass redaction) — use get_backup_snapshot_metadata for that path instead. For a ' +
+  'redacted/inline text preview instead of raw bytes, use dump_backup_snapshot_file.';
 
 export const TOOL_DESCRIPTION_SUFFIXES: Readonly<Record<string, string>> = {
   exec_container: EXEC_RETURNS_NO_OUTPUT,
@@ -198,4 +215,5 @@ export const TOOL_DESCRIPTION_SUFFIXES: Readonly<Record<string, string>> = {
   run_backup_destination_task: BACKUP_DESTINATION_TASK_DESTRUCTIVE,
   run_backup_restore: RESTORE_IN_PLACE_DESTRUCTIVE,
   dump_backup_snapshot_file: BACKUP_SNAPSHOT_DUMP_MAY_EXPOSE_VOLUME_SECRETS,
+  download_backup_snapshot_file: BACKUP_SNAPSHOT_DOWNLOAD_RETURNS_RAW_BYTES,
 };

--- a/src/openapi/tool-endpoint-map.ts
+++ b/src/openapi/tool-endpoint-map.ts
@@ -91,6 +91,7 @@ export const TOOL_ENDPOINT_MAP: Readonly<Record<string, ToolEndpointEntry>> = {
   "disable_user_mfa": { method: "DELETE", path: "/api/users/{id}/mfa" },
   "disconnect_container_from_network": { method: "POST", path: "/api/networks/{id}/disconnect" },
   "down_stack": { method: "POST", path: "/api/stacks/{name}/down" },
+  "download_backup_snapshot_file": { method: "GET", path: "/api/backup/snapshots/{id}/dump" },
   "download_container_file": { method: "GET", path: "/api/containers/{id}/files/download" },
   "dump_backup_snapshot_file": { method: "GET", path: "/api/backup/snapshots/{id}/dump" },
   "enable_user_mfa": { method: "POST", path: "/api/users/{id}/mfa" },

--- a/src/tools/backup-snapshots.ts
+++ b/src/tools/backup-snapshots.ts
@@ -7,7 +7,8 @@
  * src/routes/api/backup/snapshots/diff/+server.ts           GET (diff)
  * src/routes/api/backup/snapshots/[id]/+server.ts           DELETE (forget/prune)
  * src/routes/api/backup/snapshots/[id]/browse/+server.ts    GET (browse)
- * src/routes/api/backup/snapshots/[id]/dump/+server.ts      GET (dump — preview only here)
+ * src/routes/api/backup/snapshots/[id]/dump/+server.ts      GET (dump — preview AND
+ *                                                                  binary download, #247)
  * src/routes/api/backup/snapshots/[id]/metadata/+server.ts  GET (metadata, server-redacted)
  * src/routes/api/backup/instance/+server.ts                 GET (this install's instance id)
  *
@@ -65,17 +66,16 @@
  * `env` above).
  *
  * dump_backup_snapshot_file — PREVIEW ONLY, deliberately incomplete vs. the full
- * endpoint contract (tracked as a #202 follow-up):
+ * endpoint contract (was a #202 follow-up; the binary variant below closes it, #247):
  *   - The real endpoint has THREE response shapes: an inline text/JSON preview (the
  *     default), a raw binary tar/byte stream when `download=1` is set (window.open-style
  *     navigation, can't be JSON-wrapped, needs `client.getRaw()` + base64 to model over
- *     MCP), and a 403 refusal of a raw `metadata.json` download specifically (to force
- *     that one path through the redacting metadata endpoint instead).
+ *     MCP — see download_backup_snapshot_file below), and a 403 refusal of a raw
+ *     `metadata.json` download specifically (to force that one path through the
+ *     redacting metadata endpoint instead).
  *   - This tool's schema has NO `download` field at all, and the query object built
  *     below never includes that key — so it can only ever reach the inline-preview
- *     branch. The binary-download variant is a deferred follow-up (needs a distinct
- *     tool wrapping client.getRaw(), since the response shape — raw bytes vs. JSON — is
- *     fundamentally different, not just a flag on this one).
+ *     branch.
  *   - `path`/`type` select between a directory-listing preview (`type: 'directory'`)
  *     and a single-file preview (`type` omitted or anything else) — modeled as
  *     `z.enum(['directory']).optional()` since that literal is the only value the
@@ -90,10 +90,35 @@
  *     path the endpoint itself redacts before returning (never raw) — surfaced in the
  *     same suffix, pointing callers at get_backup_snapshot_metadata instead for that.
  *
+ * download_backup_snapshot_file (#247, the binary-download follow-up to #202) — the
+ * SAME endpoint (`GET .../dump`) as dump_backup_snapshot_file, called with `download`
+ * hardcoded to `'1'` (never a caller-facing field, matching how dump_backup_snapshot_file
+ * hardcodes its ABSENCE) and `client.getRaw()` instead of `client.get()`:
+ *   - `type: 'directory'` streams the whole directory as a tar (`application/x-tar`
+ *     server-side); omitted/any other value streams a single file's raw bytes
+ *     (`application/octet-stream` server-side). `client.getRaw()` doesn't care which —
+ *     it just returns the raw `Buffer` either way (verified against
+ *     src/client/dockhand-client.ts's `getRaw()`: `Buffer.from(await
+ *     response.arrayBuffer())`, no content-type branching) — mirrors
+ *     download_container_file (src/tools/containers.ts), which frames its own
+ *     `client.getRaw()` result the same way for a single-file download.
+ *   - Response framing: `textResponse(`base64:${buffer.toString('base64')}`)` — same
+ *     literal pattern as download_container_file, chosen there (not jsonResponse) because
+ *     the payload is raw bytes, not JSON; a UTF-8 round-trip would corrupt any non-ASCII
+ *     byte in a tar or binary file (the handler's own comment on the archive branch says
+ *     the same: "a UTF-8 round-trip would corrupt any non-ASCII byte in the archive").
+ *   - The server's own `/metadata/metadata.json` raw-download refusal (403, "cannot be
+ *     downloaded raw; use the snapshot metadata endpoint") applies unchanged here — this
+ *     tool does nothing client-side to special-case that path; the 403 surfaces as a
+ *     normal `requestRaw()`-thrown Error, same as any other non-ok response.
+ *   - SECURITY: same /volumes/* real-secrets exposure as dump_backup_snapshot_file, PLUS
+ *     the returned content is now the actual raw bytes (base64-framed), not a redacted
+ *     preview string — surfaced via its own TOOL_DESCRIPTION_SUFFIXES entry.
+ *
  * get_backup_snapshot_metadata: no further query params beyond destinationId — the
  * response is already redacted server-side (stack secrets + container Config.Env/Labels
  * stripped by redactSnapshotLayout()) before it leaves the process, so this tool is safe
- * to log/print unlike dump_backup_snapshot_file.
+ * to log/print unlike dump_backup_snapshot_file/download_backup_snapshot_file.
  *
  * get_backup_instance_id: no path, no query at all.
  *
@@ -111,7 +136,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DockhandClient } from '../client/dockhand-client.js';
-import { registerTool, jsonResponse } from '../utils/tool-helper.js';
+import { registerTool, jsonResponse, textResponse } from '../utils/tool-helper.js';
 import { encodePath } from '../utils/encode-path.js';
 
 export function registerBackupSnapshotTools(server: McpServer, client: DockhandClient): void {
@@ -185,6 +210,24 @@ export function registerBackupSnapshotTools(server: McpServer, client: DockhandC
         path,
         type,
       }));
+    }
+  );
+
+  registerTool(server, 'download_backup_snapshot_file',
+    {
+      snapshotId: z.string().describe('The restic snapshot id to download a file/directory from (from list_backup_snapshots)'),
+      destinationId: z.number().describe('Destination the snapshot lives in (from list_backup_destinations)'),
+      path: z.string().describe('Path inside the snapshot to download (must resolve under /volumes or /metadata; a raw /metadata/metadata.json download is refused with 403 — use get_backup_snapshot_metadata instead)'),
+      type: z.enum(['directory']).optional().describe('Set to "directory" to download the whole directory as a tar; omit to download a single file\'s raw bytes'),
+    },
+    async ({ snapshotId, destinationId, path, type }) => {
+      const buffer = await client.getRaw(`/api/backup/snapshots/${encodePath(snapshotId)}/dump`, {
+        destinationId,
+        path,
+        type,
+        download: '1',
+      });
+      return textResponse(`base64:${buffer.toString('base64')}`);
     }
   );
 

--- a/tests/backup-snapshots.test.ts
+++ b/tests/backup-snapshots.test.ts
@@ -48,6 +48,7 @@ interface MockClient {
   post: ReturnType<typeof vi.fn>;
   put: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
+  getRaw: ReturnType<typeof vi.fn>;
 }
 
 function jsonOut(res: unknown): unknown {
@@ -68,6 +69,7 @@ function setup(): { handlers: Map<string, ToolHandler>; schemas: Map<string, Zod
     post: vi.fn().mockResolvedValue({ ok: true }),
     put: vi.fn().mockResolvedValue({ ok: true }),
     delete: vi.fn().mockResolvedValue({ ok: true }),
+    getRaw: vi.fn().mockResolvedValue(Buffer.from('raw-bytes')),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registerBackupSnapshotTools(server as any, client as any);
@@ -90,13 +92,14 @@ function expectToolError(result: unknown, contains: string) {
 }
 
 describe('backup snapshot tools — registration', () => {
-  it('registers all seven operations', () => {
+  it('registers all eight operations', () => {
     const { handlers } = setup();
 
     expect([...handlers.keys()].sort()).toEqual([
       'browse_backup_snapshot',
       'delete_backup_snapshot',
       'diff_backup_snapshots',
+      'download_backup_snapshot_file',
       'dump_backup_snapshot_file',
       'get_backup_instance_id',
       'get_backup_snapshot_metadata',
@@ -449,6 +452,160 @@ describe('dump_backup_snapshot_file', () => {
     const description = describeTool('dump_backup_snapshot_file');
     expect(description.toLowerCase()).toContain('volumes');
     expect(description.toLowerCase()).toMatch(/secret|sensitive/);
+  });
+});
+
+describe('download_backup_snapshot_file (#247 — binary download=1 variant of dump)', () => {
+  it('happy path: directory download — calls client.getRaw with type=directory and download=1, base64-frames the raw bytes', async () => {
+    const { handlers, client } = setup();
+    client.getRaw.mockResolvedValueOnce(Buffer.from('fake-tar-bytes'));
+    const result = await handlers.get('download_backup_snapshot_file')!({
+      snapshotId: 'abc123',
+      destinationId: 3,
+      path: '/volumes/data',
+      type: 'directory',
+    });
+    expect(client.getRaw).toHaveBeenCalledWith('/api/backup/snapshots/abc123/dump', {
+      destinationId: 3,
+      path: '/volumes/data',
+      type: 'directory',
+      download: '1',
+    });
+    const r = result as { content: { type: string; text: string }[] };
+    expect(r.content[0]!.text).toBe(`base64:${Buffer.from('fake-tar-bytes').toString('base64')}`);
+  });
+
+  it('happy path: single-file download — type omitted, download=1 still sent', async () => {
+    const { client } = await call('download_backup_snapshot_file', {
+      snapshotId: 'abc123',
+      destinationId: 3,
+      path: '/volumes/data/config.json',
+    });
+    expect(client.getRaw).toHaveBeenCalledWith('/api/backup/snapshots/abc123/dump', {
+      destinationId: 3,
+      path: '/volumes/data/config.json',
+      type: undefined,
+      download: '1',
+    });
+  });
+
+  it('URL-encodes a snapshot id that needs it', async () => {
+    const { client } = await call('download_backup_snapshot_file', {
+      snapshotId: 'a/b c',
+      destinationId: 3,
+      path: '/volumes/x',
+    });
+    expect(client.getRaw).toHaveBeenCalledWith('/api/backup/snapshots/a%2Fb%20c/dump', {
+      destinationId: 3,
+      path: '/volumes/x',
+      type: undefined,
+      download: '1',
+    });
+  });
+
+  it('uses client.getRaw, not client.get — the binary variant needs the raw-bytes path, not the JSON one', async () => {
+    const spyClient = {
+      get: vi.fn().mockRejectedValue(new Error('client.get should never be called for download_backup_snapshot_file')),
+      post: vi.fn().mockRejectedValue(new Error('client.post should never be called for download_backup_snapshot_file')),
+      put: vi.fn().mockRejectedValue(new Error('client.put should never be called for download_backup_snapshot_file')),
+      delete: vi.fn().mockRejectedValue(new Error('client.delete should never be called for download_backup_snapshot_file')),
+      getRaw: vi.fn().mockResolvedValue(Buffer.from('bytes')),
+    };
+    const handlersMap = new Map<string, ToolHandler>();
+    const server = {
+      tool: (name: string, _d: string, _s: ZodShape, cb: ToolHandler) => { handlersMap.set(name, cb); },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerBackupSnapshotTools(server as any, spyClient as any);
+    const result = await handlersMap.get('download_backup_snapshot_file')!({
+      snapshotId: 'abc123',
+      destinationId: 3,
+      path: '/volumes/x',
+    });
+    expect(spyClient.get).not.toHaveBeenCalled();
+    expect(spyClient.post).not.toHaveBeenCalled();
+    expect(spyClient.put).not.toHaveBeenCalled();
+    expect(spyClient.delete).not.toHaveBeenCalled();
+    expect(spyClient.getRaw).toHaveBeenCalledWith('/api/backup/snapshots/abc123/dump', {
+      destinationId: 3,
+      path: '/volumes/x',
+      type: undefined,
+      download: '1',
+    });
+    const r = result as { content: { text: string }[] };
+    expect(r.content[0]!.text).toBe(`base64:${Buffer.from('bytes').toString('base64')}`);
+  });
+
+  it('GEGENVERSUCH: ALWAYS sends download="1" — unlike dump_backup_snapshot_file (the preview tool), which NEVER sends it. Manually verified by temporarily deleting the `download: \'1\'` line from download_backup_snapshot_file in src/tools/backup-snapshots.ts and rerunning this test: it went red (missing key vs. the exact object below), for the right reason, then reverted — see task report.', async () => {
+    const { client } = await call('download_backup_snapshot_file', {
+      snapshotId: 'abc123',
+      destinationId: 3,
+      path: '/metadata',
+      type: 'directory',
+    });
+    const sentParams = client.getRaw.mock.calls[0]![1] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(sentParams, 'download')).toBe(true);
+    expect(sentParams).toEqual({ destinationId: 3, path: '/metadata', type: 'directory', download: '1' });
+  });
+
+  it('requires path — the tool schema rejects a call missing it (the handler 400s without it)', () => {
+    const { schemas } = setup();
+    const schema = z.object(schemas.get('download_backup_snapshot_file')!);
+    const result = schema.safeParse({ snapshotId: 'abc123', destinationId: 3 });
+    expect(result.success).toBe(false);
+  });
+
+  it('requires destinationId — the tool schema rejects a call missing it', () => {
+    const { schemas } = setup();
+    const schema = z.object(schemas.get('download_backup_snapshot_file')!);
+    const result = schema.safeParse({ snapshotId: 'abc123', path: '/volumes/x' });
+    expect(result.success).toBe(false);
+  });
+
+  it('error path: backend 403 (a raw /metadata/metadata.json download is refused server-side) is a structured tool error', async () => {
+    const { handlers, client } = setup();
+    client.getRaw.mockRejectedValueOnce(new Error('403 metadata.json cannot be downloaded raw; use the snapshot metadata endpoint (secrets are redacted there)'));
+    const result = await handlers.get('download_backup_snapshot_file')!({
+      snapshotId: 'abc123',
+      destinationId: 3,
+      path: '/metadata/metadata.json',
+    });
+    expectToolError(result, 'metadata.json cannot be downloaded raw');
+  });
+
+  it('error path: backend 400 (missing/invalid destinationId or path) is a structured tool error', async () => {
+    const { handlers, client } = setup();
+    client.getRaw.mockRejectedValueOnce(new Error('400 path parameter is required'));
+    const result = await handlers.get('download_backup_snapshot_file')!({ snapshotId: 'abc123', destinationId: 3, path: '/volumes/x' });
+    expectToolError(result, 'path parameter is required');
+  });
+
+  it('error path: backend 500 (restic dump failed) is a structured tool error', async () => {
+    const { handlers, client } = setup();
+    client.getRaw.mockRejectedValueOnce(new Error('500 restic dump failed'));
+    const result = await handlers.get('download_backup_snapshot_file')!({ snapshotId: 'abc123', destinationId: 3, path: '/volumes/x' });
+    expectToolError(result, 'restic dump failed');
+  });
+
+  it('network error propagates as a structured tool error', async () => {
+    const { handlers, client } = setup();
+    client.getRaw.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const result = await handlers.get('download_backup_snapshot_file')!({ snapshotId: 'abc123', destinationId: 3, path: '/volumes/x' });
+    expectToolError(result, 'ECONNREFUSED');
+  });
+
+  it('the tool description warns about raw/unredacted secret exposure AND points at dump_backup_snapshot_file for a preview', () => {
+    setup();
+    const description = describeTool('download_backup_snapshot_file');
+    expect(description.toLowerCase()).toContain('volumes');
+    expect(description.toLowerCase()).toMatch(/secret|sensitive/);
+    expect(description).toContain('dump_backup_snapshot_file');
+  });
+
+  it('the dump_backup_snapshot_file description now points at download_backup_snapshot_file for the binary variant (no longer "not-yet-wrapped")', () => {
+    setup();
+    const description = describeTool('dump_backup_snapshot_file');
+    expect(description).toContain('download_backup_snapshot_file');
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #202, closes #247.

`dump_backup_snapshot_file` (added in #202) wraps `GET /api/backup/snapshots/{id}/dump` but was deliberately preview-only: it never sets `download=1`, so it only ever reaches the endpoint's inline/redacted-preview branch. The endpoint also has a raw binary tar/byte-stream mode (`download=1`), which needs `client.getRaw()` + base64 framing instead of `jsonResponse` — a fundamentally different response shape, scoped out of #202 as a follow-up.

This PR adds that follow-up: a separate tool, `download_backup_snapshot_file`, for the `download=1` variant.

- Same endpoint, same path/destinationId/type params as `dump_backup_snapshot_file`, plus `download` hardcoded to `'1'` (never a caller-facing field).
- `type: 'directory'` streams the whole directory as a tar; omitted streams a single file's raw bytes — `client.getRaw()` returns the same raw `Buffer` either way (no content-type branching), mirroring `download_container_file` (`src/tools/containers.ts`) exactly, including its `textResponse(`base64:${buffer.toString('base64')}`)` framing.
- The server's existing 403 refusal of a raw `/metadata/metadata.json` download (it would bypass redaction) surfaces unchanged as a structured tool error — no client-side special-casing needed.
- New `TOOL_DESCRIPTION_SUFFIXES` entry warns that `/volumes/*` content can carry real secrets and is returned completely unredacted, and cross-references `dump_backup_snapshot_file` for a redacted preview instead. `dump_backup_snapshot_file`'s own suffix is updated to point at the new tool instead of describing the binary variant as "a separate, not-yet-wrapped follow-up".

## Test plan

- [x] `npx vitest run` — 108 test files / 1459 tests, all green
- [x] New tests in `tests/backup-snapshots.test.ts`: happy path (directory + file), `encodePath` on the snapshot id, uses `client.getRaw` (not get/post/put/delete), schema requires `path`+`destinationId`, error paths (403 metadata refusal, 400, 500, network error), description-suffix content on both tools
- [x] Gegenversuch: temporarily removed the `download: '1'` key from the new tool — the "ALWAYS sends download=1" test went red for the right reason, then reverted
- [x] `npm run api:tool-endpoint-map` — picked up the new `client.getRaw()` call automatically (no `EXPLICIT_OVERRIDES` needed); regenerated file staged
- [x] `npm run api:coverage-doc` — unchanged (endpoint already covered by `dump_backup_snapshot_file`; 329/346, no write)
- [x] `node scripts/generate-body-contract-doc.mjs` — unchanged (no body params; no write)
- [x] `npm run api:validate` — clean: 0 `PARAM_MISMATCH`/`QUERY_PARAM_MISSING_REQUIRED`/`QUERY_PARAM_UNKNOWN`/`ORPHANED_TOOL`; `COVERED`/`MISSING_TOOL` unchanged (329/17, endpoint was already covered), tool-call count grew 334 → 335
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing warning in `tests/tool-error-logging.test.ts`, unrelated to this change, confirmed present on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QZfJ5mmFxX8KEQcvSBU1F